### PR TITLE
docs: swap Node badge for Glama MCP server score badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Where Playwright drives the browser, Figwright drives Figma._
 [![npm](https://img.shields.io/npm/v/@figwright/mcp?logo=npm&color=cb3837)](https://www.npmjs.com/package/@figwright/mcp)
 [![CI](https://github.com/awdr74100/figwright/actions/workflows/ci.yml/badge.svg)](https://github.com/awdr74100/figwright/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![Node](https://img.shields.io/node/v/@figwright/mcp?logo=node.js)](https://nodejs.org)
+[![Glama MCP server](https://glama.ai/mcp/servers/awdr74100/figwright/badges/score.svg)](https://glama.ai/mcp/servers/awdr74100/figwright)
 
 </div>
 


### PR DESCRIPTION
Replaces the Node version badge with the Glama quality-score badge now that Figwright is listed on the Glama MCP registry.

Badge URL uses the `/badges/score.svg` endpoint (the score variant) — it auto-updates as Glama finishes scanning and assigns a score/tier.

Links to https://glama.ai/mcp/servers/awdr74100/figwright