### PR TITLE
docs(tools): enrich low-scoring tool descriptions for Glama TDQS

### DIFF
--- a/packages/mcp/src/tools/bind-variable-to-node.ts
+++ b/packages/mcp/src/tools/bind-variable-to-node.ts
@@ -7,9 +7,11 @@ export const BIND_VARIABLE_TO_NODE_TOOL_NAME = 'bind_variable_to_node';
 export const bindVariableToNodeTool: ToolSpec = {
   name: BIND_VARIABLE_TO_NODE_TOOL_NAME,
   description:
-    'Bind a variable to a node field (e.g. width, height, characters, itemSpacing, ' +
-    'topLeftRadius, or cornerRadius to bind all four corners at once), or unbind by passing ' +
-    'variableId: null. The variable type must match the field. Returns { ok, nodeId }.',
+    'Bind a variable to a node field (e.g. width, height, characters, itemSpacing, topLeftRadius, ' +
+    'or cornerRadius to bind all four corners at once), or unbind by passing variableId: null. The ' +
+    "variable's resolvedType must match the field's type. To bind a fill or stroke color use " +
+    'bind_variable_to_paint instead; get bindable variable ids from get_variable_defs. Returns ' +
+    '{ ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('Node to bind on'),
     field: z.string().describe('Bindable field name, e.g. "width"'),

--- a/packages/mcp/src/tools/clone-node.ts
+++ b/packages/mcp/src/tools/clone-node.ts
@@ -7,7 +7,10 @@ export const CLONE_NODE_TOOL_NAME = 'clone_node';
 export const cloneNodeTool: ToolSpec = {
   name: CLONE_NODE_TOOL_NAME,
   description:
-    'Duplicate a node next to the original (same parent). Returns { ok, nodeId, name, type } for the copy.',
+    'Duplicate a node — including its full subtree — and place the copy as a sibling right after ' +
+    'the original under the same parent. Cloning a component instance keeps it an instance; to make ' +
+    'a fresh instance of a component use create_instance instead. Returns ' +
+    '{ ok, nodeId, name, type } for the copy.',
   inputShape: {
     nodeId: z.string().describe('Node id to clone'),
   },

--- a/packages/mcp/src/tools/create-ellipse.ts
+++ b/packages/mcp/src/tools/create-ellipse.ts
@@ -7,15 +7,16 @@ export const CREATE_ELLIPSE_TOOL_NAME = 'create_ellipse';
 export const createEllipseTool: ToolSpec = {
   name: CREATE_ELLIPSE_TOOL_NAME,
   description:
-    'Create an ellipse, optionally sized / named / positioned and placed under a parent (default: ' +
-    'current page). Returns { ok, nodeId, name, type }.',
+    'Create an ellipse (a circle when width equals height), optionally sized/named/positioned under ' +
+    'a parent (default: current page). To turn it into a pie, arc, or ring afterwards use set_arc. ' +
+    'Returns { ok, nodeId, name, type }.',
   inputShape: {
     parentId: z.string().optional().describe('Parent node id (default: current page)'),
-    name: z.string().optional(),
-    x: z.number().optional(),
-    y: z.number().optional(),
-    width: z.number().optional(),
-    height: z.number().optional(),
+    name: z.string().optional().describe('Layer name'),
+    x: z.number().optional().describe('X position in the parent'),
+    y: z.number().optional().describe('Y position in the parent'),
+    width: z.number().optional().describe('Width in px'),
+    height: z.number().optional().describe('Height in px'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/create-frame.ts
+++ b/packages/mcp/src/tools/create-frame.ts
@@ -7,8 +7,10 @@ export const CREATE_FRAME_TOOL_NAME = 'create_frame';
 export const createFrameTool: ToolSpec = {
   name: CREATE_FRAME_TOOL_NAME,
   description:
-    'Create a frame, optionally sized/positioned and appended to a parent (else the current page). ' +
-    'Returns { ok, nodeId, name, type }.',
+    'Create a frame — the primary container for UI and the only node that hosts auto-layout — ' +
+    'optionally sized/positioned and appended to a parent (default: current page). Enable ' +
+    'auto-layout afterwards with set_auto_layout; for a canvas-level grouping container use ' +
+    'create_section instead. Returns { ok, nodeId, name, type }.',
   inputShape: {
     parentId: z
       .string()

--- a/packages/mcp/src/tools/create-grid-style.ts
+++ b/packages/mcp/src/tools/create-grid-style.ts
@@ -7,8 +7,9 @@ export const CREATE_GRID_STYLE_TOOL_NAME = 'create_grid_style';
 export const createGridStyleTool: ToolSpec = {
   name: CREATE_GRID_STYLE_TOOL_NAME,
   description:
-    'Create a local layout-grid style. GRID is uniform (sectionSize); ROWS / COLUMNS carry ' +
-    'count + gutterSize + alignment. Returns { ok, styleId, name }.',
+    'Create a reusable local layout-grid style for aligning content. Each grid pattern is GRID ' +
+    '(uniform squares via sectionSize) or ROWS / COLUMNS (count + gutterSize + alignment). Apply it ' +
+    'to frames with apply_style_to_node. Returns { ok, styleId, name }.',
   inputShape: {
     name: z.string().describe('Style name, e.g. "Layout/8pt"'),
     grids: z.array(

--- a/packages/mcp/src/tools/create-paint-style.ts
+++ b/packages/mcp/src/tools/create-paint-style.ts
@@ -8,8 +8,9 @@ export const CREATE_PAINT_STYLE_TOOL_NAME = 'create_paint_style';
 export const createPaintStyleTool: ToolSpec = {
   name: CREATE_PAINT_STYLE_TOOL_NAME,
   description:
-    'Create a local paint (color) style. SOLID or gradient paints (same shape as set_fills). ' +
-    'Use a/b/c slashes in the name for folder grouping. Returns { ok, styleId, name }.',
+    'Create a reusable local paint (color) style from SOLID or gradient paints (same shape as ' +
+    'set_fills); use slashes in the name for folder grouping. Apply it to nodes with ' +
+    'apply_style_to_node, or edit it later with update_paint_style. Returns { ok, styleId, name }.',
   inputShape: {
     name: z.string().describe('Style name, e.g. "Brand/Primary"'),
     paints: z.array(paintItemSchema).describe('Paints'),

--- a/packages/mcp/src/tools/create-rectangle.ts
+++ b/packages/mcp/src/tools/create-rectangle.ts
@@ -7,15 +7,17 @@ export const CREATE_RECTANGLE_TOOL_NAME = 'create_rectangle';
 export const createRectangleTool: ToolSpec = {
   name: CREATE_RECTANGLE_TOOL_NAME,
   description:
-    'Create a rectangle, optionally sized/positioned and appended to a parent (else the current page). ' +
-    'Returns { ok, nodeId, name, type }.',
+    'Create a rectangle, optionally sized/positioned and appended to a parent (default: current ' +
+    'page). Useful for solid shapes, dividers, and color blocks; for a container that holds other ' +
+    'layers use create_frame, and for placed bitmaps use import_image. Returns ' +
+    '{ ok, nodeId, name, type }.',
   inputShape: {
     parentId: z.string().optional().describe('Container node id; omit for current page'),
-    name: z.string().optional(),
-    x: z.number().optional(),
-    y: z.number().optional(),
-    width: z.number().optional(),
-    height: z.number().optional(),
+    name: z.string().optional().describe('Layer name'),
+    x: z.number().optional().describe('X position in the parent'),
+    y: z.number().optional().describe('Y position in the parent'),
+    width: z.number().optional().describe('Width in px'),
+    height: z.number().optional().describe('Height in px'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/create-section.ts
+++ b/packages/mcp/src/tools/create-section.ts
@@ -7,15 +7,17 @@ export const CREATE_SECTION_TOOL_NAME = 'create_section';
 export const createSectionTool: ToolSpec = {
   name: CREATE_SECTION_TOOL_NAME,
   description:
-    'Create a section (a canvas-level grouping container), optionally sized / named / positioned. ' +
-    'Sections live on a page or inside another section. Returns { ok, nodeId, name, type }.',
+    'Create a section: a canvas-level container for grouping and labelling regions of a page (e.g. ' +
+    'flows or screen sets). Sections sit on a page or nest inside another section, but not inside a ' +
+    'frame; for a UI container or auto-layout use create_frame instead. Returns ' +
+    '{ ok, nodeId, name, type }.',
   inputShape: {
-    parentId: z.string().optional().describe('Parent node id (default: current page)'),
-    name: z.string().optional(),
-    x: z.number().optional(),
-    y: z.number().optional(),
-    width: z.number().optional(),
-    height: z.number().optional(),
+    parentId: z.string().optional().describe('Parent page or section id (default: current page)'),
+    name: z.string().optional().describe('Section name'),
+    x: z.number().optional().describe('X position in the parent'),
+    y: z.number().optional().describe('Y position in the parent'),
+    width: z.number().optional().describe('Width in px'),
+    height: z.number().optional().describe('Height in px'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/create-text-style.ts
+++ b/packages/mcp/src/tools/create-text-style.ts
@@ -7,9 +7,10 @@ export const CREATE_TEXT_STYLE_TOOL_NAME = 'create_text_style';
 export const createTextStyleTool: ToolSpec = {
   name: CREATE_TEXT_STYLE_TOOL_NAME,
   description:
-    'Create a local text style. The font is loaded before assignment. lineHeight unit is ' +
-    'AUTO / PIXELS / PERCENT (AUTO omits value); letterSpacing unit is PIXELS / PERCENT. ' +
-    'Returns { ok, styleId, name }.',
+    'Create a reusable local text style (a typography token) that can be applied to TEXT nodes with ' +
+    'apply_style_to_node. The font is loaded before assignment. lineHeight unit is AUTO / PIXELS / ' +
+    'PERCENT (AUTO omits value); letterSpacing unit is PIXELS / PERCENT. For one-off formatting of a ' +
+    'single node use set_text_properties instead. Returns { ok, styleId, name }.',
   inputShape: {
     name: z.string().describe('Style name, e.g. "Heading/H1"'),
     fontName: z.object({ family: z.string(), style: z.string() }).optional(),

--- a/packages/mcp/src/tools/create-text.ts
+++ b/packages/mcp/src/tools/create-text.ts
@@ -7,14 +7,16 @@ export const CREATE_TEXT_TOOL_NAME = 'create_text';
 export const createTextTool: ToolSpec = {
   name: CREATE_TEXT_TOOL_NAME,
   description:
-    'Create a TEXT node with the given characters (default font loaded automatically), optionally ' +
-    'sized/positioned and appended to a parent (else the current page). Returns { ok, nodeId, name, type }.',
+    'Create a new TEXT node with the given characters (default font loaded automatically), ' +
+    'optionally sized/positioned and appended to a parent (default: current page). To change the ' +
+    'text of an existing node use set_text; for font, size, or color use set_text_properties. ' +
+    'Returns { ok, nodeId, name, type }.',
   inputShape: {
     characters: z.string().describe('Text content'),
     parentId: z.string().optional().describe('Container node id; omit for current page'),
-    x: z.number().optional(),
-    y: z.number().optional(),
-    fontSize: z.number().optional(),
+    x: z.number().optional().describe('X position in the parent'),
+    y: z.number().optional().describe('Y position in the parent'),
+    fontSize: z.number().optional().describe('Font size in px'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/create-variable.ts
+++ b/packages/mcp/src/tools/create-variable.ts
@@ -7,12 +7,13 @@ export const CREATE_VARIABLE_TOOL_NAME = 'create_variable';
 export const createVariableTool: ToolSpec = {
   name: CREATE_VARIABLE_TOOL_NAME,
   description:
-    'Create a variable in a collection. resolvedType is BOOLEAN / FLOAT / STRING / COLOR. ' +
-    'Use set_variable_value to populate per-mode values. Returns { ok, variableId, name }.',
+    'Create a variable in a collection with resolvedType BOOLEAN / FLOAT / STRING / COLOR. The ' +
+    'variable starts empty — set per-mode values with set_variable_value, then attach it with ' +
+    'bind_variable_to_node or bind_variable_to_paint. Returns { ok, variableId, name }.',
   inputShape: {
     name: z.string().describe('Variable name, e.g. "color/primary"'),
     collectionId: z.string().describe('Variable collection id'),
-    resolvedType: z.enum(['BOOLEAN', 'FLOAT', 'STRING', 'COLOR']),
+    resolvedType: z.enum(['BOOLEAN', 'FLOAT', 'STRING', 'COLOR']).describe('Variable data type'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/delete-nodes.ts
+++ b/packages/mcp/src/tools/delete-nodes.ts
@@ -7,7 +7,9 @@ export const DELETE_NODES_TOOL_NAME = 'delete_nodes';
 export const deleteNodesTool: ToolSpec = {
   name: DELETE_NODES_TOOL_NAME,
   description:
-    'Delete nodes by id. Missing / non-removable nodes are skipped. Returns { ok, affected } — the ids actually removed.',
+    'Permanently delete nodes by id; missing or non-removable nodes are skipped. To hide nodes ' +
+    'reversibly instead of deleting them, use set_visible(false). Returns { ok, affected } — the ' +
+    'ids actually removed.',
   inputShape: {
     nodeIds: z.array(z.string()).describe('Node ids to delete'),
   },

--- a/packages/mcp/src/tools/delete-variable-collection.ts
+++ b/packages/mcp/src/tools/delete-variable-collection.ts
@@ -7,8 +7,9 @@ export const DELETE_VARIABLE_COLLECTION_TOOL_NAME = 'delete_variable_collection'
 export const deleteVariableCollectionTool: ToolSpec = {
   name: DELETE_VARIABLE_COLLECTION_TOOL_NAME,
   description:
-    'Delete a variable collection by id, removing the collection and every variable in it ' +
-    '(bindings to those variables revert to raw values). Returns { ok, collectionId, name }.',
+    'Delete a variable collection by id, removing the collection and every variable and mode in ' +
+    'it; bindings to those variables revert to their raw values. To delete a single variable ' +
+    'instead, use delete_variable. Returns { ok, collectionId, name }.',
   inputShape: {
     collectionId: z.string().describe('Variable collection id to delete'),
   },

--- a/packages/mcp/src/tools/delete-variable.ts
+++ b/packages/mcp/src/tools/delete-variable.ts
@@ -6,7 +6,10 @@ export const DELETE_VARIABLE_TOOL_NAME = 'delete_variable';
 
 export const deleteVariableTool: ToolSpec = {
   name: DELETE_VARIABLE_TOOL_NAME,
-  description: 'Delete a variable by id. Returns { ok, variableId, name }.',
+  description:
+    'Delete a single variable by id; any node or paint bound to it reverts to its raw value. To ' +
+    'delete an entire collection and all its variables use delete_variable_collection. Returns ' +
+    '{ ok, variableId, name }.',
   inputShape: {
     variableId: z.string().describe('Variable id to delete'),
   },

--- a/packages/mcp/src/tools/detach-instance.ts
+++ b/packages/mcp/src/tools/detach-instance.ts
@@ -7,8 +7,10 @@ export const DETACH_INSTANCE_TOOL_NAME = 'detach_instance';
 export const detachInstanceTool: ToolSpec = {
   name: DETACH_INSTANCE_TOOL_NAME,
   description:
-    'Detach an instance into a plain frame (breaks the component link). ' +
-    'Returns { ok, nodeId, name, type } for the resulting frame.',
+    'Detach a component instance into a plain frame, permanently breaking its link to the main ' +
+    'component; the frame keeps its current appearance and its layers become directly editable. To ' +
+    'switch an instance to a different component instead of detaching, use swap_component. Returns ' +
+    '{ ok, nodeId, name, type } for the resulting frame.',
   inputShape: {
     instanceId: z.string().describe('Instance node id to detach'),
   },

--- a/packages/mcp/src/tools/export-pdf.ts
+++ b/packages/mcp/src/tools/export-pdf.ts
@@ -21,12 +21,12 @@ const inputShape = {
 export const exportPdfTool: ToolSpec = {
   name: EXPORT_PDF_TOOL_NAME,
   description:
-    'Export a node (or the current page) to a single PDF file on disk: { nodeId, path, empty? }. ' +
-    "Renders the target as one PDF page — Figma's plugin API exports one page per node and cannot " +
-    'paginate a page into one-frame-per-page or combine multiple nodes into a multi-page file. Pass a ' +
-    'frame / section id for a vector PDF of that node; omit nodeId for the current page (large pages ' +
-    'can be slow). path is null if the target is missing or not exportable; empty:true means it ' +
-    'rendered nothing (blank PDF).',
+    "Export a node (or the current page) to a single-page vector PDF file on disk. Figma's plugin " +
+    'API renders one PDF page per node and cannot paginate a page into one-frame-per-page or merge ' +
+    'multiple nodes into a multi-page file. Pass a frame / section / component id for a vector PDF ' +
+    'of that node; omit nodeId for the current page (large pages can be slow). For raster output ' +
+    '(PNG/JPG) use save_screenshots instead. Returns { nodeId, path, empty? }; path is null if the ' +
+    'target is missing or not exportable, and empty:true means it rendered a blank PDF.',
   inputShape,
   kind: 'local',
 };

--- a/packages/mcp/src/tools/lock-nodes.ts
+++ b/packages/mcp/src/tools/lock-nodes.ts
@@ -6,7 +6,11 @@ export const LOCK_NODES_TOOL_NAME = 'lock_nodes';
 
 export const lockNodesTool: ToolSpec = {
   name: LOCK_NODES_TOOL_NAME,
-  description: 'Lock nodes (prevent selection/editing on canvas). Returns { ok, affected }.',
+  description:
+    "Lock nodes so they can't be selected or edited on the canvas (e.g. backgrounds); locking a " +
+    'parent also locks its descendants. Locked nodes still render and export — this only affects ' +
+    'canvas interaction and is reversed by unlock_nodes. Returns { ok, affected } with the ids ' +
+    'actually locked.',
   inputShape: {
     nodeIds: z.array(z.string()).describe('Node ids to lock'),
   },

--- a/packages/mcp/src/tools/remove-reactions.ts
+++ b/packages/mcp/src/tools/remove-reactions.ts
@@ -6,7 +6,10 @@ export const REMOVE_REACTIONS_TOOL_NAME = 'remove_reactions';
 
 export const removeReactionsTool: ToolSpec = {
   name: REMOVE_REACTIONS_TOOL_NAME,
-  description: 'Clear all prototype reactions from a node. Returns { ok, nodeId }.',
+  description:
+    'Clear every prototype reaction from a node (equivalent to set_reactions with an empty array). ' +
+    'Use this to strip interactivity; to replace reactions with new ones use set_reactions. Returns ' +
+    '{ ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('Node to clear reactions from'),
   },

--- a/packages/mcp/src/tools/rename-node.ts
+++ b/packages/mcp/src/tools/rename-node.ts
@@ -6,7 +6,10 @@ export const RENAME_NODE_TOOL_NAME = 'rename_node';
 
 export const renameNodeTool: ToolSpec = {
   name: RENAME_NODE_TOOL_NAME,
-  description: 'Rename a node. Returns { ok, nodeId }.',
+  description:
+    "Rename a single canvas node's layer name; does not affect a component's name elsewhere or its " +
+    'instances. To rename a document page use rename_page; to rename many nodes by pattern use ' +
+    'batch_rename_nodes. Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('Figma node id'),
     name: z.string().describe('New layer name'),

--- a/packages/mcp/src/tools/rename-page.ts
+++ b/packages/mcp/src/tools/rename-page.ts
@@ -6,7 +6,10 @@ export const RENAME_PAGE_TOOL_NAME = 'rename_page';
 
 export const renamePageTool: ToolSpec = {
   name: RENAME_PAGE_TOOL_NAME,
-  description: 'Rename a page by id. Returns { ok, nodeId }.',
+  description:
+    'Rename a Figma page (a top-level page/tab in the document) by id. Affects only the page name; ' +
+    'its node id and contents are unchanged. To rename a layer/node on the canvas use rename_node ' +
+    'instead. Returns { ok, nodeId }.',
   inputShape: {
     pageId: z.string().describe('Page id to rename'),
     name: z.string().describe('New page name'),

--- a/packages/mcp/src/tools/rename-variable.ts
+++ b/packages/mcp/src/tools/rename-variable.ts
@@ -7,7 +7,9 @@ export const RENAME_VARIABLE_TOOL_NAME = 'rename_variable';
 export const renameVariableTool: ToolSpec = {
   name: RENAME_VARIABLE_TOOL_NAME,
   description:
-    'Rename a variable (e.g. "color/primary" → "color/brand"). Returns { ok, variableId, name }.',
+    'Rename a variable (e.g. "color/primary" → "color/brand"); use slashes in the name for folder ' +
+    'grouping in the Variables panel. The variable id is unchanged, so existing bindings keep ' +
+    'working. Returns { ok, variableId, name }.',
   inputShape: {
     variableId: z.string().describe('Variable id'),
     name: z.string().describe('New variable name, e.g. "color/brand"'),

--- a/packages/mcp/src/tools/reparent-nodes.ts
+++ b/packages/mcp/src/tools/reparent-nodes.ts
@@ -7,8 +7,10 @@ export const REPARENT_NODES_TOOL_NAME = 'reparent_nodes';
 export const reparentNodesTool: ToolSpec = {
   name: REPARENT_NODES_TOOL_NAME,
   description:
-    'Move nodes into a new parent (optionally at `index`). Nodes that no longer exist are skipped. ' +
-    'Returns { ok, affected }.',
+    'Move nodes into a different parent, optionally inserting at `index` (default: appended last). ' +
+    'On-screen positions may shift because coordinates become relative to the new parent; nodes ' +
+    'that no longer exist are skipped. To reorder within the current parent use reorder_nodes; to ' +
+    'wrap nodes in a new frame/group use group_nodes. Returns { ok, affected }.',
   inputShape: {
     nodeIds: z.array(z.string()).describe('Node ids to move'),
     newParentId: z.string().describe('Id of the parent to move them into'),

--- a/packages/mcp/src/tools/scan-nodes-by-types.ts
+++ b/packages/mcp/src/tools/scan-nodes-by-types.ts
@@ -7,8 +7,10 @@ export const SCAN_NODES_BY_TYPES_TOOL_NAME = 'scan_nodes_by_types';
 export const scanNodesByTypesTool: ToolSpec = {
   name: SCAN_NODES_BY_TYPES_TOOL_NAME,
   description:
-    'Return every node whose type is in the given types list, within a subtree. ' +
-    'Scope with root (a node id); defaults to the current page. Returns a flat array of matching nodes.',
+    'Return a flat list of every node whose type is in `types`, searched recursively through a ' +
+    'subtree scoped by `root` (a node id) or the current page by default. Use this to collect nodes ' +
+    'by kind (e.g. all TEXT or COMPONENT nodes); to search by name or characters use search_nodes, ' +
+    'and for a styled tree snapshot use get_design_context. Returns a flat array of matching nodes.',
   inputShape: {
     types: z.array(z.string()).describe('Node types to match, e.g. ["FRAME", "COMPONENT"]'),
     root: z.string().describe('Node id to scope the scan; omit for the current page').optional(),

--- a/packages/mcp/src/tools/set-blend-mode.ts
+++ b/packages/mcp/src/tools/set-blend-mode.ts
@@ -7,10 +7,13 @@ export const SET_BLEND_MODE_TOOL_NAME = 'set_blend_mode';
 export const setBlendModeTool: ToolSpec = {
   name: SET_BLEND_MODE_TOOL_NAME,
   description:
-    "Set a node's blend mode (e.g. NORMAL, MULTIPLY, SCREEN, OVERLAY). Returns { ok, nodeId }.",
+    'Set how a node composites with the layers beneath it (NORMAL, MULTIPLY, SCREEN, OVERLAY, ' +
+    'DARKEN, LIGHTEN, COLOR_DODGE, etc.). PASS_THROUGH is only meaningful on groups/frames (lets ' +
+    "children blend with content outside the group). Affects compositing only, not the node's own " +
+    'fills — use set_fills or set_opacity for those. Returns { ok, nodeId }.',
   inputShape: {
-    nodeId: z.string(),
-    blendMode: z.string().describe('Figma blend mode literal'),
+    nodeId: z.string().describe('Node to set the blend mode on'),
+    blendMode: z.string().describe('Figma blend mode literal, e.g. "MULTIPLY"'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/set-constraints.ts
+++ b/packages/mcp/src/tools/set-constraints.ts
@@ -8,11 +8,16 @@ const constraint = z.enum(['MIN', 'CENTER', 'MAX', 'STRETCH', 'SCALE']);
 
 export const setConstraintsTool: ToolSpec = {
   name: SET_CONSTRAINTS_TOOL_NAME,
-  description: "Set a node's resize constraints relative to its parent. Returns { ok, nodeId }.",
+  description:
+    'Set how a node responds when its parent frame is resized, via horizontal and vertical ' +
+    'constraints: MIN pins to the left/top, MAX to the right/bottom, CENTER keeps it centered, ' +
+    'STRETCH pins both edges (grows with the parent), and SCALE resizes proportionally. Constraints ' +
+    'apply inside plain frames only — auto-layout frames position children by layout rules and ' +
+    'ignore them. Returns { ok, nodeId }.',
   inputShape: {
-    nodeId: z.string(),
-    horizontal: constraint,
-    vertical: constraint,
+    nodeId: z.string().describe('Node to constrain'),
+    horizontal: constraint.describe('Horizontal behavior when the parent resizes'),
+    vertical: constraint.describe('Vertical behavior when the parent resizes'),
   },
   kind: 'write',
 };

--- a/packages/mcp/src/tools/set-opacity.ts
+++ b/packages/mcp/src/tools/set-opacity.ts
@@ -6,7 +6,10 @@ export const SET_OPACITY_TOOL_NAME = 'set_opacity';
 
 export const setOpacityTool: ToolSpec = {
   name: SET_OPACITY_TOOL_NAME,
-  description: "Set a node's opacity (0–1). Returns { ok, nodeId }.",
+  description:
+    "Set a node's layer opacity from 0 (transparent) to 1 (opaque); this multiplies with any fill " +
+    'or stroke alpha. Opacity 0 still renders, exports, and hit-tests — to exclude a node from ' +
+    'rendering use set_visible(false), and to remove it use delete_nodes. Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('Figma node id'),
     opacity: z.number().min(0).max(1).describe('Opacity 0–1'),

--- a/packages/mcp/src/tools/set-reactions.ts
+++ b/packages/mcp/src/tools/set-reactions.ts
@@ -26,9 +26,10 @@ const reaction = z.looseObject({ trigger, actions: z.array(action) });
 export const setReactionsTool: ToolSpec = {
   name: SET_REACTIONS_TOOL_NAME,
   description:
-    "Replace a node's prototype reactions. Each reaction has a trigger (e.g. { type: 'ON_CLICK' }) " +
-    "and an actions array (e.g. { type: 'NODE', destinationId, navigation, transition }). Best used " +
-    'to round-trip get_reactions output. Returns { ok, nodeId }.',
+    "Replace all of a node's prototype reactions — this overwrites existing reactions rather than " +
+    "appending. Each reaction pairs a trigger (e.g. { type: 'ON_CLICK' }) with an actions array " +
+    "(e.g. { type: 'NODE', destinationId, navigation, transition }). Best used to round-trip " +
+    'get_reactions output; to clear all reactions instead use remove_reactions. Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('Node to set reactions on'),
     reactions: z.array(reaction).describe('Reactions to apply (replaces existing)'),

--- a/packages/mcp/src/tools/set-text.ts
+++ b/packages/mcp/src/tools/set-text.ts
@@ -7,7 +7,10 @@ export const SET_TEXT_TOOL_NAME = 'set_text';
 export const setTextTool: ToolSpec = {
   name: SET_TEXT_TOOL_NAME,
   description:
-    "Replace a TEXT node's characters. The plugin loads the node's fonts first. Returns { ok, nodeId }.",
+    "Replace the entire text content of a TEXT node; the plugin loads the node's current fonts " +
+    'first and preserves existing character styling where possible. For formatting (font, size, ' +
+    'color, spacing) use set_text_properties, and to substitute text across many nodes use ' +
+    'find_replace_text. Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('TEXT node id to update'),
     characters: z.string().describe('New text content'),

--- a/packages/mcp/src/tools/set-variable-value.ts
+++ b/packages/mcp/src/tools/set-variable-value.ts
@@ -23,8 +23,10 @@ const variableValue = z
 export const setVariableValueTool: ToolSpec = {
   name: SET_VARIABLE_VALUE_TOOL_NAME,
   description:
-    "Set a variable's value for a mode. value is a boolean / number / string, a color " +
-    '{ r, g, b, a } (0–1), or an alias { type: "VARIABLE_ALIAS", id }. Returns { ok, variableId, name }.',
+    "Set a variable's value for one mode (modeId comes from the variable's collection). value must " +
+    'match the variable resolvedType: a boolean, a number (FLOAT), a string, a color { r, g, b, a } ' +
+    '(0–1), or an alias { type: "VARIABLE_ALIAS", id } pointing at another variable. Create the ' +
+    'variable first with create_variable. Returns { ok, variableId, name }.',
   inputShape: {
     variableId: z.string().describe('Variable id'),
     modeId: z.string().describe('Mode id (from the collection)'),

--- a/packages/mcp/src/tools/set-visible.ts
+++ b/packages/mcp/src/tools/set-visible.ts
@@ -6,7 +6,11 @@ export const SET_VISIBLE_TOOL_NAME = 'set_visible';
 
 export const setVisibleTool: ToolSpec = {
   name: SET_VISIBLE_TOOL_NAME,
-  description: 'Show or hide a node. Returns { ok, nodeId }.',
+  description:
+    'Show or hide a node by toggling its `visible` flag. A hidden node stays in the layer tree but ' +
+    'is excluded from rendering and exports, and its descendants are hidden with it; the change is ' +
+    'fully reversible. To remove a node use delete_nodes; to dim one while keeping it visible and ' +
+    'exported use set_opacity. Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('Figma node id'),
     visible: z.boolean().describe('true to show, false to hide'),

--- a/packages/mcp/src/tools/unlock-nodes.ts
+++ b/packages/mcp/src/tools/unlock-nodes.ts
@@ -6,7 +6,10 @@ export const UNLOCK_NODES_TOOL_NAME = 'unlock_nodes';
 
 export const unlockNodesTool: ToolSpec = {
   name: UNLOCK_NODES_TOOL_NAME,
-  description: 'Unlock nodes. Returns { ok, affected }.',
+  description:
+    'Unlock nodes so they can be selected and edited on the canvas again — the inverse of ' +
+    'lock_nodes. Ids that no longer exist are skipped. Returns { ok, affected } with the ids ' +
+    'actually unlocked.',
   inputShape: {
     nodeIds: z.array(z.string()).describe('Node ids to unlock'),
   },


### PR DESCRIPTION
## What

Rewrites the **31 tool descriptions Glama scored ≤ 4.0/5** so they follow the high-scoring template:
**action → precise behavior/side-effects → when to use vs. the nearest related tool → `Returns` shape.**
Also adds `.describe()` to previously bare params (`set_blend_mode`, `set_constraints`, the `create_*`
shape tools, `create_variable`) to lift the Parameter Semantics dimension.

## Why

Glama's server score is **60% average TDQS + 40% lowest TDQS**, so lifting the whole sub-4.0 floor
cluster is the highest-leverage move on the current **A / 83%** rating. The lowest scorers were
`rename_page` / `set_reactions` / `set_visible` (3.2), which dragged the 40% term.

Targets the dimensions Glama flagged (Behavioral Transparency, Usage Guidelines, Parameter Semantics).
Deliberately does **not** touch Tool Count Appropriateness (2/5, structural — not cutting tool breadth
for a score) and leaves > 4.0 tools alone to avoid gold-plating.

## Scope / safety

- Description + param `.describe()` text only — **no behavior changes**.
- Tool count and advertised schemas are unchanged (`ALL_TOOL_SPECS.length` unaffected).
- Full gate green: `typecheck` / `lint` / `format:check` / `knip` / `build` / `test` (693 tests).

## Re-score (post-merge, manual)

Glama won't re-scan automatically: publish a new npm version, then bump the Glama build spec version →
Deploy → Make Release to trigger re-scoring.