### PR TITLE
feat: make the plugin window resizable with a drag handle

### DIFF
--- a/packages/plugin/src/code.ts
+++ b/packages/plugin/src/code.ts
@@ -3,7 +3,34 @@ import { createPluginContextEvent, SELECTION_DETAIL_LIMIT } from '@figwright/sha
 import { dispatchSandboxMessage } from './dispatcher.js';
 import { createSandboxHandlers } from './handlers/registry.js';
 
-figma.showUI(__html__, { width: 292, height: 312, themeColors: true });
+// The window opens at this size and never shrinks below the floor (keeps the header/footer layout
+// intact). There's no max — Figma clamps the window to the canvas viewport.
+const UI_SIZE_KEY = 'ui-size';
+const DEFAULT_UI_SIZE = { width: 292, height: 312 };
+const MIN_UI_SIZE = { width: 280, height: 300 };
+
+const clampUiSize = (width: number, height: number): { width: number; height: number } => ({
+  width: Math.max(MIN_UI_SIZE.width, Math.round(width)),
+  height: Math.max(MIN_UI_SIZE.height, Math.round(height)),
+});
+
+figma.showUI(__html__, { ...DEFAULT_UI_SIZE, themeColors: true });
+
+// Restore the last user-chosen size. clientStorage is async, so the window opens at the default and
+// then snaps to the saved size; clamp defensively in case a stored value predates the current floor.
+void (async (): Promise<void> => {
+  try {
+    const saved: unknown = await figma.clientStorage.getAsync(UI_SIZE_KEY);
+    if (typeof saved !== 'object' || saved === null) return;
+    const { width, height } = saved as { width?: unknown; height?: unknown };
+    if (typeof width === 'number' && typeof height === 'number') {
+      const size = clampUiSize(width, height);
+      figma.ui.resize(size.width, size.height);
+    }
+  } catch {
+    // No saved size (or storage unavailable) — keep the default.
+  }
+})();
 
 // "Run in background" hides the panel (figma.ui.hide keeps this iframe + the relay socket alive, so
 // the connection survives). Running the plugin again from the Plugins menu re-reveals it.
@@ -46,6 +73,21 @@ figma.ui.onmessage = (raw: unknown) => {
     (raw as { type?: unknown }).type === 'ui:minimize'
   ) {
     figma.ui.hide();
+    return;
+  }
+  // UI control: live window resize from the drag handle. `persist` (sent on drag-release) saves the
+  // final size so the next open restores it. Handled locally, not routed to tool dispatch.
+  if (typeof raw === 'object' && raw !== null && (raw as { type?: unknown }).type === 'ui:resize') {
+    const { width, height, persist } = raw as {
+      width?: unknown;
+      height?: unknown;
+      persist?: unknown;
+    };
+    if (typeof width === 'number' && typeof height === 'number') {
+      const size = clampUiSize(width, height);
+      figma.ui.resize(size.width, size.height);
+      if (persist === true) figma.clientStorage.setAsync(UI_SIZE_KEY, size).catch(() => {});
+    }
     return;
   }
   void (async (): Promise<void> => {

--- a/packages/plugin/ui/App.vue
+++ b/packages/plugin/ui/App.vue
@@ -182,10 +182,45 @@ const runInBackground = (): void => {
     '*',
   );
 };
+
+// Drag-to-resize. The grip sits in the bottom-right corner, so the pointer's viewport coords during a
+// drag are (≈) the desired window width/height (the iframe origin is the window's top-left). The
+// sandbox does the authoritative clamp + figma.ui.resize; we clamp here too so the grip stops tracking
+// at the floor instead of running away. `persist` on release tells the sandbox to remember the size.
+const MIN_UI_WIDTH = 280;
+const MIN_UI_HEIGHT = 300;
+let resizing = false;
+
+const postResize = (clientX: number, clientY: number, persist: boolean): void => {
+  (globalThis as { parent?: { postMessage: (m: unknown, t: string) => void } }).parent?.postMessage(
+    {
+      pluginMessage: {
+        type: 'ui:resize',
+        width: Math.max(MIN_UI_WIDTH, Math.floor(clientX + 4)),
+        height: Math.max(MIN_UI_HEIGHT, Math.floor(clientY + 4)),
+        persist,
+      },
+    },
+    '*',
+  );
+};
+
+const onResizeStart = (e: PointerEvent): void => {
+  resizing = true;
+  (e.target as Element).setPointerCapture(e.pointerId);
+};
+const onResizeMove = (e: PointerEvent): void => {
+  if (resizing) postResize(e.clientX, e.clientY, false);
+};
+const onResizeEnd = (e: PointerEvent): void => {
+  if (!resizing) return;
+  resizing = false;
+  postResize(e.clientX, e.clientY, true);
+};
 </script>
 
 <template>
-  <main class="flex h-full flex-col bg-fig-bg text-fig-fg text-xs">
+  <main class="relative flex h-full flex-col bg-fig-bg text-fig-fg text-xs">
     <header class="flex items-center gap-2 border-b border-white/10 px-2.5 py-1.5">
       <span :class="['inline-block size-2 shrink-0 rounded-full', dotClass[state.status]]" />
       <span class="font-medium">{{ statusLabel[state.status] }}</span>
@@ -356,5 +391,26 @@ const runInBackground = (): void => {
         Run in background
       </button>
     </footer>
+
+    <!-- Drag handle — Figma has no built-in resize grip, so we render one in the bottom-right corner. -->
+    <div
+      class="absolute right-0 bottom-0 flex size-3.5 cursor-nwse-resize touch-none items-end justify-end p-0.5 text-fig-muted hover:text-fig-fg"
+      title="Drag to resize"
+      @pointerdown="onResizeStart"
+      @pointermove="onResizeMove"
+      @pointerup="onResizeEnd"
+      @pointercancel="onResizeEnd"
+    >
+      <svg
+        viewBox="0 0 10 10"
+        class="size-2.5"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.2"
+        stroke-linecap="round"
+      >
+        <path d="M10 4 4 10M10 7.5 7.5 10" />
+      </svg>
+    </div>
   </main>
 </template>


### PR DESCRIPTION
## What

The plugin window was a fixed 292×312. This adds a drag handle in the bottom-right corner so the whole UI can be resized, with the chosen size remembered across sessions.

## How

Figma has no built-in resize grip and the window only resizes if you call `figma.ui.resize` yourself, so:

- **UI** (`App.vue`): a small corner grip captures a pointer drag and posts `ui:resize` (width/height from the pointer's viewport coords; the iframe origin is the window's top-left) to the sandbox. It clamps to the floor too so the grip stops tracking instead of running away.
- **Sandbox** (`code.ts`): receives `ui:resize`, clamps to a **280×300** floor (keeps header/footer intact — Figma caps the max at the canvas viewport) and calls `figma.ui.resize` live.
- **Persistence**: drag-release carries `persist: true` → the final size is saved to `figma.clientStorage`. On open, the saved size is restored (async, so the window opens at the default then snaps). No settings UI.

Reuses the existing local `ui:*` control-message path (cf. `ui:minimize` → `figma.ui.hide`); no shared schema change.

## Verification

- Full gate green: `typecheck && lint && format:check && knip && build && test` — **690 tests** (no behavioural tests added — this is Figma-global wiring + DOM pointer handling, matching the existing untested `ui:minimize` precedent).
- **Live** (reload plugin to pick up the new build): grip appears in the corner, dragging resizes live, it stops at the 280×300 floor without breaking layout, and reopening the plugin restores the last size.