### PR TITLE
feat: add set_arc and read ellipse arcData (pie / gauge / ring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **91 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **92 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
@@ -147,7 +147,7 @@ npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-cod
 
 ## Tools
 
-Figwright exposes **91 MCP tools** in three groups:
+Figwright exposes **92 MCP tools** in three groups:
 
 - **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, and PDF export.
 - **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components, pages, and reactions; plus a `batch` tool to apply many edits at once.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **91 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **92 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -73,6 +73,7 @@ import { scanComponentsTool } from './scan-components.js';
 import { scanNodesByTypesTool } from './scan-nodes-by-types.js';
 import { scanTextNodesTool } from './scan-text-nodes.js';
 import { searchNodesTool } from './search-nodes.js';
+import { setArcTool } from './set-arc.js';
 import { setAutoLayoutTool } from './set-auto-layout.js';
 import { setBlendModeTool } from './set-blend-mode.js';
 import { setConstraintsTool } from './set-constraints.js';
@@ -148,6 +149,7 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   setLayoutPropsTool,
   setBlendModeTool,
   setMaskTool,
+  setArcTool,
   setConstraintsTool,
   rotateNodesTool,
   lockNodesTool,

--- a/packages/mcp/src/tools/set-arc.ts
+++ b/packages/mcp/src/tools/set-arc.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const SET_ARC_TOOL_NAME = 'set_arc';
+
+export const setArcTool: ToolSpec = {
+  name: SET_ARC_TOOL_NAME,
+  description:
+    'Turn an ellipse into a pie slice / gauge or a ring / donut by setting its arc data. ' +
+    'startingAngle / endingAngle are in radians and carve out the visible wedge (a full circle is ' +
+    '0 → 2π ≈ 6.28319; a half is π ≈ 3.14159); innerRadius is 0–1 of the radius (0 = a solid disc, ' +
+    '> 0 = a ring with a hole, e.g. 0.6 for a donut or progress ring). Only ellipses have arc data. ' +
+    'Pass any subset — omitted fields keep their current value. At least one is required. Returns ' +
+    '{ ok, nodeId }.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id (must be an ellipse)'),
+    startingAngle: z.number().optional().describe('Arc start angle in radians'),
+    endingAngle: z.number().optional().describe('Arc end angle in radians'),
+    innerRadius: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe('Inner radius 0–1 of the outer radius (0 = solid disc, > 0 = ring / donut)'),
+  },
+  kind: 'write',
+};

