### PR TITLE
feat(get_design_context): surface mixed-text segments + WRAP cross-axis spacing, omit no-op defaults

### DIFF
--- a/packages/plugin/src/handlers/get-design-context.ts
+++ b/packages/plugin/src/handlers/get-design-context.ts
@@ -7,6 +7,7 @@ import {
   type GetDesignContextResult,
   MIXED,
   type ResolvedToken,
+  simplifyPaint,
 } from '@figwright/shared';
 
 import type { SandboxToolHandler } from '../dispatcher.js';
@@ -24,37 +25,46 @@ const isDetailLevel = (value: unknown): value is DetailLevel =>
  * few values straight off the node and skip the full serializeFlatSync — which maps every
  * paint/effect and calls getStyledTextSegments on mixed TEXT, work that compact/minimal then
  * discard. serializeNode is a pure passthrough for id/name/type/visible/x/y/w/h and
- * enrichWithMixins never touches those, so the direct reads are byte-identical to projecting the
- * serialized form. The full branch is left exactly as before (one serializeFlatSync, every field
- * from flat), so no detail level does more work than it used to.
+ * enrichWithMixins never touches those, so the direct reads match projecting the serialized form.
+ * The full branch is one serializeFlatSync, every field from flat — so no detail level does more
+ * work than it used to. Across all branches, no-op defaults (visible=true / rotation=0 / opacity=1)
+ * are omitted.
  */
 const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
   if (detail === 'minimal') return { id: node.id, name: node.name, type: node.type };
   if (detail === 'compact') {
-    return {
+    const out: DesignContextNode = {
       id: node.id,
       name: node.name,
       type: node.type,
-      visible: node.visible,
       x: node.x,
       y: node.y,
       width: node.width,
       height: node.height,
     };
+    // Omit the no-op default (visible defaults to true); only a hidden node is worth a field.
+    if (node.visible === false) out.visible = false;
+    return out;
   }
 
   // full — unchanged from the original projection: serializeFlatSync once, every field from flat.
   const flat = serializeFlatSync(node);
   const out: DesignContextNode = { id: flat.id, name: flat.name, type: flat.type };
-  out.visible = flat.visible;
+  // No-op defaults are omitted (consistent with every other field here): absent visible = true,
+  // absent rotation = 0, absent opacity = 1, absent cornerRadius = 0 (unrounded). Strict equality so
+  // a 0.0001-rad rotation or a 0.99 opacity still surfaces; `mixed` corners (the MIXED symbol) are
+  // never 0 so they stay. The generated code is identical; the payload is just smaller. cornerRadius=0
+  // is the highest-volume of these — it sits on every frame/shape — so omitting it matters most.
+  if (flat.visible === false) out.visible = false;
   out.x = flat.x;
   out.y = flat.y;
   out.width = flat.width;
   out.height = flat.height;
 
-  if (flat.rotation !== undefined) out.rotation = flat.rotation;
-  if (flat.opacity !== undefined) out.opacity = flat.opacity;
-  if (flat.cornerRadius !== undefined) out.cornerRadius = flat.cornerRadius;
+  if (flat.rotation !== undefined && flat.rotation !== 0) out.rotation = flat.rotation;
+  if (flat.opacity !== undefined && flat.opacity !== 1) out.opacity = flat.opacity;
+  if (flat.cornerRadius !== undefined && flat.cornerRadius !== 0)
+    out.cornerRadius = flat.cornerRadius;
   if (flat.cornerRadii !== undefined) out.cornerRadii = flat.cornerRadii;
   if (flat.blendMode !== undefined) out.blendMode = flat.blendMode;
   if (flat.isMask !== undefined) out.isMask = flat.isMask;
@@ -107,6 +117,22 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
     out.textTruncation = flat.textTruncation;
   }
   if (typeof flat.maxLines === 'number') out.maxLines = flat.maxLines;
