### PR TITLE
feat: let create_component componentize an existing node (fromNodeId)

### DIFF
--- a/packages/mcp/src/tools/create-component.ts
+++ b/packages/mcp/src/tools/create-component.ts
@@ -7,9 +7,16 @@ export const CREATE_COMPONENT_TOOL_NAME = 'create_component';
 export const createComponentTool: ToolSpec = {
   name: CREATE_COMPONENT_TOOL_NAME,
   description:
-    'Create an empty component (a reusable main component), optionally sized / named / positioned ' +
-    'and placed under a parent (default: current page). Returns { ok, nodeId, name, type }.',
+    'Create a reusable main component. Pass fromNodeId to convert an existing node into a component ' +
+    "(e.g. a frame of vectors from import_svg, or a built layout) — it keeps the node's position and " +
+    'parent unless parentId is given; omit fromNodeId to create an empty component to build into. ' +
+    'Then create_instance the result to reuse it. Optionally sized / named / positioned and placed ' +
+    'under a parent (default: current page). Returns { ok, nodeId, name, type }.',
   inputShape: {
+    fromNodeId: z
+      .string()
+      .optional()
+      .describe('Convert this existing node into a component (default: create an empty component)'),
     parentId: z.string().optional().describe('Parent node id (default: current page)'),
     name: z.string().optional(),
     x: z.number().optional(),

--- a/packages/plugin/src/handlers/batch.ts
+++ b/packages/plugin/src/handlers/batch.ts
@@ -105,6 +105,25 @@ const createInverse = (tool: string, hasParent = true): BatchInverse => ({
   },
 });
 
+/**
+ * Create_component is invertible as an empty create (undo removes the new node), but `fromNodeId`
+ * componentizes — and consumes — an existing node, which has no faithful inverse (removing the
+ * component would destroy the original). Reject that variant up front, like other non-invertible
+ * ops.
+ */
+const componentCreateInverse = createInverse('create_component');
+const createComponentInverse: BatchInverse = {
+  async capture(figmaCtx, params) {
+    if (typeof (params as { fromNodeId?: unknown } | null)?.fromNodeId === 'string') {
+      throw new Error(
+        'batch/create_component: fromNodeId is not batchable — componentizing a node consumes it and has no faithful inverse',
+      );
+    }
+    return componentCreateInverse.capture(figmaCtx, params);
+  },
+  undo: componentCreateInverse.undo,
+};
+
 /** Set_text needs every font loaded before `characters` can be restored. */
 const setTextInverse: BatchInverse = {
   async capture(figmaCtx, params) {
@@ -193,7 +212,7 @@ const INVERSES: Readonly<Record<string, BatchInverse>> = {
   create_rectangle: createInverse('create_rectangle'),
   create_text: createInverse('create_text'),
   create_ellipse: createInverse('create_ellipse'),
-  create_component: createInverse('create_component'),
+  create_component: createComponentInverse,
   create_section: createInverse('create_section'),
   import_image: createInverse('import_image'),
   import_svg: createInverse('import_svg'),

--- a/packages/plugin/src/handlers/create-component.ts
+++ b/packages/plugin/src/handlers/create-component.ts
@@ -7,6 +7,7 @@ export const createCreateComponentHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
   async params => {
     const p = (params ?? {}) as {
+      fromNodeId?: unknown;
       parentId?: unknown;
       name?: unknown;
       x?: unknown;
@@ -15,7 +16,31 @@ export const createCreateComponentHandler =
       height?: unknown;
     };
 
-    const component = figmaCtx.createComponent();
+    // fromNodeId → componentize an existing node (createComponentFromNode replaces it in place,
+    // keeping its parent + position); otherwise create an empty component to build into.
+    let component: ComponentNode;
+    let alreadyPlaced = false;
+    if (typeof p.fromNodeId === 'string') {
+      const source = await figmaCtx.getNodeByIdAsync(p.fromNodeId);
+      if (source === null) {
+        throw new Error(`create_component: node ${p.fromNodeId} not found`);
+      }
+      if (
+        source.type === 'PAGE' ||
+        source.type === 'DOCUMENT' ||
+        source.type === 'COMPONENT' ||
+        source.type === 'COMPONENT_SET'
+      ) {
+        throw new Error(
+          `create_component: node ${p.fromNodeId} (${source.type}) can't be turned into a component`,
+        );
+      }
+      component = figmaCtx.createComponentFromNode(source as SceneNode);
+      alreadyPlaced = true;
+    } else {
+      component = figmaCtx.createComponent();
+    }
+
     if (typeof p.name === 'string') component.name = p.name;
     if (typeof p.width === 'number' && typeof p.height === 'number') {
       component.resize(p.width, p.height);
@@ -23,7 +48,11 @@ export const createCreateComponentHandler =
     if (typeof p.x === 'number') component.x = p.x;
     if (typeof p.y === 'number') component.y = p.y;
 
-    await placeNode(figmaCtx, component, p.parentId, 'create_component');
+    // An empty component must be placed; a componentized node is already in the tree — only reparent
+    // it when an explicit parentId is given (else it stays where the source node was).
+    if (!alreadyPlaced || typeof p.parentId === 'string') {
+      await placeNode(figmaCtx, component, p.parentId, 'create_component');
+    }
 
     const result: CreateResult = {
       ok: true,

--- a/packages/plugin/test/handlers/batch.test.ts
+++ b/packages/plugin/test/handlers/batch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { SandboxHandlers } from '../../src/dispatcher.js';
 import { createBatchHandler } from '../../src/handlers/batch.js';
+import { createCreateComponentHandler } from '../../src/handlers/create-component.js';
 import { createCreateFrameHandler } from '../../src/handlers/create-frame.js';
 import { createDeleteNodesHandler } from '../../src/handlers/delete-nodes.js';
 import { createMoveNodesHandler } from '../../src/handlers/move-nodes.js';
@@ -46,6 +47,7 @@ const realWrites = (figmaCtx: typeof figma): SandboxHandlers => ({
   set_fills: createSetFillsHandler(figmaCtx),
   move_nodes: createMoveNodesHandler(figmaCtx),
   create_frame: createCreateFrameHandler(figmaCtx),
+  create_component: createCreateComponentHandler(figmaCtx),
   delete_nodes: createDeleteNodesHandler(figmaCtx),
 });
 
@@ -86,6 +88,21 @@ describe('batch handler', () => {
       }),
     ).rejects.toThrow(/not batchable/);
     expect(store.get('1:1')).toMatchObject({ name: 'A' }); // untouched
+  });
+
+  it('rejects create_component with fromNodeId (no faithful inverse) at validate time', async () => {
+    const { figmaCtx, store } = makeFigma({ '1:1': { id: '1:1', type: 'FRAME', name: 'A' } });
+    const handler = createBatchHandler(figmaCtx, realWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          { tool: 'rename_node', params: { nodeId: '1:1', name: 'renamed' } },
+          { tool: 'create_component', params: { fromNodeId: '1:1' } },
+        ],
+      }),
+    ).rejects.toThrow(/fromNodeId is not batchable/);
+    expect(store.get('1:1')).toMatchObject({ name: 'A' }); // first op never applied
   });
 
   it('aborts in the capture phase (bad node id) before any op is applied', async () => {

--- a/packages/plugin/test/handlers/create-component.test.ts
+++ b/packages/plugin/test/handlers/create-component.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createCreateComponentHandler } from '../../src/handlers/create-component.js';
 
-const makeComponent = () => {
+const makeComponent = (id = '2:1') => {
   const node = {
-    id: '2:1',
+    id,
     name: 'Component',
     type: 'COMPONENT',
     x: 0,
@@ -21,21 +21,28 @@ const makeComponent = () => {
   return node;
 };
 
-const fakeFigma = (
-  node: ReturnType<typeof makeComponent>,
-  page: { appendChild: (n: unknown) => void },
-): typeof figma =>
+const fakeFigma = (opts: {
+  component?: ReturnType<typeof makeComponent>;
+  fromComponent?: ReturnType<typeof makeComponent>;
+  createComponentFromNode?: ReturnType<typeof vi.fn>;
+  lookup?: Record<string, unknown>;
+  page?: { appendChild: (n: unknown) => void };
+}): typeof figma =>
   ({
-    createComponent: () => node,
-    currentPage: page,
-    getNodeByIdAsync: async () => null,
+    createComponent: () => opts.component ?? makeComponent(),
+    createComponentFromNode:
+      opts.createComponentFromNode ?? vi.fn<(n: unknown) => unknown>(() => opts.fromComponent),
+    currentPage: opts.page ?? { appendChild: vi.fn<(n: unknown) => void>() },
+    getNodeByIdAsync: async (id: string) => opts.lookup?.[id] ?? null,
   }) as unknown as typeof figma;
 
 describe('create_component handler', () => {
-  it('creates, sizes, names, and appends to the current page by default', async () => {
+  it('creates an empty component, sizes/names it, and appends to the current page by default', async () => {
     const node = makeComponent();
     const appendChild = vi.fn<(n: unknown) => void>();
-    const handler = createCreateComponentHandler(fakeFigma(node, { appendChild }));
+    const handler = createCreateComponentHandler(
+      fakeFigma({ component: node, page: { appendChild } }),
+    );
     const result = (await handler({
       name: 'Button',
       width: 120,
@@ -48,5 +55,32 @@ describe('create_component handler', () => {
     expect([node.width, node.height, node.x, node.y]).toEqual([120, 40, 10, 5]);
     expect(appendChild).toHaveBeenCalledWith(node);
     expect(result).toEqual({ ok: true, nodeId: '2:1', name: 'Button', type: 'COMPONENT' });
+  });
+
+  it('componentizes an existing node via fromNodeId and leaves it in place (no reparent)', async () => {
+    const source = { id: 'SRC:1', type: 'FRAME' };
+    const made = makeComponent('C:9');
+    const createComponentFromNode = vi.fn<(n: unknown) => unknown>(() => made);
+    const appendChild = vi.fn<(n: unknown) => void>();
+    const handler = createCreateComponentHandler(
+      fakeFigma({ createComponentFromNode, lookup: { 'SRC:1': source }, page: { appendChild } }),
+    );
+
+    const result = (await handler({ fromNodeId: 'SRC:1', name: 'Logo' })) as CreateResult;
+
+    expect(createComponentFromNode).toHaveBeenCalledWith(source);
+    expect(appendChild).not.toHaveBeenCalled(); // stays where the source node was
+    expect(result).toEqual({ ok: true, nodeId: 'C:9', name: 'Logo', type: 'COMPONENT' });
+  });
+
+  it('throws when fromNodeId is missing or not componentizable', async () => {
+    await expect(
+      createCreateComponentHandler(fakeFigma({}))({ fromNodeId: 'GONE:1' }),
+    ).rejects.toThrow(/not found/);
+    await expect(
+      createCreateComponentHandler(fakeFigma({ lookup: { 'P:1': { id: 'P:1', type: 'PAGE' } } }))({
+        fromNodeId: 'P:1',
+      }),
+    ).rejects.toThrow(/can't be turned into a component/);
   });
 });

--- a/skills/figma-build/references/author-design-system.md
+++ b/skills/figma-build/references/author-design-system.md
@@ -52,7 +52,11 @@ look (a shadow, a type ramp step).
 ## Components & variant sets
 
 1. **`create_component`** — a reusable main component (size/name/position). Build its internals like
-   any frame (auto-layout, children, bound tokens — see `assemble-screens.md`).
+   any frame (auto-layout, children, bound tokens — see `assemble-screens.md`). To promote something
+   you already built or imported — a laid-out frame, or the vectors from an `import_svg` logo/icon —
+   pass **`fromNodeId`** to convert that node into a component in place (keeps its parent/position
+   unless `parentId` is given), then `create_instance` it to reuse it. That's the SVG-to-reusable-icon
+   path: `import_svg` → `create_component fromNodeId` → `create_instance`.
 2. **Name each variant member with `Prop=Value` syntax _before_ combining** — `Size=Small`,
    `Size=Large`. The set derives its variant properties from these names.
 3. **`combine_as_variants`** (`nodeIds`: ≥2 COMPONENTs, optional `name`) → a `COMPONENT_SET`. Read it


### PR DESCRIPTION
## What

`create_component` gains an optional **`fromNodeId`**: convert an existing node into a reusable main component (`figma.createComponentFromNode`) instead of only creating an empty one.

```
create_component({ fromNodeId?, parentId?, name?, x?, y?, width?, height? }) -> { ok, nodeId, name, type }
```

Tool count unchanged (enhancement, not a new tool).

## Why

Discovered while exploring `import_svg`: it drops a frame of raw vectors, but there was **no way to turn that (or any built frame) into a reusable component** — `create_component` only made an *empty* one. This closes the loop: **`import_svg` → `create_component` (fromNodeId) → `create_instance`** = the same structure as the file's own icon components (a COMPONENT + linked instances).

## Behaviour

- `fromNodeId` given → `createComponentFromNode` replaces the node **in place**, keeping its parent/position unless `parentId` is passed. Rejects PAGE/DOCUMENT/COMPONENT/COMPONENT_SET with a clear error.
- `fromNodeId` omitted → empty component, exactly as before (no regression).

## Batch faithfulness (the correctness bit)

`create_component` stays batchable as an empty create, but **`fromNodeId` is rejected inside a `batch`**: componentizing *consumes* the source node, so the generic "undo = remove the created node" would destroy the original — no faithful inverse. Same principle that already excludes `delete_*` / `swap_component` from batch. Rejected at validate time (capture phase), before any mutation.

## Verification

- `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` — green (681 tests / 131 files).
- New tests: handler `fromNodeId` (componentizes in place, no reparent; not-found / non-componentizable throw) + batch rejects `create_component {fromNodeId}` at validate time.
- **Live round-trip pending** (needs MCP reconnect): `import_svg` → `create_component fromNodeId` → `create_instance` → confirm the instance links back to the new component; confirm a `batch` with `fromNodeId` is rejected.