--- a/packages/plugin/src/handlers/batch.ts
+++ b/packages/plugin/src/handlers/batch.ts
@@ -161,6 +161,7 @@ const INVERSES: Readonly<Record<string, BatchInverse>> = {
   set_opacity: nodeProps('set_opacity', ['opacity']),
   set_visible: nodeProps('set_visible', ['visible']),
   set_corner_radius: nodeProps('set_corner_radius', ['cornerRadius']),
+  set_arc: nodeProps('set_arc', ['arcData']),
   set_blend_mode: nodeProps('set_blend_mode', ['blendMode']),
   set_effects: nodeProps('set_effects', ['effects']),
   set_constraints: nodeProps('set_constraints', ['constraints']),

--- a/packages/plugin/src/handlers/get-design-context.ts
+++ b/packages/plugin/src/handlers/get-design-context.ts
@@ -59,6 +59,7 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
   if (flat.blendMode !== undefined) out.blendMode = flat.blendMode;
   if (flat.isMask !== undefined) out.isMask = flat.isMask;
   if (flat.maskType !== undefined) out.maskType = flat.maskType;
+  if (flat.arcData !== undefined) out.arcData = flat.arcData;
   if (flat.fills !== undefined) out.fills = flat.fills;
   if (flat.strokes !== undefined) out.strokes = flat.strokes;
   if (flat.strokeWeight !== undefined) out.strokeWeight = flat.strokeWeight;

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -65,6 +65,7 @@ import { createRotateNodesHandler } from './rotate-nodes.js';
 import { createScanNodesByTypesHandler } from './scan-nodes-by-types.js';
 import { createScanTextNodesHandler } from './scan-text-nodes.js';
 import { createSearchNodesHandler } from './search-nodes.js';
+import { createSetArcHandler } from './set-arc.js';
 import { createSetAutoLayoutHandler } from './set-auto-layout.js';
 import { createSetBlendModeHandler } from './set-blend-mode.js';
 import { createSetConstraintsHandler } from './set-constraints.js';
@@ -115,6 +116,7 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     set_layout_props: createSetLayoutPropsHandler(figmaCtx),
     set_blend_mode: createSetBlendModeHandler(figmaCtx),
     set_mask: createSetMaskHandler(figmaCtx),
+    set_arc: createSetArcHandler(figmaCtx),
     set_constraints: createSetConstraintsHandler(figmaCtx),
     rotate_nodes: createRotateNodesHandler(figmaCtx),
     lock_nodes: createSetLockedHandler(figmaCtx, true),

--- a/packages/plugin/src/handlers/set-arc.ts
+++ b/packages/plugin/src/handlers/set-arc.ts
@@ -1,0 +1,51 @@
+import type { MutateResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+
+export const createSetArcHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as {
+      nodeId?: unknown;
+      startingAngle?: unknown;
+      endingAngle?: unknown;
+      innerRadius?: unknown;
+    };
+    if (typeof p.nodeId !== 'string') throw new TypeError('set_arc: nodeId must be a string');
+    if (p.startingAngle !== undefined && typeof p.startingAngle !== 'number') {
+      throw new TypeError('set_arc: startingAngle must be a number (radians)');
+    }
+    if (p.endingAngle !== undefined && typeof p.endingAngle !== 'number') {
+      throw new TypeError('set_arc: endingAngle must be a number (radians)');
+    }
+    if (
+      p.innerRadius !== undefined &&
+      (typeof p.innerRadius !== 'number' || p.innerRadius < 0 || p.innerRadius > 1)
+    ) {
+      throw new TypeError('set_arc: innerRadius must be a number between 0 and 1');
+    }
+    if (
+      p.startingAngle === undefined &&
+      p.endingAngle === undefined &&
+      p.innerRadius === undefined
+    ) {
+      throw new TypeError(
+        'set_arc: provide at least one of startingAngle, endingAngle, innerRadius',
+      );
+    }
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !('arcData' in node)) {
+      throw new Error(`set_arc: node ${p.nodeId} not found or is not an ellipse`);
+    }
+    // Figma requires the whole arcData object at once, so merge the given fields over the current
+    // value — a caller can tweak just innerRadius (make a donut) without resetting the angles.
+    const ellipse = node as EllipseNode;
+    const current = ellipse.arcData;
+    ellipse.arcData = {
+      startingAngle: typeof p.startingAngle === 'number' ? p.startingAngle : current.startingAngle,
+      endingAngle: typeof p.endingAngle === 'number' ? p.endingAngle : current.endingAngle,
+      innerRadius: typeof p.innerRadius === 'number' ? p.innerRadius : current.innerRadius,
+    };
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -307,6 +307,24 @@ const enrichWithMixins = (node: SceneNode, base: SerializedNode): SerializedNode
     const mt = (node as { maskType?: unknown }).maskType;
     if (typeof mt === 'string') out.maskType = mt;
   }
