### PR TITLE
feat: carry pattern fill tiling geometry for faithful codegen

### DIFF
--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -51,8 +51,31 @@ export const serializePaint = (paint: Paint): SerializedPaint => {
       gradientTransform: transform.map(row => row.slice()),
     };
   }
+  if (paint.type === 'PATTERN') {
+    // A source node tiled across the fill. Carry the geometry to reconstruct the tiling; the tile
+    // artwork itself is exported separately (like a raster) via get_screenshot on sourceNodeId.
+    // Omit the no-op defaults (spacing 0,0 / alignment START) to keep the payload lean.
+    const spacing =
+      paint.spacing.x !== 0 || paint.spacing.y !== 0
+        ? { spacing: { x: paint.spacing.x, y: paint.spacing.y } }
+        : undefined;
+    const alignment =
+      paint.horizontalAlignment !== 'START'
+        ? { horizontalAlignment: paint.horizontalAlignment }
+        : undefined;
+    return {
+      type: 'PATTERN',
+      visible,
+      opacity,
+      sourceNodeId: paint.sourceNodeId,
+      tileType: paint.tileType,
+      scalingFactor: paint.scalingFactor,
+      ...spacing,
+      ...alignment,
+    };
+  }
   // IMAGE / VIDEO paints carry a scaleMode (FILL/FIT/CROP/TILE) — the object-fit equivalent, needed
-  // so exported images get the right fit instead of being stretched. PATTERN has no scaleMode.
+  // so exported images get the right fit instead of being stretched. SHADER has none.
   const scaleMode = 'scaleMode' in paint ? (paint as { scaleMode?: string }).scaleMode : undefined;
   return scaleMode === undefined
     ? { type: paint.type, visible, opacity }

--- a/packages/plugin/test/serializer.test.ts
+++ b/packages/plugin/test/serializer.test.ts
@@ -165,11 +165,64 @@ describe('serializeFlat', () => {
     expect(out.fills).toEqual([{ type: 'IMAGE', visible: true, opacity: 1, scaleMode: 'FILL' }]);
   });
 
