### PR TITLE
docs(readme): collapse duplicated dev section into a CONTRIBUTING pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,24 +216,9 @@ Yes. Several MCP servers can share a single plugin via leader/follower **electio
 
 </details>
 
-## Contributing & development
+## Contributing
 
-Contributions are welcome — see **[CONTRIBUTING.md](./CONTRIBUTING.md)** for the workflow, and **[AGENTS.md](./AGENTS.md)** for architecture, layout, and conventions.
-
-```
-packages/
-  shared/   # types, Zod schemas, msgpack codec, plugin↔server protocol (bundled into mcp)
-  mcp/      # the MCP server — @figwright/mcp (Node, ESM): relay, election, tools, joins
-  plugin/   # Figma plugin — Vue 3 + Vite + Tailwind v4 (UI) + sandbox (Figma API)
-skills/     # agent skills that orchestrate the tools — installable via `npx skills add`
-```
-
-Run the canonical checks from the repo root (the same gates CI enforces):
-
-```bash
-pnpm install
-pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test
-```
+Contributions are welcome. See **[CONTRIBUTING.md](./CONTRIBUTING.md)** for how to get set up and open a pull request, and **[AGENTS.md](./AGENTS.md)** for the architecture, repo layout, tech stack, and conventions.
 
 ## What's in the name
 


### PR DESCRIPTION
## What

The README's **Contributing & development** section duplicated content that already lives in dedicated files:

- the `packages/` layout tree — verbatim from [AGENTS.md](./AGENTS.md)
- the canonical CI checks command (`pnpm typecheck && lint && …`) — from [CONTRIBUTING.md](./CONTRIBUTING.md) and AGENTS.md

Replaced it with a one-line pointer. The README now owns **how to use Figwright**; CONTRIBUTING.md and AGENTS.md own **how to develop it**.

## Notes

Verified along the way (left unchanged because they're already correct):

- Tool count `92` matches `ALL_TOOL_SPECS.length` (read 23 / write 64 / local 5).
- All cross-file links and the lone internal anchor (`#skills`) resolve; `LICENSE` / `.node-version` exist.
- `packages/mcp/README.md` is intentionally minimal (npm page) and defers full setup to the main repo — not a stale duplicate.

Docs-only change; no code touched.