### PR TITLE
feat(ping): surface leader/follower version skew

### DIFF
--- a/packages/mcp/src/election/follower.ts
+++ b/packages/mcp/src/election/follower.ts
@@ -83,6 +83,29 @@ export class Follower {
     }
   }
 
+  /**
+   * Read the leader's reported serverVersion (from its /ping). Lets the ping tool surface a
+   * leader/follower version skew — e.g. a stale older leader process still owns the plugin while a
+   * newer client attaches as a follower (so ping reports the new version but the work runs on the
+   * old one). Returns undefined on any failure — purely informational, never gates routing.
+   */
+  async resolveLeaderVersion(): Promise<string | undefined> {
+    try {
+      const res = await this.opts.fetch(`${this.opts.leaderUrl}${PING_PATH}`, {
+        signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
+      });
+      if (!res.ok) return undefined;
+      const body: unknown = await res.json();
+      const version =
+        typeof body === 'object' && body !== null
+          ? (body as { serverVersion?: unknown }).serverVersion
+          : undefined;
+      return typeof version === 'string' ? version : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   async sendRpc(
     toolName: string,
     args?: unknown,

--- a/packages/mcp/src/tools/ping.ts
+++ b/packages/mcp/src/tools/ping.ts
@@ -8,7 +8,9 @@ export const PING_TOOL_NAME = 'ping';
 export const pingTool: ToolSpec = {
   name: PING_TOOL_NAME,
   description:
-    'Health check. Returns server info plus, when a plugin is connected, end-to-end info from the Figma sandbox.',
+    'Health check. Returns server info plus, when a plugin is connected, end-to-end info from the ' +
+    'Figma sandbox. On a follower it also reports the leader’s version and warns (versionSkew) ' +
+    'when a stale older server still owns the plugin.',
   inputShape: {},
   kind: 'read',
 };
@@ -19,6 +21,17 @@ export interface PingServerInfo {
   role: NodeRole;
   port: number | null;
   ts: number;
+  /**
+   * Follower path only: the version of the leader process that actually owns the plugin and runs
+   * the work. Usually equal to `version`; differs when a stale older server still holds the port.
+   */
+  leaderVersion?: string;
+  /**
+   * Present only when `leaderVersion` differs from `version` — a human-readable warning that a
+   * stale server process is serving the plugin, so this client's newer build isn't actually in
+   * effect.
+   */
+  versionSkew?: string;
 }
 
 /**
@@ -122,7 +135,26 @@ export const handlePing = async (ctx: PingContext): Promise<PingResult> => {
     }
   }
 
-  // Follower path — no direct relay visibility, so no sessions info.
+  // Follower path — no direct relay visibility, so no sessions info. Surface the leader's version so
+  // a stale older leader still owning the plugin (this client's new build never took effect) is
+  // visible instead of silent — the zombie-leader trap. Best-effort, never gates routing.
+  const leaderVersion = await ctx.follower.resolveLeaderVersion();
+  const followerServer: PingServerInfo =
+    leaderVersion === undefined
+      ? server
+      : {
+          ...server,
+          leaderVersion,
+          ...(leaderVersion === server.version
+            ? {}
+            : {
+                versionSkew:
+                  `leader is v${leaderVersion} but this client's server is v${server.version} — a ` +
+                  `stale server process still owns the plugin, so your newer build isn't in effect. ` +
+                  `Kill the leader (lsof -iTCP:3055 -sTCP:LISTEN) so election promotes this version.`,
+              }),
+        };
+
   try {
     const plugin = await dispatchTool(
       {
@@ -133,11 +165,11 @@ export const handlePing = async (ctx: PingContext): Promise<PingResult> => {
       'ping',
       {},
     );
-    return { ok: true, hop: 'e2e', server, plugin };
+    return { ok: true, hop: 'e2e', server: followerServer, plugin };
   } catch (err) {
     const dispatchError = err instanceof Error ? err.message : String(err);
     ctx.log?.(`[ping] dispatch failed, falling back to server-only: ${dispatchError}`);
-    return { ok: true, hop: 'server-only', server, plugin: null, dispatchError };
+    return { ok: true, hop: 'server-only', server: followerServer, plugin: null, dispatchError };
   }
 };
 

--- a/packages/mcp/test/election/follower.test.ts
+++ b/packages/mcp/test/election/follower.test.ts
@@ -194,6 +194,17 @@ describe('Follower HTTP client', () => {
     expect(await f.resolveActiveSession()).toBeUndefined();
   });
 
+  it('resolveLeaderVersion reads the leader-reported serverVersion', async () => {
+    const b = await startLeader();
+    const f = new Follower({ leaderUrl: `http://127.0.0.1:${b.port}` });
+    expect(await f.resolveLeaderVersion()).toBe('test-1.0.0');
+  });
+
+  it('resolveLeaderVersion returns undefined when the leader is unreachable', async () => {
+    const f = new Follower({ leaderUrl: 'http://127.0.0.1:1', pingTimeoutMs: 200 });
+    expect(await f.resolveLeaderVersion()).toBeUndefined();
+  });
+
   it('sendRpc threads sessionId so the leader pins the call', async () => {
     const b = await startLeader();
     await attachFakePlugin(b, async () => ({ ok: true }));

--- a/packages/mcp/test/tools/ping.test.ts
+++ b/packages/mcp/test/tools/ping.test.ts
@@ -91,6 +91,7 @@ describe('ping tool', () => {
       getLeader: () => null,
     });
     const follower = makeFollower({
+      resolveLeaderVersion: async () => '1.0.0',
       sendRpc: async () => ({
         kind: 'err' as const,
         requestId: 'r',
@@ -109,5 +110,66 @@ describe('ping tool', () => {
     expect(result.dispatchError).toContain('no plugin connected');
     expect(result.server.role).toBe(NodeRole.Follower);
     expect(result.server.port).toBeNull();
+  });
+
+  it('flags a leader/follower version skew (zombie-leader trap)', async () => {
+    const node = makeNode({
+      role: NodeRole.Follower,
+      isLeader: () => false,
+      getLeader: () => null,
+    });
+    const follower = makeFollower({
+      resolveLeaderVersion: async () => '0.1.0', // stale older leader still owns the plugin
+      sendRpc: async () => ({
+        kind: 'ok' as const,
+        requestId: 'r',
+        result: { apiVersion: '1.0.0' },
+      }),
+    });
+    const result = await handlePing({ node, follower, serverVersion: '0.2.0', log: () => {} });
+
+    expect(result.server.version).toBe('0.2.0');
+    expect(result.server.leaderVersion).toBe('0.1.0');
+    expect(result.server.versionSkew).toMatch(/leader is v0\.1\.0.*v0\.2\.0/);
+  });
+
+  it('reports leaderVersion with no skew warning when versions match', async () => {
+    const node = makeNode({
+      role: NodeRole.Follower,
+      isLeader: () => false,
+      getLeader: () => null,
+    });
+    const follower = makeFollower({
+      resolveLeaderVersion: async () => '0.2.0',
+      sendRpc: async () => ({
+        kind: 'ok' as const,
+        requestId: 'r',
+        result: { apiVersion: '1.0.0' },
+      }),
+    });
+    const result = await handlePing({ node, follower, serverVersion: '0.2.0', log: () => {} });
+
+    expect(result.server.leaderVersion).toBe('0.2.0');
+    expect(result.server.versionSkew).toBeUndefined();
+  });
+
+  it('omits leaderVersion when the leader version is unreachable', async () => {
+    const node = makeNode({
+      role: NodeRole.Follower,
+      isLeader: () => false,
+      getLeader: () => null,
+    });
+    const follower = makeFollower({
+      resolveLeaderVersion: async () => undefined,
+      sendRpc: async () => ({
+        kind: 'ok' as const,
+        requestId: 'r',
+        result: { apiVersion: '1.0.0' },
+      }),
+    });
+    const result = await handlePing({ node, follower, serverVersion: '0.2.0', log: () => {} });
+
+    expect(result.server.leaderVersion).toBeUndefined();
+    expect(result.server.versionSkew).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Problem
`ping().server.version` reports the version of the **local process the client spawned**. When that process is a **follower**, the actual work runs on the **leader** — which can be a different, older version. We hit this live: a stale `v0.1.0` server that had been running for ~1.5 days still owned the plugin, while a freshly-spawned `v0.2.0` attached as a follower. `ping` cheerfully reported `0.2.0`, but every call was being served by the old `0.1.0` leader. The only way to notice was `lsof :3055` + `ps`.

### Fix — purely additive, warning-only
The leader's HTTP `/ping` already returns `serverVersion` (the follower fetches it just to confirm it's a real leader, then discards it). Now:

- `Follower.resolveLeaderVersion()` reads that version (mirrors `resolveActiveSession()`; best-effort, returns `undefined` on failure).
- The `ping` tool, on the **follower path**, adds `server.leaderVersion`, and — only when it differs from the local version — a human-readable `server.versionSkew` warning that points at killing the stale leader.

**Why equal-or-better:** new optional fields only. No blocking, no auto-kill, no routing change — the skew was already happening silently; this just makes it visible. Reuses data the leader already exposes; no protocol change.

### Changed
- `election/follower.ts` — `resolveLeaderVersion()`.
- `tools/ping.ts` — `leaderVersion` / `versionSkew` on `PingServerInfo`, computed on the follower path; description updated.
- Tests: follower (+2), ping tool (+3: skew / no-skew / unreachable). **707 passing.**

Gate green: typecheck · lint · format · knip · build · test. Server-only change — live-verifiable by reconnecting a follower against an older leader.