### PR TITLE
docs: rewrite README, add CONTRIBUTING, and polish project metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ test/       # cross-package integration tests (e.g. server tool registry ↔ plu
 
 ## Tech stack
 
-- **Node 24** (see `.node-version`), **pnpm 10** workspace, ESM throughout.
+- **Node 24** (see `.node-version`), **pnpm 11** workspace (pinned via `packageManager`), ESM throughout.
 - **TypeScript** (strict). Build: **tsdown** (the server bundles `shared`); the plugin builds with **Vite** (single-file UI).
 - **Vitest** (tests), **oxlint** (lint), **oxfmt** (format), **knip** (unused deps/exports/files).
 - **Zod** for server tool I/O + shared schemas; **msgpack** on the wire.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Figwright
+
+Thanks for your interest in Figwright! Contributions of all kinds are welcome — bug reports, fixes, new tools, docs, and ideas.
+
+This guide covers the **contribution process**. For the **technical deep-dive** — architecture, the monorepo layout, the tech stack, and gotchas — read **[AGENTS.md](./AGENTS.md)**, which is the canonical guide for working in this repo.
+
+By participating, please keep interactions respectful and constructive. We want Figwright to be a welcoming project for everyone.
+
+## Ways to contribute
+
+- **Report a bug** — open an [issue](https://github.com/awdr74100/figwright/issues) with steps to reproduce, what you expected, and what happened. Include your MCP client, OS, and Figwright/Node versions.
+- **Request a feature** — open an issue describing the problem you're trying to solve, not just the solution. Figwright is **provider-first** and aims for **generality** — proposals that make a wide range of real designs work better are prioritized over narrow, one-off additions.
+- **Send a pull request** — for anything non-trivial, please open an issue first so we can agree on the approach before you invest time.
+
+## Prerequisites
+
+- **Node.js 24 LTS or newer** (see [`.node-version`](./.node-version)).
+- **pnpm 11** — this is a pnpm workspace; the version is pinned via `packageManager` in the root `package.json`, so [Corepack](https://nodejs.org/api/corepack.html) uses it automatically.
+
+## Getting started
+
+```bash
+git clone https://github.com/awdr74100/figwright.git
+cd figwright
+pnpm install
+pnpm build
+```
+
+To run your local build end-to-end, point your MCP client at the built server and import the plugin from `packages/plugin` — see the [Quick start](./README.md#quick-start) in the README. After changing `packages/mcp` or `packages/shared`, **rebuild and restart the MCP server**: it runs the built `dist`, not source.
+
+## Development workflow
+
+The canonical checks — the same gates CI enforces on every push and PR — run from the repo root:
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test
+```
+
+A few things worth knowing (full details in [AGENTS.md](./AGENTS.md)):
+
+- **`pnpm test` from the root is canonical.** It picks up both `packages/*/test/**` and the cross-package suite in the root `test/`. Don't run tests per-package — you'll miss the integration tests.
+- **No git hooks.** Formatting and lint are enforced by CI, so run `pnpm format` before committing (or format on save).
+- **Tests live in `test/`**, mirroring `src/` — no co-located tests. Cross-package tests go in the root `test/`.
+- Add or update tests for any behavior change.
+
+## Commit & PR conventions
+
+- **[Conventional Commits](https://www.conventionalcommits.org/)** — prefix messages with `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `ci:`, etc. The version bump and changelog are derived from these.
+- **PR titles are validated** (`semantic-pr.yml`) and must follow the same format. PRs are **squash-merged**, so the PR title becomes the commit on `main` — write it carefully.
+- **Branch off `main`**, keep PRs focused, and make sure CI is green before requesting review.
+
+## Releasing
+
+Releases are handled by maintainers. Versioning and the changelog are driven by Conventional Commits via `changelogen`; see the [Releasing](./AGENTS.md#releasing) section in AGENTS.md for the full flow.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,49 +1,217 @@
+<div align="center">
+
 # Figwright
 
-Open-source Figma Dev Mode MCP alternative — bridges Claude Code (and other MCP clients) with a Figma plugin over a local WebSocket relay.
+**Open-source, bidirectional Figma agent for MCP clients.**
+A free alternative to Figma's Dev Mode MCP — your AI agent reads designs with high-fidelity grounding _and_ writes back to the canvas. No paid Figma seat required.
 
-> Status: **M0 Foundation**. Not yet usable.
+[![npm](https://img.shields.io/npm/v/@figwright/mcp?logo=npm&color=cb3837)](https://www.npmjs.com/package/@figwright/mcp)
+[![CI](https://github.com/awdr74100/figwright/actions/workflows/ci.yml/badge.svg)](https://github.com/awdr74100/figwright/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Node](https://img.shields.io/node/v/@figwright/mcp?logo=node.js)](https://nodejs.org)
 
-## Why
+</div>
 
-- **Free** — no Figma paid tier required.
-- **Cross-stack** — Vue / React / .NET / Laravel / Django profile-aware codegen.
-- **Open** — extend with your own skills.
+<!-- TODO(demo): drop a short GIF / screenshot of a real codegen → canvas round-trip here. -->
+
+## What is Figwright?
+
+Figwright connects an **MCP server** to a **Figma plugin** over a local WebSocket relay, so an AI agent — Claude Code, Cursor, or any other MCP client — can work _with_ Figma instead of just looking at it.
+
+It works in both directions:
+
+- **Read** — turn a Figma selection into framework-aware code, grounded on faithful, de-duplicated design context (layout, typography, variables, components).
+- **Write** — author and edit the canvas directly: frames, text, auto-layout, styles, variables, components, whole screens.
+
+Everything runs on your machine and talks to Figma through a plugin, so it needs **no Figma Dev Mode seat** and **no paid tier**.
+
+## Why Figwright
+
+- **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
+- **Bidirectional** — not read-only. **88 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
+- **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
+- **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
+
+## How it works
+
+```mermaid
+flowchart LR
+    subgraph machine["Your machine"]
+        A["MCP client<br/>(Claude Code, Cursor, …)"]
+        B["@figwright/mcp<br/>server · relay · election"]
+    end
+    subgraph figma["Figma app"]
+        C["Figwright plugin<br/>Vue 3 UI + sandbox"]
+        D[("Canvas")]
+    end
+    A -->|"MCP (stdio)"| B
+    B <-->|"local WebSocket · msgpack"| C
+    C -->|"Figma Plugin API"| D
+```
+
+The **server** (`@figwright/mcp`) is the process your MCP client launches. It owns the WebSocket **relay**, leader/follower **election** (several MCP servers can share one plugin), and request **idempotency**. The **plugin** runs inside Figma — a Vue 3 UI plus a sandbox that performs the actual Figma API calls — and connects out to the local server.
+
+By design Figwright is **provider-first**: rather than a fixed compiler pipeline, the tools surface honest design context and let the model generate code that matches _your_ codebase. The [`figma-codegen`](#skills) skill encodes this approach.
+
+## Quick start
+
+### 1. Add the server to your MCP client
+
+For Claude Code, add this to your `.mcp.json` (other clients use the same shape):
+
+```json
+{
+  "mcpServers": {
+    "figwright": {
+      "command": "npx",
+      "args": ["-y", "@figwright/mcp@latest"]
+    }
+  }
+}
+```
+
+`npx` fetches and runs the published server — no global install needed.
+
+### 2. Install the Figma plugin
+
+The plugin isn't on the Figma Community marketplace yet, so install it from the latest release:
+
+1. Download the plugin zip from the [**latest GitHub Release**](https://github.com/awdr74100/figwright/releases/latest) and unzip it.
+2. In the Figma **desktop app**: **Menu → Plugins → Development → Import plugin from manifest…** and pick the unzipped `manifest.json`.
+
+### 3. Connect
+
+Open the Figwright plugin in Figma (**Plugins → Development → Figwright**). It connects to the local server automatically and shows **Connected**. Ask your agent to run `ping` to confirm the link.
+
+### 4. (Optional) Install the skills
+
+The [skills](#skills) make agents reach for Figwright at the right moment and follow the grounded workflows:
+
+```bash
+npx skills add awdr74100/figwright/skills
+```
+
+### 5. Try it
+
+With a frame selected in Figma, prompt your agent:
+
+> _Code this Figma selection as a React component._
+
+or, the other direction:
+
+> _Build a pricing section in Figma from this spec._
+
+## Skills
+
+Agent skills orchestrate Figwright's tools. They're model-invoked — your agent loads one automatically when the task matches its description.
+
+| Skill                                              | What it does                                                                                        |
+| :------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| [`figma-codegen`](./skills/figma-codegen/SKILL.md) | Turn a Figma selection into framework-aware code, grounded on your stack and existing components.   |
+| [`figma-build`](./skills/figma-build/SKILL.md)     | Build a Figma design from code or a description, reusing the file's existing components and styles. |
+
+Install across any supported agent with the [`skills`](https://www.skills.sh) CLI:
+
+```bash
+npx skills add awdr74100/figwright/skills      # both
+npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-codegen  # one
+```
+
+> Skills need the `@figwright/mcp` server connected — on their own they have no tools to drive.
+
+## Tools
+
+Figwright exposes **88 MCP tools** in three groups:
+
+- **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, and PDF export.
+- **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components, pages, and reactions; plus a `batch` tool to apply many edits at once.
+- **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have.
+
+Your MCP client lists every tool at connect time — that's always the authoritative, up-to-date catalog.
 
 ## Requirements
 
-- Node 24 LTS+
-- pnpm 10+
+- An **MCP client** (Claude Code, Cursor, …).
+- **Node.js 24 LTS or newer** — the server runs via `npx`.
+- **Figma** — the free tier is enough; the desktop app is needed to import the plugin in development.
 
-## Development
+## FAQ
 
-```bash
-pnpm install
-pnpm typecheck
-pnpm lint
-pnpm test
-pnpm build
-```
+<details>
+<summary><strong>My MCP client can't start the server — <code>npx</code> or <code>node</code> "command not found".</strong></summary>
 
-### Monorepo layout
+This almost always means your MCP client can't find `node` / `npx` on its `PATH` — it isn't specific to Figwright and affects any `npx`-launched MCP server. It's especially common when Node is managed by a version manager (**fnm, nvm, asdf, volta, mise**): those set `PATH` from shell hooks that only run in interactive terminals, so a GUI app or MCP client that spawns the command directly never inherits them.
+
+Fixes, easiest first:
+
+- **Use an absolute path.** In a normal terminal run `which npx` (or `which node`) and use that full path as `command`:
+
+  ```json
+  {
+    "mcpServers": {
+      "figwright": {
+        "command": "/Users/you/.local/share/fnm/node-versions/v24.x.x/installation/bin/npx",
+        "args": ["-y", "@figwright/mcp@latest"]
+      }
+    }
+  }
+  ```
+
+- **Install it and point at the binary.** Install the package (globally with `npm i -g @figwright/mcp`, or as a local dependency), then set `command` to the absolute path from `which figwright-mcp`. As a bonus this skips the network resolution that `npx … @latest` does on every launch.
+
+- **Pass `PATH` through `env`.** If your client supports a per-server `env`, add your version manager's `bin` directory to `env.PATH`.
+
+</details>
+
+<details>
+<summary><strong>The plugin stays on "Waiting" and never connects.</strong></summary>
+
+The server is launched by your MCP client, so it only runs while that client is open. Check that:
+
+- your MCP client is running and has Figwright configured (try a `ping`);
+- the plugin is open in the **same** Figma app on the same machine (the relay is local-only, `127.0.0.1`);
+- nothing is blocking local loopback connections (some firewall / security tools do).
+
+</details>
+
+<details>
+<summary><strong>Do I need a paid Figma plan or Dev Mode?</strong></summary>
+
+No. Figwright talks to Figma through a plugin, so the free tier is enough — no Dev Mode seat or paid tier required.
+
+</details>
+
+<details>
+<summary><strong>Can more than one agent use the same plugin at once?</strong></summary>
+
+Yes. Several MCP servers can share a single plugin via leader/follower **election** — one leads, the others follow, with a graceful handoff if the leader goes away.
+
+</details>
+
+## Contributing & development
+
+Contributions are welcome — see **[CONTRIBUTING.md](./CONTRIBUTING.md)** for the workflow, and **[AGENTS.md](./AGENTS.md)** for architecture, layout, and conventions.
 
 ```
 packages/
-  shared/   # types / schemas / msgpack codec / protocol
-  mcp/      # MCP server (Node, pure ESM)
-  plugin/   # Figma plugin (Vue 3 + Vite + Tailwind v4)
-skills/     # agent skills (markdown) — install with `npx skills add`
+  shared/   # types, Zod schemas, msgpack codec, plugin↔server protocol (bundled into mcp)
+  mcp/      # the MCP server — @figwright/mcp (Node, ESM): relay, election, tools, joins
+  plugin/   # Figma plugin — Vue 3 + Vite + Tailwind v4 (UI) + sandbox (Figma API)
+skills/     # agent skills that orchestrate the tools — installable via `npx skills add`
 ```
 
-### Running the server locally
+Run the canonical checks from the repo root (the same gates CI enforces):
 
 ```bash
-pnpm --filter @figwright/mcp build
-pnpm --filter @figwright/mcp link --global
-# Then in your MCP client config:
-#   command: "npx", args: ["@figwright/mcp@latest"]
+pnpm install
+pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test
 ```
+
+## What's in the name
+
+`figwright` follows the **_-wright_** tradition — an old English word for a maker or craftsman: a **playwright** writes plays, a **shipwright** builds ships, a **wheelwright**, wheels. The name is a nod to [**Playwright**](https://playwright.dev), which automates the browser. Where Playwright drives the browser, **Figwright** drives Figma — a maker of designs that both reads the canvas and crafts work back onto it.
 
 ## License
 
-MIT
+[MIT](./LICENSE) © Roya

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "figwright",
   "version": "0.0.0",
   "private": true,
-  "description": "Open-source Figma Dev Mode MCP alternative — bridges Claude Code (and other MCP clients) with a Figma plugin over a local WebSocket relay.",
+  "description": "Free, bidirectional Figma MCP server — turn designs into framework-aware code and write back to the canvas, for Claude Code, Cursor, and any MCP client.",
   "homepage": "https://github.com/awdr74100/figwright",
   "bugs": {
     "url": "https://github.com/awdr74100/figwright/issues"
@@ -43,7 +43,7 @@
   },
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.0.0"
   },
   "packageManager": "pnpm@11.8.0"
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **88 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,21 @@
 {
   "name": "@figwright/mcp",
   "version": "0.1.0",
-  "description": "MCP server for Figwright — bridges MCP clients to a Figma plugin over local WebSocket.",
+  "description": "Free, bidirectional Figma MCP server — turn designs into framework-aware code and write back to the canvas, for Claude Code, Cursor, and any MCP client.",
+  "keywords": [
+    "claude-code",
+    "codegen",
+    "cursor",
+    "design-to-code",
+    "design-tokens",
+    "dev-mode",
+    "figma",
+    "figma-mcp",
+    "figma-plugin",
+    "figma-to-code",
+    "mcp",
+    "model-context-protocol"
+  ],
   "homepage": "https://github.com/awdr74100/figwright#readme",
   "bugs": "https://github.com/awdr74100/figwright/issues",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Polishes the project's open-source front door. No runtime/behavior changes beyond a pnpm-version requirement bump.

- **README** — full rewrite (the old one still read "M0 / Not yet usable"). Adds a Mermaid architecture diagram, Quick start, Skills, an 88-tool overview, an FAQ (covering the common `npx` + version-manager PATH gotcha with fnm/nvm/asdf/volta/mise), and a "What's in the name" note (the `-wright` maker tradition, a nod to Playwright).
- **CONTRIBUTING.md** — new contributor guide; points to AGENTS.md for the architecture deep-dive.
- **npm metadata** — sharpened the `@figwright/mcp` description and added `keywords` for discoverability; aligned the root description to match.
- **pnpm 11** — bumped `engines.pnpm` to `>=11.0.0` and aligned the docs (the project already pins `pnpm@11.8.0` via `packageManager`).

## Validation

- Local CI gate green: `typecheck`, `lint`, `format:check`, `knip`, `build`, `test` (664 tests).
- `publint` reports no issues for `@figwright/mcp`.

## Out of band

- GitHub repo **About** + **topics** were updated separately and are already live (not part of this diff).