### PR TITLE
fix: report version mismatches clearly and validate the leader ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 **Open-source, bidirectional Figma agent for MCP clients.**
 A free alternative to Figma's Dev Mode MCP — your AI agent reads designs with high-fidelity grounding _and_ writes back to the canvas. No paid Figma seat required.
 
+_Where Playwright drives the browser, Figwright drives Figma._
+
 [![npm](https://img.shields.io/npm/v/@figwright/mcp?logo=npm&color=cb3837)](https://www.npmjs.com/package/@figwright/mcp)
 [![CI](https://github.com/awdr74100/figwright/actions/workflows/ci.yml/badge.svg)](https://github.com/awdr74100/figwright/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
@@ -35,22 +37,44 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 
 ## How it works
 
-```mermaid
-flowchart LR
-    subgraph machine["Your machine"]
-        A["MCP client<br/>(Claude Code, Cursor, …)"]
-        B["@figwright/mcp<br/>server · relay · election"]
-    end
-    subgraph figma["Figma app"]
-        C["Figwright plugin<br/>Vue 3 UI + sandbox"]
-        D[("Canvas")]
-    end
-    A -->|"MCP (stdio)"| B
-    B <-->|"local WebSocket · msgpack"| C
-    C -->|"Figma Plugin API"| D
-```
+Your MCP client talks to the `@figwright/mcp` server over stdio; the server relays to the Figma plugin over a local WebSocket. Several clients can share one plugin — they elect a leader that owns the connection — and the transport is built to ride out dropped sockets:
 
-The **server** (`@figwright/mcp`) is the process your MCP client launches. It owns the WebSocket **relay**, leader/follower **election** (several MCP servers can share one plugin), and request **idempotency**. The **plugin** runs inside Figma — a Vue 3 UI plus a sandbox that performs the actual Figma API calls — and connects out to the local server.
+```text
+┌─────────────────────────────────────────────────────────────────────┐
+│ MCP CLIENTS  —  one per agent                                       │
+│ Claude Code · Cursor · Claude · any MCP-capable client              │
+└─────────────────────────────────────────────────────────────────────┘
+                                   │  MCP protocol over stdio
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ @figwright/mcp  —  your client launches one; they elect a leader    │
+│                                                                     │
+│ LEADER   (owns the single plugin connection)                        │
+│    • WebSocket relay · request idempotency                          │
+│    • routes to the most-recently-active file                        │
+│    • session resume · "busy ≠ dead" heartbeat                       │
+│    • endpoints:  /ws (plugin) · /ping (health) · /rpc (followers)   │
+│                                                                     │
+│ FOLLOWERS                                                           │
+│    • forward tool calls to the leader over HTTP /rpc                │
+│    • take over automatically if the leader exits                    │
+└─────────────────────────────────────────────────────────────────────┘
+                                   │  local WebSocket · msgpack (binary)
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ FIGMA  (desktop or browser)                                         │
+│                                                                     │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ Figwright plugin                                                │ │
+│ │   • UI (Vue 3 iframe): WebSocket client + heartbeat             │ │
+│ │   • sandbox: executes Figma Plugin API calls                    │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│              │ Figma Plugin API                                     │
+│              ▼                                                      │
+│            Canvas                                                   │
+└─────────────────────────────────────────────────────────────────────┘
+```
 
 By design Figwright is **provider-first**: rather than a fixed compiler pipeline, the tools surface honest design context and let the model generate code that matches _your_ codebase. The [`figma-codegen`](#skills) skill encodes this approach.
 
@@ -118,6 +142,7 @@ npx skills add awdr74100/figwright/skills      # both
 npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-codegen  # one
 ```
 
+> [!NOTE]
 > Skills need the `@figwright/mcp` server connected — on their own they have no tools to drive.
 
 ## Tools
@@ -128,7 +153,8 @@ Figwright exposes **88 MCP tools** in three groups:
 - **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components, pages, and reactions; plus a `batch` tool to apply many edits at once.
 - **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have.
 
-Your MCP client lists every tool at connect time — that's always the authoritative, up-to-date catalog.
+> [!TIP]
+> Your MCP client lists every tool at connect time — that's always the authoritative, up-to-date catalog.
 
 ## Requirements
 

--- a/packages/mcp/src/election/follower.ts
+++ b/packages/mcp/src/election/follower.ts
@@ -44,7 +44,17 @@ export class Follower {
       const res = await this.opts.fetch(`${this.opts.leaderUrl}${PING_PATH}`, {
         signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
       });
-      return res.ok;
+      if (!res.ok) return false;
+      // Confirm the responder is actually a figwright leader, not some unrelated process that happens
+      // to hold the port and answer 200 — otherwise this node would attach as a follower and every
+      // RPC it forwards would fail. The leader's /ping returns { ok: true, serverVersion, … }.
+      const body: unknown = await res.json();
+      return (
+        typeof body === 'object' &&
+        body !== null &&
+        (body as { ok?: unknown }).ok === true &&
+        typeof (body as { serverVersion?: unknown }).serverVersion === 'string'
+      );
     } catch {
       return false;
     }

--- a/packages/mcp/src/relay/relay.ts
+++ b/packages/mcp/src/relay/relay.ts
@@ -273,6 +273,18 @@ export class Relay {
       return null;
     }
 
+    // Gate protocol compatibility here (the envelope schema no longer enforces it per-message, so the
+    // mismatched peer can decode this rejection). A skew is realistic: the plugin ships as a manually
+    // imported release while the server updates via `npx @latest`.
+    if (parsed.data.protocolVersion !== PROTOCOL_VERSION) {
+      const message =
+        `protocol mismatch: server speaks ${PROTOCOL_VERSION}, plugin speaks ${parsed.data.protocolVersion} — ` +
+        'update the older Figwright component so both match (server: @figwright/mcp, plugin: re-import the latest release)';
+      this.opts.log(`[relay] rejecting plugin — ${message}`);
+      this.sendError(socket, env, ErrorCode.ProtocolMismatch, message);
+      return null;
+    }
+
     const { session, resumed } = this.sessions.register({
       id: env.sessionId,
       socket,

--- a/packages/mcp/test/election/follower.test.ts
+++ b/packages/mcp/test/election/follower.test.ts
@@ -129,6 +129,21 @@ describe('Follower HTTP client', () => {
     expect(await f.ping()).toBe(false);
   });
 
+  it('ping returns false when the port is held by a non-figwright server', async () => {
+    const http = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('not a figwright leader');
+    });
+    await new Promise<void>(resolve => http.listen(0, '127.0.0.1', () => resolve()));
+    const port = (http.address() as AddressInfo).port;
+    const f = new Follower({ leaderUrl: `http://127.0.0.1:${port}` });
+    try {
+      expect(await f.ping()).toBe(false);
+    } finally {
+      await new Promise<void>(resolve => http.close(() => resolve()));
+    }
+  });
+
   it('sendRpc round-trips through leader to plugin', async () => {
     const b = await startLeader();
     await attachFakePlugin(b, async (method, params) => {

--- a/packages/mcp/test/relay/relay.test.ts
+++ b/packages/mcp/test/relay/relay.test.ts
@@ -8,6 +8,8 @@ import {
   decodeEnvelope,
   encodeEnvelope,
   type Envelope,
+  ErrorCode,
+  type ErrorEnvelope,
   type HelloParams,
   type HelloResult,
   newId,
@@ -127,6 +129,26 @@ describe('Relay hello loop', () => {
     );
     const res = decodeEnvelope(await nextMessage(ws));
     expect(res.kind).toBe('err');
+  });
+
+  it('rejects a $hello with a mismatched protocolVersion and a clear ProtocolMismatch error', async () => {
+    const { port } = await startRelay();
+    const ws = await connect(port);
+    ws.send(
+      encodeEnvelope(
+        createRequest({
+          id: 'h1',
+          sessionId: newId(),
+          method: SystemMethod.Hello,
+          params: helloParams({ protocolVersion: '9.9.9' }),
+        }),
+      ),
+    );
+    const res = decodeEnvelope(await nextMessage(ws)) as ErrorEnvelope;
+    expect(res.kind).toBe('err');
+    expect(res.error.code).toBe(ErrorCode.ProtocolMismatch);
+    expect(res.error.message).toMatch(/protocol mismatch/i);
+    await new Promise(r => ws.once('close', r));
   });
 
   it('responds to client-initiated $ping with ok result', async () => {

--- a/packages/plugin/test/relay/client.test.ts
+++ b/packages/plugin/test/relay/client.test.ts
@@ -226,6 +226,30 @@ describe('RelayClient', () => {
     expect(sockets).toHaveLength(2);
   });
 
+  it('surfaces a hello rejection reason (e.g. protocol mismatch) in lastError', async () => {
+    const { WS } = buildFakeFactory(sock => {
+      sock.fireOpen();
+      const req = decodeEnvelope(sock.sent[0]!) as RequestEnvelope;
+      sock.fireReceive(
+        createError({
+          id: req.id,
+          sessionId: req.sessionId,
+          code: ErrorCode.ProtocolMismatch,
+          message: 'protocol mismatch: server speaks 0.1.0, plugin speaks 9.9.9 — update …',
+        }),
+      );
+    });
+    const client = new RelayClient({
+      ports: [3055],
+      clientVersion: '0.0.0',
+      WS,
+      reconnectInitialDelayMs: 5,
+    });
+    await client.connect();
+    expect(client.getState().lastError).toMatch(/protocol mismatch/i);
+    await client.disconnect();
+  });
+
   it('responds to server-initiated $ping with ok result', async () => {
     let liveSock: FakeSocketControl | undefined;
     const { WS } = buildFakeFactory(sock => {

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -177,10 +177,14 @@ export class RelayClient {
     // background with the same back-off loop used after a live socket drops, so the plugin connects
     // on its own once the server appears. Failing the initial probe is not a reconnect, so the loop
     // must not bump `reconnectCount`.
+    // Preserve a specific rejection reason captured during the probe (e.g. a protocol mismatch
+    // recorded by attemptPort) — masking it with the generic "no server" message would be wrong when a
+    // server was found but turned us away.
     this.update({
       status: 'disconnected',
       port: null,
-      lastError: `no relay server found on ports [${this.opts.ports.join(', ')}]`,
+      lastError:
+        this.state.lastError ?? `no relay server found on ports [${this.opts.ports.join(', ')}]`,
     });
     if (!this.stopped) void this.runReconnectLoop();
   }
@@ -269,6 +273,10 @@ export class RelayClient {
         }
 
         if (envelope.kind === 'err') {
+          // A hello rejection (e.g. a protocol-version mismatch) is a concrete, actionable reason.
+          // Record it so the UI surfaces "update your plugin" rather than the generic "no server
+          // found", and so the reconnect path can preserve it (see connect()).
+          this.update({ lastError: envelope.error.message });
           fail(`hello rejected: ${envelope.error.message}`);
           return;
         }

--- a/packages/shared/src/envelope.ts
+++ b/packages/shared/src/envelope.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import { ErrorCode, PROTOCOL_VERSION } from './protocol.js';
 
 const baseFields = {
-  v: z.literal(PROTOCOL_VERSION),
+  // Accept any version here rather than a strict literal: a peer on a different protocol must still be
+  // able to *decode* our messages (and we theirs) so a mismatch surfaces as a clear error at the
+  // $hello handshake instead of a cryptic envelope-decode failure. Compatibility is gated once, in the
+  // relay's hello handler — not per-envelope. We still stamp our own PROTOCOL_VERSION via create*.
+  v: z.string(),
   id: z.string(),
   ts: z.number(),
   sessionId: z.string(),
@@ -55,13 +59,15 @@ export type Envelope = z.infer<typeof EnvelopeSchema>;
 export const HelloParamsSchema = z.object({
   clientType: z.enum(['plugin']),
   clientVersion: z.string(),
-  protocolVersion: z.literal(PROTOCOL_VERSION),
+  // String, not a literal: a version-mismatched plugin must still parse so the relay can reject it
+  // with a clear ProtocolMismatch message (see relay.handleHello), not a generic schema-parse failure.
+  protocolVersion: z.string(),
 });
 export type HelloParams = z.infer<typeof HelloParamsSchema>;
 
 export const HelloResultSchema = z.object({
   serverVersion: z.string(),
-  protocolVersion: z.literal(PROTOCOL_VERSION),
+  protocolVersion: z.string(),
   sessionResumed: z.boolean(),
 });
 export type HelloResult = z.infer<typeof HelloResultSchema>;

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -15,6 +15,7 @@ export const ErrorCode = {
   PluginDisconnected: 'PLUGIN_DISCONNECTED',
   NotLeader: 'NOT_LEADER',
   SessionUnknown: 'SESSION_UNKNOWN',
+  ProtocolMismatch: 'PROTOCOL_MISMATCH',
 } as const;
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
 

--- a/packages/shared/test/envelope.test.ts
+++ b/packages/shared/test/envelope.test.ts
@@ -44,9 +44,11 @@ describe('envelope factories', () => {
     expect(EnvelopeSchema.parse(evt).kind).toBe('evt');
   });
 
-  it('rejects envelope with wrong protocol version', () => {
+  it('accepts an envelope with a differing protocol version (gated at the $hello handshake, not per-envelope)', () => {
+    // A version-mismatched peer must still decode our messages so the mismatch surfaces as a clear
+    // error at the handshake; per-envelope version rejection is intentionally gone (see envelope.ts).
     const env = { ...createRequest({ ...baseInput, method: 'foo' }), v: '9.9.9' };
-    expect(() => EnvelopeSchema.parse(env)).toThrow(Error);
+    expect(EnvelopeSchema.parse(env).v).toBe('9.9.9');
   });
 
   it('rejects envelope with unknown kind', () => {


### PR DESCRIPTION
Single PR (by request) with two focused commits; squash subject is the `fix:` — the changelog-worthy change. The README rework rides along (docs don't need a changelog line).

### `fix(protocol)` — clearer version handling + ping hardening
- Version compatibility was enforced implicitly by a per-envelope `v` literal, so a mismatched plugin failed to decode and got a cryptic `invalid envelope` close — and because both sides were strict, neither could even read the other's error envelope.
- Relax `v` (and the hello `protocolVersion`) to a plain string and gate the version **once, at the `$hello` handshake**: on mismatch the relay returns a clear `ProtocolMismatch` error the peer can actually decode, and the plugin surfaces it in `lastError`.
- **Forward-looking:** already-shipped strict clients still can't receive the new error, but shipping the tolerant handshake early is what lets future version pairs report cleanly.
- Harden `follower.ping()`: validate the `/ping` body (`ok` + `serverVersion`) so a foreign process holding the port and answering `200` isn't mistaken for a leader.

### `docs(readme)` — one architecture diagram
- Replace the two separate diagrams with a single bridge-style diagram (full-width boxes listing each component's responsibilities, labelled connections, nested plugin box), surfacing differentiators a single-connection bridge lacks (msgpack, session resume, busy != dead heartbeat, multi-file routing, idempotency).
- Pull the Playwright name origin up as a one-line hook; convert two plain blockquotes to GitHub admonitions.

### Tests
All gates green locally (typecheck / lint / format / knip / build / **667 tests**). New tests cover the protocol-mismatch rejection, the foreign-`/ping` rejection, and the client surfacing the rejection reason.