+  // Per-run styling of a mixed TEXT node — serializeFlatSync already computed this (only set when the
+  // node is genuinely mixed), get_design_context just used to drop it. Carry it so inline bold / links
+  // / coloured spans survive instead of collapsing to a single `mixed` marker. fills are simplified to
+  // hex like every other paint in this view.
+  if (flat.segments !== undefined) {
+    out.segments = flat.segments.map(s => ({
+      characters: s.characters,
+      start: s.start,
+      end: s.end,
+      fontName: s.fontName,
+      fontSize: s.fontSize,
+      fills: s.fills.map(simplifyPaint),
+      textDecoration: s.textDecoration,
+      textCase: s.textCase,
+    }));
+  }
   // Grounding fields (M3 P1): surface what serializeFlatSync already captured but
   // get_design_context used to drop. id→token-name resolution lands in P2 (top-level maps below);
   // globalVars dedup in P3.

--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -109,6 +109,8 @@ const serializeAutoLayout = (node: SceneNode): SerializedAutoLayout => {
     primaryAxisAlignItems: string;
     counterAxisAlignItems: string;
     layoutWrap?: string;
+    counterAxisSpacing?: number | null;
+    counterAxisAlignContent?: string;
     gridRowCount?: number;
     gridColumnCount?: number;
     gridRowGap?: number;
@@ -144,6 +146,17 @@ const serializeAutoLayout = (node: SceneNode): SerializedAutoLayout => {
     counterAxisAlignItems: n.counterAxisAlignItems,
   };
   if (typeof n.layoutWrap === 'string') out.layoutWrap = n.layoutWrap;
+  // WRAP cross-axis: the row gap (counterAxisSpacing, null when content-distributed) and the line
+  // distribution (counterAxisAlignContent). Only meaningful when wrapping; emit non-default values so
+  // a non-wrapping flex stays clean. Figma sets counterAxisSpacing to null under SPACE_BETWEEN.
+  if (n.layoutWrap === 'WRAP') {
+    if (typeof n.counterAxisSpacing === 'number' && n.counterAxisSpacing !== 0) {
+      out.counterAxisSpacing = n.counterAxisSpacing;
+    }
+    if (typeof n.counterAxisAlignContent === 'string' && n.counterAxisAlignContent !== 'AUTO') {
+      out.counterAxisAlignContent = n.counterAxisAlignContent;
+    }
+  }
   return out;
 };
 

