### PR TITLE
chore: skip changelogen GitHub release prompt in pnpm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "postinstall": "node scripts/sync-skills.mjs",
-    "release": "pnpm -C packages/mcp exec changelogen --release --output ../../CHANGELOG.md",
+    "release": "pnpm -C packages/mcp exec changelogen --release --no-github --output ../../CHANGELOG.md",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",


### PR DESCRIPTION
## What

Add `--no-github` to the root `release` script so `pnpm release` only bumps the version, writes the changelog, commits, and tags locally.

## Why

`changelogen --release` opens a browser to **manually create a GitHub release by default**, but does **not** push the commit/tag unless `--push` is given. That asymmetry is a footgun (upstream unjs/changelogen#237): submitting the release form before the bump commit+tag are pushed creates the tag on the **wrong commit** — which is exactly how `v0.2.0` ended up tagged on a pre-bump commit and the npm publish failed.

The GitHub Release is already created by the `Release` workflow (`changelogen gh release`) **after** npm publish succeeds, so the local prompt is redundant and dangerous.

## Flow after this change

```
pnpm release            # bump + commit + annotated tag (no browser)
git push --follow-tags  # CI: npm publish (OIDC) + GitHub Release + plugin zip
```