### PR TITLE
fix(server): self-terminate on stdin EOF to prevent zombie leaders

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,6 +9,7 @@ import { Election } from './election/election.js';
 import { Follower } from './election/follower.js';
 import { attachLeaderEndpoints } from './election/leader-endpoints.js';
 import { Node, NodeRole } from './election/node.js';
+import { wireShutdown } from './lifecycle.js';
 import { normalizeIdArgs } from './node-id.js';
 import { PROMPTS } from './prompts/registry.js';
 import { ANALYZE_PROJECT_TOOL_NAME, handleAnalyzeProject } from './tools/analyze-project.js';
@@ -165,5 +166,7 @@ const shutdown = async (): Promise<void> => {
   await node.stop();
   process.exit(0);
 };
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+// Exit on SIGINT/SIGTERM and on stdin EOF. stdin closes when the client that spawned us goes away
+// (including a crash that sends no signal); without this the process would linger holding the relay
+// port as a stale "zombie" leader serving an old build. wireShutdown runs shutdown at most once.
+wireShutdown({ proc: process, stdin: process.stdin, shutdown });

--- a/packages/mcp/src/lifecycle.ts
+++ b/packages/mcp/src/lifecycle.ts
@@ -1,0 +1,34 @@
+type Listenable = Pick<NodeJS.EventEmitter, 'on'>;
+
+export interface ShutdownWiring {
+  /** The process, for SIGINT / SIGTERM. */
+  proc: Listenable;
+  /** The transport input stream (stdin); its end/close means the client that spawned us is gone. */
+  stdin: Listenable;
+  /** Performs the actual graceful shutdown; invoked at most once. */
+  shutdown: () => void | Promise<void>;
+}
+
+/**
+ * Wire every "exit now" trigger to a single idempotent shutdown.
+ *
+ * SIGINT / SIGTERM cover a client that politely signals us. But an MCP server is spawned over stdio
+ * by its client, and when that client crashes or is force-closed it may send no signal at all — it
+ * just closes the pipe. The SDK's stdio transport reacts only to stdin 'data' / 'error', never to
+ * EOF, so without this the process lingers, keeps holding the relay port, and becomes a stale
+ * "zombie" leader serving an old build. stdin 'end' / 'close' is the reliable "client is gone"
+ * signal, so we treat it as a shutdown trigger too. shutdown runs at most once even if several
+ * triggers fire together (e.g. 'end' then 'close').
+ */
+export const wireShutdown = ({ proc, stdin, shutdown }: ShutdownWiring): void => {
+  let triggered = false;
+  const once = (): void => {
+    if (triggered) return;
+    triggered = true;
+    void shutdown();
+  };
+  proc.on('SIGINT', once);
+  proc.on('SIGTERM', once);
+  stdin.on('end', once);
+  stdin.on('close', once);
+};

--- a/packages/mcp/test/lifecycle.test.ts
+++ b/packages/mcp/test/lifecycle.test.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, it } from 'vitest';
+
+import { wireShutdown } from '../src/lifecycle.js';
+
+describe('wireShutdown', () => {
+  it.each([
+    ['proc', 'SIGINT'],
+    ['proc', 'SIGTERM'],
+    ['stdin', 'end'],
+    ['stdin', 'close'],
+  ] as const)('runs shutdown when %s emits %s', (source, event) => {
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    let calls = 0;
+    wireShutdown({ proc, stdin, shutdown: () => void calls++ });
+
+    (source === 'proc' ? proc : stdin).emit(event);
+    expect(calls).toBe(1);
+  });
+
+  it('runs shutdown at most once across multiple triggers', () => {
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    let calls = 0;
+    wireShutdown({ proc, stdin, shutdown: () => void calls++ });
+
+    stdin.emit('end');
+    stdin.emit('close');
+    proc.emit('SIGTERM');
+    proc.emit('SIGINT');
+    expect(calls).toBe(1);
+  });
+
+  it('does not run shutdown until a trigger fires', () => {
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    let calls = 0;
+    wireShutdown({ proc, stdin, shutdown: () => void calls++ });
+
+    expect(calls).toBe(0);
+  });
+});


### PR DESCRIPTION
### Root cause
An MCP server is spawned over **stdio** by its client. When the client crashes or is force-closed it may send **no signal** — it just closes the pipe. `index.ts` only listened for `SIGINT`/`SIGTERM`, and the SDK's stdio transport reacts only to stdin `'data'`/`'error'` — **never to EOF** (`onclose` fires only on an explicit `close()`). So an orphaned server **lingers, keeps holding the relay port (:3055), and becomes a stale "zombie" leader** that serves an old build to the plugin. We hit this live twice: `ping` reported the new version while the actual work was served by a day-and-a-half-old leader.

### Fix — self-terminate on stdin EOF
New `wireShutdown` (`lifecycle.ts`) treats stdin `'end'`/`'close'` as a shutdown trigger alongside `SIGINT`/`SIGTERM`, running the existing graceful shutdown **at most once** (idempotent). When the client goes away the server now exits → election promotes a still-alive follower (which is, by construction, a current-build process) → **no zombie, and version skew is structurally prevented**, not just reported.

### Why equal-or-better
- Purely additive: SIGINT/SIGTERM behavior unchanged; adds the EOF trigger the SDK omits.
- stdin EOF = the client is unambiguously gone, which is exactly when a stdio server should exit (standard MCP behavior). No new failure mode.
- Lifecycle wiring extracted to a testable unit (`index.ts` is an entry point).

### Relationship to the version-skew warning (#21)
This is the **primary** fix — it stops zombies being born. #21's `versionSkew` is the **fallback gauge** for the rare residual case (e.g. multiple clients legitimately sharing one leader, or a server hung so hard it never sees the stdin event).

### Changed
- New `src/lifecycle.ts` (`wireShutdown`) + `test/lifecycle.test.ts` (triggers / idempotency / no-fire).
- `index.ts` wires it in place of the bare SIGINT/SIGTERM handlers.
- **708 tests.** Gate green: typecheck · lint · format · knip · build · test.