--- a/packages/plugin/test/handlers/get-design-context.test.ts
+++ b/packages/plugin/test/handlers/get-design-context.test.ts
@@ -67,7 +67,9 @@ describe('get_design_context handler', () => {
     const compact = (await createGetDesignContextHandler(fakeFigma({ selection: [text] }))({
       detail: 'compact',
     })) as GetDesignContextResult;
-    expect(compact.nodes[0]).toMatchObject({ id: 't', visible: true, width: 10 });
+    expect(compact.nodes[0]).toMatchObject({ id: 't', x: 0, y: 0, width: 10, height: 10 });
+    // visible defaults to true → omitted as a no-op (only a hidden node carries the field)
+    expect(compact.nodes[0]?.visible).toBeUndefined();
     expect(compact.nodes[0]?.characters).toBeUndefined();
 
     const full = (await createGetDesignContextHandler(fakeFigma({ selection: [text] }))({
@@ -160,6 +162,94 @@ describe('get_design_context handler', () => {
       fontStyle: 'Regular',
       fontSize: 16,
     });
+  });
+
+  it('omits no-op layout defaults (visible=true / rotation=0 / opacity=1 / cornerRadius=0) but keeps real values', async () => {
+    const clean = node({ id: 'clean', rotation: 0, opacity: 1, cornerRadius: 0 }); // visible true by default
+    const cleanFull = (await createGetDesignContextHandler(fakeFigma({ selection: [clean] }))({
+      detail: 'full',
+    })) as GetDesignContextResult;
+    expect(cleanFull.nodes[0]?.visible).toBeUndefined();
+    expect(cleanFull.nodes[0]?.rotation).toBeUndefined();
+    expect(cleanFull.nodes[0]?.opacity).toBeUndefined();
+    expect(cleanFull.nodes[0]?.cornerRadius).toBeUndefined();
+
+    const real = node({ id: 'real', visible: false, rotation: 90, opacity: 0.5, cornerRadius: 8 });
+    const realFull = (await createGetDesignContextHandler(fakeFigma({ selection: [real] }))({
+      detail: 'full',
+    })) as GetDesignContextResult;
+    expect(realFull.nodes[0]).toMatchObject({
+      visible: false,
+      rotation: 90,
+      opacity: 0.5,
+      cornerRadius: 8,
+    });
+  });
+
+  it('surfaces per-run segments for a mixed-style TEXT node (fills simplified to hex), full detail only', async () => {
+    const mixed = node({
+      id: 'mt',
+      type: 'TEXT',
+      characters: 'Terms and Privacy Policy',
+      fontSize: Symbol('mixed'), // non-number → the serializer marks the node mixed
+      fontName: { family: 'Inter', style: 'Regular' },
+      getStyledTextSegments: () => [
+        {
+          characters: 'Terms and ',
+          start: 0,
+          end: 10,
+          fontName: { family: 'Inter', style: 'Regular' },
+          fontSize: 14,
+          fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 }, visible: true, opacity: 1 }],
+          textDecoration: 'NONE',
+          textCase: 'ORIGINAL',
+        },
+        {
+          characters: 'Privacy Policy',
+          start: 10,
+          end: 24,
+          fontName: { family: 'Inter', style: 'Bold' },
+          fontSize: 14,
+          fills: [{ type: 'SOLID', color: { r: 0, g: 0.4, b: 1 }, visible: true, opacity: 1 }],
+          textDecoration: 'UNDERLINE',
+          textCase: 'ORIGINAL',
+        },
+      ],
+    });
+
+    const full = (await createGetDesignContextHandler(fakeFigma({ selection: [mixed] }))({
+      detail: 'full',
+    })) as GetDesignContextResult;
+    // The link span survives: its own characters, Bold style, underline, and blue colour as hex —
+    // instead of the whole string collapsing to one `mixed` marker with no way to locate the link.
+    expect(full.nodes[0]?.segments).toEqual([
+      {
+        characters: 'Terms and ',
+        start: 0,
+        end: 10,
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', color: '#000000' }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+      },
+      {
+        characters: 'Privacy Policy',
+        start: 10,
+        end: 24,
+        fontName: { family: 'Inter', style: 'Bold' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', color: '#0066FF' }],
+        textDecoration: 'UNDERLINE',
+        textCase: 'ORIGINAL',
+      },
+    ]);
+
+    // not surfaced below full (the hot exploration default stays lean)
+    const compact = (await createGetDesignContextHandler(fakeFigma({ selection: [mixed] }))({
+      detail: 'compact',
+    })) as GetDesignContextResult;
+    expect(compact.nodes[0]?.segments).toBeUndefined();
   });
 
   it('uses the selection, and throws when nothing is selected', async () => {

--- a/packages/plugin/test/serializer.test.ts
+++ b/packages/plugin/test/serializer.test.ts
@@ -386,6 +386,56 @@ describe('serializeFlat — strokes / effects / auto layout', () => {
     });
   });
 
+  it('serializes WRAP cross-axis spacing + alignment (non-default only), skips them when not wrapping', () => {
+    const base = {
+      type: 'FRAME',
+      layoutMode: 'HORIZONTAL',
+      paddingTop: 0,
+      paddingRight: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      itemSpacing: 8,
+      primaryAxisAlignItems: 'MIN',
+      counterAxisAlignItems: 'MIN',
+    } as const;
+
+    // WRAP with a real row gap → counterAxisSpacing surfaces; AUTO alignment is the default → omitted.
+    const wrapped = serializeFlatSync(
+      fake({
+        ...base,
+        layoutWrap: 'WRAP',
+        counterAxisSpacing: 16,
+        counterAxisAlignContent: 'AUTO',
+      }),
+    );
+    expect(wrapped.layout?.counterAxisSpacing).toBe(16);
+    expect(wrapped.layout?.counterAxisAlignContent).toBeUndefined();
+
+    // SPACE_BETWEEN distributes the rows → Figma reports counterAxisSpacing null; alignment surfaces.
+    const distributed = serializeFlatSync(
+      fake({
+        ...base,
+        layoutWrap: 'WRAP',
+        counterAxisSpacing: null,
+        counterAxisAlignContent: 'SPACE_BETWEEN',
+      }),
+    );
+    expect(distributed.layout?.counterAxisSpacing).toBeUndefined();
+    expect(distributed.layout?.counterAxisAlignContent).toBe('SPACE_BETWEEN');
+
+    // A non-wrapping flex never carries them, even if the underlying props are set.
+    const noWrap = serializeFlatSync(
+      fake({
+        ...base,
+        layoutWrap: 'NO_WRAP',
+        counterAxisSpacing: 16,
+        counterAxisAlignContent: 'SPACE_BETWEEN',
+      }),
+    );
+    expect(noWrap.layout?.counterAxisSpacing).toBeUndefined();
+    expect(noWrap.layout?.counterAxisAlignContent).toBeUndefined();
+  });
+
   it('serializes GRID layoutMode with counts / gaps / track sizes, no H/V-only fields', () => {
     const out = serializeFlatSync(
       fake({

--- a/packages/shared/src/design-context-dedupe.ts
+++ b/packages/shared/src/design-context-dedupe.ts
@@ -53,7 +53,7 @@ export const toHex = (c: SerializedColor, alpha?: number): string => {
   return withAlpha.toUpperCase();
 };
 
-interface SimplifiedPaint {
+export interface SimplifiedPaint {
   type: string;
   color?: string;
   gradientStops?: { position: number; color: string }[];
@@ -71,7 +71,7 @@ interface SimplifiedPaint {
 }
 
 /** Convert a serialized paint to a structured, codegen-friendly form (SOLID → hex). */
-const simplifyPaint = (paint: SerializedPaint): SimplifiedPaint => {
+export const simplifyPaint = (paint: SerializedPaint): SimplifiedPaint => {
   const out: SimplifiedPaint = { type: paint.type };
   if (paint.type === 'SOLID') {
     out.color = toHex(paint.color, paint.opacity);

--- a/packages/shared/src/design-context.ts
+++ b/packages/shared/src/design-context.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import type { SimplifiedPaint } from './design-context-dedupe.js';
 import {
   MIXED,
   SerializedAutoLayoutSchema,
@@ -31,10 +32,32 @@ export const DETAIL_LEVELS = ['minimal', 'compact', 'full'] as const;
 export type DetailLevel = (typeof DETAIL_LEVELS)[number];
 
 /**
+ * One run of uniform styling inside a mixed-style TEXT node (full detail only). Without this a node
+ * with inline variation reads as `fontSize: "mixed"` / `textDecoration: "mixed"` with no way to
+ * tell _which_ characters are the bold word, the underlined link, the coloured span — so codegen
+ * flattens the whole string to one style (the classic "Terms and Privacy Policy" link with no
+ * underline). `fills` are simplified to hex like every other paint in this view; `start`/`end` are
+ * char offsets into the node's `characters`.
+ */
+export interface DesignContextTextSegment {
+  characters: string;
+  start: number;
+  end: number;
+  fontName: z.infer<typeof SerializedFontNameSchema>;
+  fontSize: number;
+  fills: readonly SimplifiedPaint[];
+  textDecoration: string;
+  textCase: string;
+}
+
+/**
  * Token-efficient, depth-limited tree node for LLM exploration. Fields populate by detail level:
  *
+ * No-op defaults are omitted at every level (absent visible = true, rotation = 0, opacity = 1,
+ * cornerRadius = 0).
+ *
  * - Minimal: id / name / type
- * - Compact: + visible / x / y / width / height
+ * - Compact: + x / y / width / height (+ visible only when hidden)
  * - Full: + rotation / opacity / cornerRadius / fills / text mixin `truncated` marks children dropped
  *   at the depth limit; `deduped` marks an instance whose main component was already expanded (its
  *   children are omitted), with `mainComponentId` for cross-ref. A deduped instance keeps its own
@@ -117,6 +140,10 @@ export interface DesignContextNode {
   textAlignVertical?: string;
   textTruncation?: string;
   maxLines?: number | null;
+  // Per-run styling of a *mixed* TEXT node — the only way to recover which characters carry the
+  // inline bold / link / coloured span that the node-level `mixed` markers flag but can't locate.
+  // Present only when the node is actually mixed (so uniform text stays clean).
+  segments?: readonly DesignContextTextSegment[];
   styleIds?: SerializedStyleIds;
   boundVariables?: Readonly<Record<string, readonly string[]>>;
   componentProperties?: Readonly<Record<string, SerializedComponentProperty>>;
@@ -206,6 +233,21 @@ export const DesignContextNodeSchema = z.lazy(() =>
     textAlignVertical: z.string().optional(),
     textTruncation: z.string().optional(),
     maxLines: z.number().nullable().optional(),
+    // Simplified paints are opaque here (hex lives in `color`), mirroring globalVars' z.unknown().
+    segments: z
+      .array(
+        z.object({
+          characters: z.string(),
+          start: z.number(),
+          end: z.number(),
+          fontName: SerializedFontNameSchema,
+          fontSize: z.number(),
+          fills: z.array(z.unknown()),
+          textDecoration: z.string(),
+          textCase: z.string(),
+        }),
+      )
+      .optional(),
     styleIds: SerializedStyleIdsSchema.optional(),
     boundVariables: z.record(z.string(), z.array(z.string())).optional(),
     componentProperties: z.record(z.string(), SerializedComponentPropertySchema).optional(),

--- a/packages/shared/src/serialized-node.ts
+++ b/packages/shared/src/serialized-node.ts
@@ -140,6 +140,12 @@ export const SerializedAutoLayoutSchema = z.object({
   primaryAxisAlignItems: z.string().optional(),
   counterAxisAlignItems: z.string().optional(),
   layoutWrap: z.string().optional(),
+  // WRAP only: gap between wrapped lines (cross-axis) + how those lines distribute. Without these a
+  // wrapping flex (tag cloud / chip group / gallery) keeps its primary `itemSpacing` but loses the
+  // row gap entirely → codegen guesses the vertical spacing. Omitted unless layoutWrap is WRAP and
+  // the value is non-default.
+  counterAxisSpacing: z.number().optional(),
+  counterAxisAlignContent: z.string().optional(),
   // GRID only
   gridRowCount: z.number().optional(),
   gridColumnCount: z.number().optional(),

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -39,6 +39,13 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   (`CENTER`/`RIGHT`/`JUSTIFIED` → `text-center`/`text-right`/`text-justify`; absent = left/top) and
   `textTruncation: 'ENDING'` + `maxLines` (→ `line-clamp-N` / `truncate`). Each is omitted when it's
   the no-op default, so anything present is real intent — translate it, don't drop it.
+  - **Mixed (inline) styling → read `segments`.** When a value reads `"mixed"` (e.g. `fontSize` or
+    `textDecoration`), the node carries `segments` — each a run of uniform styling with its own
+    `characters`, `fontName`, `fontSize`, `fills` (hex), `textDecoration`, `textCase` over offsets
+    `start`/`end`. These describe runs **within** the node's `characters` (not extra text) — emit each
+    as its own span: the underlined/coloured `Privacy Policy` inside a sentence, the bold word in a
+    label, the smaller `/mo` after a price. Dropping them flattens the whole string to one style (a
+    link with no underline, a price with no emphasis) — the classic mixed-text miss.
 - **Per-side borders.** When `strokeWeight` is `mixed`, the node carries `strokeWeights`
   `{ top, right, bottom, left }` — emit only the non-zero sides (`border-t` / `border-b` / …),
   **never a uniform `border`**. Collapsing a per-side stroke into a full border turns a table row
@@ -83,7 +90,12 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   a `layout` object with the _exact_ spacing; don't reverse-engineer padding/gap/justify from child
   `x/y/w/h`. `mode` `HORIZONTAL`/`VERTICAL` → `flex-row`/`flex-col`; `padding*` → `p-*`; for H/V
   `itemSpacing` → `gap`, `primaryAxisAlignItems`/`counterAxisAlignItems` → `justify-*`/`items-*`
-  (`SPACE_BETWEEN` → `justify-between`). `mode: 'GRID'` → `display:grid` with
+  (`SPACE_BETWEEN` → `justify-between`). When `layoutWrap: 'WRAP'` (a tag cloud / chip group /
+  gallery) the frame also carries the cross-axis row spacing: `counterAxisSpacing` is the gap
+  **between wrapped rows** (→ `flex-wrap` + the row part of `gap-x/gap-y`; with a single `gap` only
+  when it equals `itemSpacing`), and `counterAxisAlignContent: 'SPACE_BETWEEN'` distributes the rows
+  (`align-content: space-between`, and `counterAxisSpacing` is then absent). Don't collapse a wrapping
+  flex to a single-axis `gap` — the row gap is its own value. `mode: 'GRID'` → `display:grid` with
   `gridRowCount`/`gridColumnCount` → `grid-template-rows`/`grid-template-columns: repeat(N, 1fr)`,
   `gridRowGap`/`gridColumnGap` → `gap`, and optional `gridRowSizes`/`gridColumnSizes` tracks
   (`FIXED`→px, `FLEX`→fr) — **emit a real CSS grid, don't flatten it to stacked flex**. A grid child


### PR DESCRIPTION
Three **equal-or-better** improvements to the highest-frequency read tool — the codegen grounding source of truth. Each is strictly faithful-or-smaller; no real design's generated code regresses.

## What & why

- **Mixed-style TEXT now carries `segments`** — per-run `characters` + `fontName` + `fontSize` + `fills` (hex) + `textDecoration` + `textCase`. Previously a node with inline variation read as `fontSize: "mixed"` / `textDecoration: "mixed"` with no way to locate the bold word / underlined link / coloured span, so codegen flattened it to a single style (the classic "Terms and Privacy Policy with no underline" miss). The serializer already computed these (the long-proven `get_node` path) — full detail just dropped them; now it copies them with paints simplified to hex like everything else in this view. **Zero extra compute at full detail.**

- **Auto-layout now captures WRAP cross-axis geometry** — `counterAxisSpacing` (the gap between wrapped rows) and `counterAxisAlignContent`. A wrapping flex (tag cloud / chip group) kept its primary `itemSpacing` but lost the row gap entirely, forcing a guess. Emitted only when `layoutWrap === 'WRAP'` and non-default (Figma reports `counterAxisSpacing: null` under `SPACE_BETWEEN`, so it's omitted there).

- **Omit no-op defaults consistently** — absent `visible` = true, `rotation` = 0, `opacity` = 1, `cornerRadius` = 0. Strict equality (so a 0.99 opacity / 0.0001-rad rotation still surfaces; `mixed` corners are a symbol, never 0). Identical generated code, smaller payload; `cornerRadius = 0` is the highest-volume of these — every frame/shape carries it.

A candidate to drop in-flow children's `x/y` was **rejected**: under WRAP it's currently the only row-gap signal, so it would regress — which is what surfaced the WRAP gap above.

## Verification

- Full gate green: typecheck / lint / format:check / knip / build / test (**693 tests**), incl. new unit tests for all three (segments with hex fills, WRAP spacing across three cases, no-op omission).
- **Live-verified** on real designs: a genuine consent-label link (Bold + underline + coloured) recovered exactly via `segments`; no-op omission confirmed clean across several frames. WRAP is unit-test-only (no wrapping flex existed in the test designs, and the write tools can't synthesize a non-zero `counterAxisSpacing`).

## Files

`shared/serialized-node.ts` (WRAP schema), `shared/design-context.ts` (`segments` type + schema), `shared/design-context-dedupe.ts` (export `simplifyPaint`), `plugin/serializer.ts` (WRAP emit), `plugin/handlers/get-design-context.ts` (segments copy + no-op omission), tests, and `skills/figma-codegen/references/grounding.md` (how to read segments + WRAP row gap).