### PR TITLE
chore: add glama.json for Glama MCP registry listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["awdr74100"],
+  "name": "figwright",
+  "description": "Open-source, bidirectional Figma agent for MCP clients — a free alternative to Figma's Dev Mode MCP. Reads designs with high-fidelity grounding and writes back to the canvas: frames, text, auto-layout, styles, variables, and components. 92 tools, no API token, no paid Figma seat.",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds `glama.json` so Figwright can be listed (and author-verified) on the Glama MCP registry.

- `maintainers: [awdr74100]` — required field; enables claiming/verifying the server as author.
- `name` / `description` / `license` — optional metadata for the directory card.
- Tool list intentionally omitted: Glama scores from the live `tools/list`, so the authoritative source stays `ALL_TOOL_SPECS` in `registry.ts` (avoids a second, drift-prone source of truth).

Glama indexes from the default branch, so this needs to land on `main` before submitting via Add MCP Server.