-  it('serializes a PATTERN paint as type-only (no scaleMode)', () => {
+  it('serializes a PATTERN paint with its tiling geometry (source node + repeat)', () => {
     const out = serializeFlatSync(
-      fake({ fills: [{ type: 'PATTERN', visible: false, opacity: 0.8 }] }),
+      fake({
+        fills: [
+          {
+            type: 'PATTERN',
+            visible: false,
+            opacity: 0.8,
+            sourceNodeId: '12:34',
+            tileType: 'RECTANGULAR',
+            scalingFactor: 0.5,
+            spacing: { x: 4, y: 8 },
+            horizontalAlignment: 'CENTER',
+          },
+        ],
+      }),
     );
-    expect(out.fills).toEqual([{ type: 'PATTERN', visible: false, opacity: 0.8 }]);
+    expect(out.fills).toEqual([
+      {
+        type: 'PATTERN',
+        visible: false,
+        opacity: 0.8,
+        sourceNodeId: '12:34',
+        tileType: 'RECTANGULAR',
+        scalingFactor: 0.5,
+        spacing: { x: 4, y: 8 },
+        horizontalAlignment: 'CENTER',
+      },
+    ]);
+  });
+
+  it('omits the no-op pattern defaults (spacing 0,0 / alignment START)', () => {
+    const out = serializeFlatSync(
+      fake({
+        fills: [
+          {
+            type: 'PATTERN',
+            visible: true,
+            opacity: 1,
+            sourceNodeId: '12:34',
+            tileType: 'RECTANGULAR',
+            scalingFactor: 1,
+            spacing: { x: 0, y: 0 },
+            horizontalAlignment: 'START',
+          },
+        ],
+      }),
+    );
+    expect(out.fills).toEqual([
+      {
+        type: 'PATTERN',
+        visible: true,
+        opacity: 1,
+        sourceNodeId: '12:34',
+        tileType: 'RECTANGULAR',
+        scalingFactor: 1,
+      },
+    ]);
   });
 
   it('falls back paint.visible/opacity to defaults when undefined', () => {

--- a/packages/shared/src/design-context-dedupe.ts
+++ b/packages/shared/src/design-context-dedupe.ts
@@ -61,6 +61,12 @@ interface SimplifiedPaint {
   gradientTransform?: number[][];
   /** IMAGE/VIDEO object-fit equivalent: FILL=cover, FIT=contain, CROP, TILE=repeat. */
   scaleMode?: string;
+  /** PATTERN tiling: the source tile node + how it repeats. See grounding.md "Pattern fills". */
+  sourceNodeId?: string;
+  tileType?: string;
+  scalingFactor?: number;
+  spacing?: { x: number; y: number };
+  horizontalAlignment?: string;
   visible?: false;
 }
 
@@ -79,6 +85,15 @@ const simplifyPaint = (paint: SerializedPaint): SimplifiedPaint => {
     out.gradientTransform = paint.gradientTransform;
   } else if ('scaleMode' in paint && paint.scaleMode !== undefined) {
     out.scaleMode = paint.scaleMode;
+  } else if (paint.type === 'PATTERN') {
+    // The source tile + its repeat geometry — without it a pattern fill is just `{ type: 'PATTERN' }`
+    // and the LLM can only flatten it to a colour. The serializer already omits no-op defaults.
+    out.sourceNodeId = paint.sourceNodeId;
+    out.tileType = paint.tileType;
+    out.scalingFactor = paint.scalingFactor;
+    if (paint.spacing !== undefined) out.spacing = paint.spacing;
+    if (paint.horizontalAlignment !== undefined)
+      out.horizontalAlignment = paint.horizontalAlignment;
   }
   if (paint.visible === false) out.visible = false;
   return out;

--- a/packages/shared/src/serialized-node.ts
+++ b/packages/shared/src/serialized-node.ts
@@ -47,23 +47,41 @@ const GradientPaintSchema = z.object({
 });
 
 /**
- * IMAGE / VIDEO / PATTERN / SHADER. scaleMode (the object-fit equivalent: FILL=cover, FIT=contain,
- * CROP, TILE=repeat) is carried for IMAGE/VIDEO so an exported image gets the right fit; the raster
- * bytes themselves stay out of scope (exported separately via get_screenshot). PATTERN and SHADER
- * (a procedural fill) carry no scaleMode — we emit only the type marker so the fill isn't silently
- * dropped from codegen, since neither has a meaningful CSS translation.
+ * IMAGE / VIDEO / SHADER. scaleMode (the object-fit equivalent: FILL=cover, FIT=contain, CROP,
+ * TILE=repeat) is carried for IMAGE/VIDEO so an exported image gets the right fit; the raster bytes
+ * themselves stay out of scope (exported separately via get_screenshot). SHADER is a procedural
+ * fill with no scaleMode and no meaningful CSS translation — we emit only the type marker so it
+ * isn't silently dropped. (PATTERN has its own schema below; it carries the tiling geometry.)
  */
 const OtherPaintSchema = z.object({
-  type: z.enum(['IMAGE', 'VIDEO', 'PATTERN', 'SHADER']),
+  type: z.enum(['IMAGE', 'VIDEO', 'SHADER']),
   visible: z.boolean(),
   opacity: z.number(),
   scaleMode: z.enum(['FILL', 'FIT', 'CROP', 'TILE']).optional(),
+});
+
+/**
+ * PATTERN — a source node tiled across the fill (a newer Figma feature). The tile artwork itself
+ * lives at `sourceNodeId` and is exported separately (like a raster) via get_screenshot; we carry
+ * the geometry needed to reconstruct the tiling in code. `spacing` (0,0) and `horizontalAlignment`
+ * 'START' are the no-op defaults, omitted by the serializer to keep the payload lean.
+ */
+const PatternPaintSchema = z.object({
+  type: z.literal('PATTERN'),
+  visible: z.boolean(),
+  opacity: z.number(),
+  sourceNodeId: z.string(),
+  tileType: z.enum(['RECTANGULAR', 'HORIZONTAL_HEXAGONAL', 'VERTICAL_HEXAGONAL']),
+  scalingFactor: z.number(),
+  spacing: z.object({ x: z.number(), y: z.number() }).optional(),
+  horizontalAlignment: z.enum(['START', 'CENTER', 'END']).optional(),
 });
 
 export const SerializedPaintSchema = z.discriminatedUnion('type', [
   SolidPaintSchema,
   GradientPaintSchema,
   OtherPaintSchema,
+  PatternPaintSchema,
 ]);
 export type SerializedPaint = z.infer<typeof SerializedPaintSchema>;
 

--- a/packages/shared/test/design-context-dedupe.test.ts
+++ b/packages/shared/test/design-context-dedupe.test.ts
@@ -90,6 +90,38 @@ describe('dedupeStyles', () => {
     expect(globalVars.styles[nodes[0]!.fill!]).toEqual([{ type: 'IMAGE', scaleMode: 'FILL' }]);
   });
 
+  it('carries the tiling geometry on a PATTERN fill (source node + repeat)', () => {
+    const { nodes, globalVars } = dedupeStyles([
+      {
+        id: 'a',
+        name: 'a',
+        type: 'RECTANGLE',
+        fills: [
+          {
+            type: 'PATTERN',
+            visible: true,
+            opacity: 1,
+            sourceNodeId: '12:34',
+            tileType: 'RECTANGULAR',
+            scalingFactor: 0.5,
+            spacing: { x: 4, y: 8 },
+            horizontalAlignment: 'CENTER',
+          },
+        ],
+      },
+    ]);
+    expect(globalVars.styles[nodes[0]!.fill!]).toEqual([
+      {
+        type: 'PATTERN',
+        sourceNodeId: '12:34',
+        tileType: 'RECTANGULAR',
+        scalingFactor: 0.5,
+        spacing: { x: 4, y: 8 },
+        horizontalAlignment: 'CENTER',
+      },
+    ]);
+  });
+
   it('hoists effects (drop-shadow) and strokes into refs, converting colors to hex', () => {
     const n: DesignContextNode = {
       id: 'card',

--- a/packages/shared/test/serialized-node.test.ts
+++ b/packages/shared/test/serialized-node.test.ts
@@ -109,9 +109,35 @@ describe('SerializedPaint variant', () => {
     expect(SerializedPaintSchema.parse(paint)).toEqual(paint);
   });
 
-  it('accepts an IMAGE/VIDEO/PATTERN paint (type only, no gradient detail)', () => {
+  it('accepts an IMAGE/VIDEO paint (type only, no gradient detail)', () => {
     const paint = { type: 'IMAGE' as const, visible: false, opacity: 1 };
     expect(SerializedPaintSchema.parse(paint)).toEqual(paint);
+  });
+
+  it('accepts a PATTERN paint with its tiling geometry', () => {
+    const paint = {
+      type: 'PATTERN' as const,
+      visible: true,
+      opacity: 1,
+      sourceNodeId: '12:34',
+      tileType: 'RECTANGULAR' as const,
+      scalingFactor: 0.5,
+      spacing: { x: 4, y: 8 },
+      horizontalAlignment: 'CENTER' as const,
+    };
+    expect(SerializedPaintSchema.parse(paint)).toEqual(paint);
+  });
+
+  it('rejects a PATTERN paint missing its source node', () => {
+    expect(() =>
+      SerializedPaintSchema.parse({
+        type: 'PATTERN',
+        visible: true,
+        opacity: 1,
+        tileType: 'RECTANGULAR',
+        scalingFactor: 1,
+      }),
+    ).toThrow(/sourceNodeId/);
   });
 
   it('rejects a gradient paint missing stops', () => {

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -73,6 +73,12 @@ the obvious ones. These are ordered by how easily they're silently dropped.
 - **Image fit.** An `IMAGE` (or `VIDEO`) fill carries `scaleMode` — the object-fit equivalent:
   `FILL` → `object-cover`, `FIT` → `object-contain`, `CROP` → `cover` + a position, `TILE` →
   `background-repeat: repeat`. Apply it to the exported image so it isn't stretched or letterboxed.
+- **Pattern fills.** A `PATTERN` fill tiles a source node (`sourceNodeId`) across the element — it is
+  **not** a flat colour. Export that tile with `get_screenshot` on `sourceNodeId`, then: for
+  `tileType: RECTANGULAR`, use `background-image` + `background-repeat: repeat` with a
+  `background-size` derived from `scalingFactor` (and gaps from `spacing`); for the hexagonal tile
+  types (`HORIZONTAL_HEXAGONAL` / `VERTICAL_HEXAGONAL`), use an SVG `<pattern>` with offset rows.
+  Don't flatten it to a solid colour.
 - **Auto-layout & Grid — read spacing off `layout`, never eyeball it.** Each auto-layout frame carries
   a `layout` object with the _exact_ spacing; don't reverse-engineer padding/gap/justify from child
   `x/y/w/h`. `mode` `HORIZONTAL`/`VERTICAL` → `flex-row`/`flex-col`; `padding*` → `p-*`; for H/V


### PR DESCRIPTION
## Problem

A `PATTERN` fill (a source node tiled across an element — a newer Figma feature) used to serialize to a bare `{ type: "PATTERN" }`. After dedupe, the form fed to the LLM was literally `[{ "type": "PATTERN" }]` — `sourceNodeId`, `tileType`, `scalingFactor`, `spacing`, and `horizontalAlignment` were all dropped. The LLM could only see the tiled result in the screenshot and would flatten it to a solid colour. Same miss-class as the earlier gradient-transform / text-fidelity gaps: a multi-field paint collapsed to a single `type` string.

## Change (read side only)

- **Schema** (`serialized-node.ts`): split `PATTERN` out of `OtherPaintSchema` into its own `PatternPaintSchema` carrying the tiling geometry.
- **Serializer** (`serializer.ts`): emit `sourceNodeId` / `tileType` / `scalingFactor` always; emit `spacing` / `horizontalAlignment` only when non-default (omit the no-op `{0,0}` / `START`).
- **Dedupe** (`design-context-dedupe.ts`): carry the same fields into the `globalVars` form the LLM actually reads.
- **Grounding** (`figma-codegen/references/grounding.md`): a new "Pattern fills" bullet — export the tile via `get_screenshot` on `sourceNodeId`, then `background-repeat` + `background-size` (RECTANGULAR) or an SVG `<pattern>` (hexagonal tile types); don't flatten to a colour.

## Out of scope

- **Write side**: `set_fills` still rejects `PATTERN` (it references a source node; authoring it generically isn't viable).
- **SHADER**: stays a bare type marker — even rarer, no meaningful CSS translation.

## Verification

- Full gate green: `typecheck && lint && format:check && knip && build && test` — **690 tests** (+4 new: serializer geometry + no-op omission, schema accept/reject, dedupe carry-through).
- **Live**: against a real pattern-filled text node, both the inline fill and the `globalVars` entry now carry `{ sourceNodeId, tileType, scalingFactor }`, with the no-op `spacing`/`alignment` correctly omitted.