+  // Ellipse arc data (pie slices, gauges, rings / donuts). Only an EllipseNode exposes arcData; emit
+  // it only when the ellipse isn't a plain full disc — a partial sweep or a non-zero innerRadius — so
+  // a solid circle stays clean. Otherwise codegen would render a progress ring or pie as a flat
+  // circle. startingAngle / endingAngle are radians; innerRadius is 0–1 of the outer radius.
+  if ('arcData' in node) {
+    const arc = (
+      node as { arcData: { startingAngle: number; endingAngle: number; innerRadius: number } }
+    ).arcData;
+    const sweep = arc.endingAngle - arc.startingAngle;
+    const isFullDisc = arc.innerRadius === 0 && sweep >= Math.PI * 2 - 1e-4;
+    if (!isFullDisc) {
+      out.arcData = {
+        startingAngle: arc.startingAngle,
+        endingAngle: arc.endingAngle,
+        innerRadius: arc.innerRadius,
+      };
+    }
+  }
   if ('fills' in node) {
     const fills = (node as { fills: unknown }).fills;
     out.fills = Array.isArray(fills) ? fills.map(p => serializePaint(p as Paint)) : MIXED;

--- a/packages/plugin/test/handlers/set-arc.test.ts
+++ b/packages/plugin/test/handlers/set-arc.test.ts
@@ -1,0 +1,42 @@
+import type { MutateResult } from '@figwright/shared';
+import { describe, expect, it } from 'vitest';
+
+import { createSetArcHandler } from '../../src/handlers/set-arc.js';
+
+const fakeFigma = (lookup: Record<string, unknown>): typeof figma =>
+  ({ getNodeByIdAsync: async (id: string) => lookup[id] ?? null }) as unknown as typeof figma;
+
+const fullDisc = () => ({ startingAngle: 0, endingAngle: Math.PI * 2, innerRadius: 0 });
+
+describe('set_arc handler', () => {
+  it('sets the full arc data (a half-circle pie)', async () => {
+    const node = { id: '1:1', arcData: fullDisc() };
+    const handler = createSetArcHandler(fakeFigma({ '1:1': node }));
+    const result = (await handler({
+      nodeId: '1:1',
+      startingAngle: 0,
+      endingAngle: Math.PI,
+      innerRadius: 0,
+    })) as MutateResult;
+    expect(node.arcData).toEqual({ startingAngle: 0, endingAngle: Math.PI, innerRadius: 0 });
+    expect(result).toEqual({ ok: true, nodeId: '1:1' });
+  });
+
+  it('merges a partial update over the current arc (a donut keeps its angles)', async () => {
+    const node = { id: '1:1', arcData: { startingAngle: 0.5, endingAngle: 2, innerRadius: 0 } };
+    const handler = createSetArcHandler(fakeFigma({ '1:1': node }));
+    await handler({ nodeId: '1:1', innerRadius: 0.6 });
+    expect(node.arcData).toEqual({ startingAngle: 0.5, endingAngle: 2, innerRadius: 0.6 });
+  });
+
+  it('rejects out-of-range innerRadius, no fields, and non-ellipse nodes', async () => {
+    const handler = createSetArcHandler(
+      fakeFigma({ '1:1': { id: '1:1', arcData: fullDisc() }, '2:2': { id: '2:2' } }),
+    );
+    await expect(handler({ nodeId: '1:1', innerRadius: 1.5 })).rejects.toThrow(/innerRadius/);
+    await expect(handler({ nodeId: '1:1', innerRadius: -0.1 })).rejects.toThrow(/innerRadius/);
+    await expect(handler({ nodeId: '1:1' })).rejects.toThrow(/at least one/);
+    await expect(handler({ nodeId: '2:2', innerRadius: 0.5 })).rejects.toThrow(/not.*ellipse/);
+    await expect(handler({ nodeId: '9:9', innerRadius: 0.5 })).rejects.toThrow(/not found/);
+  });
+});

--- a/packages/plugin/test/serializer.test.ts
+++ b/packages/plugin/test/serializer.test.ts
@@ -95,6 +95,27 @@ describe('serializeFlat', () => {
     expect(serializeFlatSync(fake({ isMask: false })).isMask).toBeUndefined();
   });
 
+  it('surfaces ellipse arcData for a partial sweep (pie) or non-zero innerRadius (donut)', () => {
+    // Partial sweep → a pie slice / gauge.
+    const pie = serializeFlatSync(
+      fake({ arcData: { startingAngle: 0, endingAngle: Math.PI, innerRadius: 0 } }),
+    );
+    expect(pie.arcData).toEqual({ startingAngle: 0, endingAngle: Math.PI, innerRadius: 0 });
+    // Full sweep but a hole → a ring / donut.
+    const donut = serializeFlatSync(
+      fake({ arcData: { startingAngle: 0, endingAngle: Math.PI * 2, innerRadius: 0.6 } }),
+    );
+    expect(donut.arcData).toEqual({ startingAngle: 0, endingAngle: Math.PI * 2, innerRadius: 0.6 });
+  });
+
+  it('omits arcData for a plain full disc and for non-ellipse nodes', () => {
+    const disc = serializeFlatSync(
+      fake({ arcData: { startingAngle: 0, endingAngle: Math.PI * 2, innerRadius: 0 } }),
+    );
+    expect(disc.arcData).toBeUndefined();
+    expect(serializeFlatSync(fake()).arcData).toBeUndefined();
+  });
+
   it('marks fills=mixed when value is not an array', () => {
     const out = serializeFlatSync(fake({ fills: Symbol('figma.mixed') }));
     expect(out.fills).toBe(MIXED);

--- a/packages/shared/src/design-context.ts
+++ b/packages/shared/src/design-context.ts
@@ -71,6 +71,12 @@ export interface DesignContextNode {
   isMask?: boolean;
   /** Mask clipping mode: ALPHA / LUMINANCE / GEOMETRY (only when isMask). */
   maskType?: string;
+  /**
+   * Ellipse arc geometry (EllipseNode only): a partial sweep → pie slice / gauge, or a non-zero
+   * innerRadius → ring / donut. Omitted for a plain full disc. Angles in radians; innerRadius 0–1.
+   * Codegen renders these as an SVG arc / conic-gradient, not a solid circle.
+   */
+  arcData?: { startingAngle: number; endingAngle: number; innerRadius: number };
   fills?: readonly z.infer<typeof SerializedPaintSchema>[] | typeof MIXED;
   strokes?: readonly SerializedPaint[];
   strokeWeight?: number | typeof MIXED;
@@ -165,6 +171,13 @@ export const DesignContextNodeSchema = z.lazy(() =>
     blendMode: z.string().optional(),
     isMask: z.boolean().optional(),
     maskType: z.string().optional(),
+    arcData: z
+      .object({
+        startingAngle: z.number(),
+        endingAngle: z.number(),
+        innerRadius: z.number(),
+      })
+      .optional(),
     fills: z.union([z.array(SerializedPaintSchema), z.literal(MIXED)]).optional(),
     strokes: z.array(SerializedPaintSchema).optional(),
     strokeWeight: z.union([z.number(), z.literal(MIXED)]).optional(),

--- a/packages/shared/src/serialized-node.ts
+++ b/packages/shared/src/serialized-node.ts
@@ -240,6 +240,12 @@ export interface SerializedNode {
   isMask?: boolean;
   /** How the mask clips: ALPHA / LUMINANCE / GEOMETRY (only meaningful when isMask). */
   maskType?: string;
+  /**
+   * Ellipse arc geometry (EllipseNode only) → a pie slice / gauge (partial sweep) or a ring / donut
+   * (non-zero innerRadius). Omitted for a plain full disc, so a solid circle stays clean. Angles
+   * are in radians; innerRadius is 0–1 of the outer radius. Round-trips with set_arc.
+   */
+  arcData?: { startingAngle: number; endingAngle: number; innerRadius: number };
   fills?: readonly SerializedPaint[] | Mixed;
   strokes?: readonly SerializedPaint[];
   strokeWeight?: number | Mixed;
@@ -316,6 +322,13 @@ export const SerializedNodeSchema = z.lazy(() =>
     blendMode: z.string().optional(),
     isMask: z.boolean().optional(),
     maskType: z.string().optional(),
+    arcData: z
+      .object({
+        startingAngle: z.number(),
+        endingAngle: z.number(),
+        innerRadius: z.number(),
+      })
+      .optional(),
     fills: z.union([z.array(SerializedPaintSchema), z.literal(MIXED)]).optional(),
     strokes: z.array(SerializedPaintSchema).optional(),
     strokeWeight: z.union([z.number(), z.literal(MIXED)]).optional(),

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -59,6 +59,12 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   `ALPHA` / `LUMINANCE` / `GEOMETRY`). **Don't render the mask layer as ordinary content** — realise
   it as the container's `overflow-hidden` + radius, a `clip-path`, or an SVG mask on the masked
   siblings, and skip emitting the mask shape itself.
+- **Ellipse arc / ring.** An `ELLIPSE` carrying `arcData` is **not a plain circle** — a partial
+  sweep (`startingAngle`→`endingAngle`, radians) is a pie slice / gauge, and `innerRadius > 0`
+  (0–1 of the radius) cuts a hole for a ring / donut (a progress ring, a donut chart). Render it as
+  an SVG `<path>` arc (or `<circle>` with `stroke-dasharray` for a progress ring) / a `conic-gradient`
+  — **not** a filled `rounded-full` div, which loses the wedge and the hole. A full disc omits
+  `arcData`, so its presence always means a real arc.
 - **Gradient fills.** A fill of type `GRADIENT_LINEAR` / `GRADIENT_RADIAL` / `GRADIENT_ANGULAR` /
   `GRADIENT_DIAMOND` carries `gradientStops` (`{ position 0–1, color hex }`) and `gradientTransform`
   (the 2×3 axis matrix). **Emit a real CSS gradient — don't flatten it to a solid colour.** Map the


### PR DESCRIPTION
## What

Ellipses could only be plain discs — the serializer dropped `arcData` and there was no write tool to set it, so pie slices, gauges and rings/donuts round-tripped as solid circles. This adds read **and** write for ellipse arc geometry, the same fidelity class as per-corner radius / mask.

## Read (codegen can see it)
- `serializer.ts` emits `arcData` for an `ELLIPSE` **only when it isn't a plain full disc** (a partial sweep or `innerRadius > 0`), so a solid circle stays clean.
- Surfaced through the `SerializedNode` + `DesignContextNode` schemas and `get_design_context`'s `project()`.
- `grounding.md`: render arcs as an SVG `<path>` / `conic-gradient`, **not** a solid `rounded-full`.

## Write (figma-build can build it)
- New **`set_arc`** tool: `startingAngle` / `endingAngle` (radians) + `innerRadius` (0–1). Merges a partial update over the current arc, so you can make a donut by setting only `innerRadius` without touching the angles.
- Registered in both registries + the batch allowlist (invertible, same shape as `set_corner_radius`).
- Standalone setter rather than folded into `create_ellipse` — matches `set_corner_radius` / `set_mask` and can edit existing ellipses.

## Tests & gates
- New `set_arc` handler tests (3) + serializer tests (2).
- Full gate green: typecheck / lint / format / knip / build / **686 tests**. Tool count 91 → 92.

## Live verify (real Figma round-trip)
- Pie (`set_arc` 0→π) read back `{0, 3.14159, 0}` ✓
- Donut (`set_arc` `innerRadius` 0.6 only) read back `{0, 6.283 (2π), 0.6}` — merge kept the angles ✓
- Rejected as expected: non-ellipse, no fields, `innerRadius` 1.5 (schema `.max(1)`) ✓
- Test nodes cleaned up.