### PR TITLE
feat(figma-build): ground build values in source code + a sensible scale

### DIFF
--- a/skills/figma-build/SKILL.md
+++ b/skills/figma-build/SKILL.md
@@ -36,8 +36,9 @@ Start by discovering the system (it almost certainly corresponds to the source U
 3. **`get_styles`** → shared paint / text / effect styles to apply.
 
 Decide per element: **reuse** an existing component/variable/style; else take the **exact value from
-the source code** (Tailwind/CSS carry real px/hex — read them, don't eyeball); only **invent** from a
-consistent scale when neither exists.
+the source code** — be provider-first (resolve whatever styling system it uses to real px/hex: CSS
+literally, Tailwind/UnoCSS/Chakra/etc via their scale or config), don't eyeball; only **invent** from
+a consistent scale when neither exists.
 
 ## Two jobs — both follow the write rules
 

--- a/skills/figma-build/SKILL.md
+++ b/skills/figma-build/SKILL.md
@@ -20,25 +20,29 @@ the user must have the target file open. Confirm a plugin is connected (`ping`) 
   view, modal/dialog/drawer/sidebar/panel, a single component, or a design-system asset.
 - **Not** for reading a Figma design into code — that's `figma-codegen`.
 
-## First, ground every value (reuse beats regenerate, invent last)
+## First, understand the environment, then build (provider-first)
 
-The write-side mirror of codegen's grounding: an off-looking build almost always comes from
-**invented values**. Trace every value to a source, in priority order — **the file's design system →
-the code/spec you were handed → a sensible default scale** (full detail + the Tailwind→px table in
-`references/write-rules.md`).
+The write-side mirror of codegen's grounding, and the **most important habit**: an off-looking build
+almost always comes from **invented values** or **assumed conventions**. So **understand this user's
+actual environment first, then build into it** — never apply a generic template. There's no single
+"right" stack; there's _their_ stack. Look at **both ends** before creating anything:
 
-Start by discovering the system (it almost certainly corresponds to the source UI):
+- **The Figma file** — its existing design system, which you'll reuse and bind to:
+  1. **`get_variable_defs`** → the file's variables (colour / spacing / radius / typography) with
+     names + values + `hex`. These are the tokens you bind to.
+  2. **`scan_components`** / **`get_local_components`** → existing components to **instance** rather
+     than rebuild. Match the source UI pattern (a card, a list row, a nav, a button) to a component.
+  3. **`get_styles`** → shared paint / text / effect styles to apply.
+- **The source you were handed** — when it's code, _which_ stack and styling system (Tailwind /
+  Chakra / MUI / CSS modules / vanilla …) and whether it has a config / theme / tokens file. That's
+  where its real values live — read them from there, don't assume a default.
 
-1. **`get_variable_defs`** → the file's variables (colour / spacing / radius / typography) with
-   names + values + `hex`. These are the tokens you bind to.
-2. **`scan_components`** / **`get_local_components`** → existing components to **instance** rather
-   than rebuild. Match the source UI pattern (a card, a list row, a nav, a button) to a component.
-3. **`get_styles`** → shared paint / text / effect styles to apply.
-
-Decide per element: **reuse** an existing component/variable/style; else take the **exact value from
-the source code** — be provider-first (resolve whatever styling system it uses to real px/hex: CSS
-literally, Tailwind/UnoCSS/Chakra/etc via their scale or config), don't eyeball; only **invent** from
-a consistent scale when neither exists.
+Then build, tracing every value to a source in priority order: **reuse** an existing
+component / variable / style; else take the **exact value from the source's own code** —
+provider-first, resolving whatever styling system it uses to real px / hex (CSS literally;
+Tailwind / Chakra / UnoCSS / … via their config or scale), never eyeballed; only **invent** from a
+consistent scale when neither exists. Full detail + the value-resolution method in
+`references/write-rules.md`.
 
 ## Two jobs — both follow the write rules
 
@@ -66,6 +70,9 @@ hierarchy. An `empty: true` export means the node rendered nothing (hidden / off
 
 ## Rules
 
+- **Understand the environment, then build.** Read both the file's design system _and_ the source's
+  stack / styling system before creating anything — there's no single right stack, only _theirs_.
+  Ground every value (design system → the code's own values → a sensible scale); never invent.
 - **Reuse beats regenerate.** Instance existing components; bind existing variables/styles. Build new
   only what the system lacks, and name/structure it to fit.
 - **Reference tokens, not literals.** Colour via `bind_variable_to_paint`, scalars via

--- a/skills/figma-build/SKILL.md
+++ b/skills/figma-build/SKILL.md
@@ -20,11 +20,14 @@ the user must have the target file open. Confirm a plugin is connected (`ping`) 
   view, modal/dialog/drawer/sidebar/panel, a single component, or a design-system asset.
 - **Not** for reading a Figma design into code — that's `figma-codegen`.
 
-## First, ground in the design system (reuse beats regenerate)
+## First, ground every value (reuse beats regenerate, invent last)
 
-The write-side mirror of codegen's grounding. The file almost certainly has a design system whose
-components/tokens correspond to the source UI. **Discover it first, then instance/bind it** — don't
-redraw boxes with hex.
+The write-side mirror of codegen's grounding: an off-looking build almost always comes from
+**invented values**. Trace every value to a source, in priority order — **the file's design system →
+the code/spec you were handed → a sensible default scale** (full detail + the Tailwind→px table in
+`references/write-rules.md`).
+
+Start by discovering the system (it almost certainly corresponds to the source UI):
 
 1. **`get_variable_defs`** → the file's variables (colour / spacing / radius / typography) with
    names + values + `hex`. These are the tokens you bind to.
@@ -32,16 +35,18 @@ redraw boxes with hex.
    than rebuild. Match the source UI pattern (a card, a list row, a nav, a button) to a component.
 3. **`get_styles`** → shared paint / text / effect styles to apply.
 
-Decide per element: **reuse** an existing component/variable/style, or **build new** only what the
-system genuinely lacks.
+Decide per element: **reuse** an existing component/variable/style; else take the **exact value from
+the source code** (Tailwind/CSS carry real px/hex — read them, don't eyeball); only **invent** from a
+consistent scale when neither exists.
 
 ## Two jobs — both follow the write rules
 
-Every build obeys the same cross-cutting rules — reference tokens (colour via
-`bind_variable_to_paint`, scalars via `bind_variable_to_node`, shared looks via
-`apply_style_to_node`), auto-layout for related children (absolute only for top-level placement),
-append-then-fill sizing (`layoutGrow`/`layoutAlign`, no FILL/HUG enum), and real fonts (a new TEXT
-node defaults to Inter). → **[`references/write-rules.md`](./references/write-rules.md).**
+Every build obeys the same cross-cutting rules — ground values (design system → source code → scale),
+reference tokens (colour via `bind_variable_to_paint`, scalars via `bind_variable_to_node`, shared
+looks via `apply_style_to_node`), auto-layout for related children (absolute only for top-level
+placement), HUG/FILL/FIXED sizing via `set_layout_props` (so the layout computes sizes — don't
+hardcode width/height), and real fonts (a new TEXT node defaults to Inter). →
+**[`references/write-rules.md`](./references/write-rules.md).**
 
 - **Assemble a screen / component from what exists** (the common case): recognise the UI pattern,
   `create_instance` matching components, bind tokens, build incrementally, screenshot-verify each
@@ -52,9 +57,11 @@ node defaults to Inter). → **[`references/write-rules.md`](./references/write-
 
 ## Verify visually (close the loop)
 
-`get_screenshot` the built node, compare it to the source intent, fix discrepancies, and
-re-screenshot — the same render-and-diff discipline codegen uses, in reverse. An `empty: true` export
-means the node rendered nothing (hidden / off-canvas).
+`get_screenshot` the built node, fix discrepancies, and re-screenshot — the same render-and-diff
+discipline codegen uses, in reverse. Check it against the source intent **and** against objective
+design health (this catches problems even when you built from a vague description with no source to
+compare): nothing clipped or overflowing, edges aligned, spacing consistent (one scale), a clear type
+hierarchy. An `empty: true` export means the node rendered nothing (hidden / off-canvas).
 
 ## Rules
 

--- a/skills/figma-build/references/assemble-screens.md
+++ b/skills/figma-build/references/assemble-screens.md
@@ -55,10 +55,17 @@ a token for (`write-rules.md` has the three paths).
 
 ## 6. Verify visually — close the loop
 
-`get_screenshot` the built node, compare it to the source intent, fix discrepancies, re-screenshot —
-the same render-and-diff discipline codegen uses, in reverse. An `empty: true` export means the node
-rendered nothing (hidden / off-canvas / no visible content) — check it's appended, visible, and on
-the canvas.
+`get_screenshot` the built node, fix discrepancies, re-screenshot — the render-and-diff discipline
+codegen uses, in reverse. Check it against the source intent **and** against objective design health,
+which catches problems even when you built from a vague description with no source to compare:
+
+- nothing **clipped or overflowing** (a frame stuck at 100×100, text cut off);
+- edges **aligned**, not off by a few px;
+- **spacing consistent** — gaps / padding from one scale, not a different number each time;
+- a clear **type hierarchy** (heading / body / caption actually differ).
+
+An `empty: true` export means the node rendered nothing (hidden / off-canvas / no visible content) —
+check it's appended, visible, and on the canvas.
 
 ## Large builds: section by section
 

--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -15,7 +15,7 @@ the model made up. Every value should trace to a source. In priority order:
    exact values; read them off instead of re-deriving by eye. This is the mirror of codegen (which
    reads exact values _out of_ Figma): building from code reads them _out of the code_. Be
    **provider-first** — resolve whatever styling system the code actually uses to its real px / hex;
-   don't assume one. There are two kinds of value:
+   don't assume one. Resolve each value by its kind:
    - **Literal** (vanilla CSS, inline styles, CSS-in-JS, compiled SCSS) → read the px / hex / rem
      straight off (`1rem`=16px unless the project says otherwise).
    - **Encoded / scaled** (utility classes, component-library props, named tokens — `p-4`,

--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -4,6 +4,38 @@ The cross-cutting rules every build follows — whether you're assembling a scre
 components or authoring a new asset. These mirror codegen's "reference tokens, not literals" rules,
 pointed at the canvas.
 
+## Where every value comes from (ground, don't invent)
+
+The top cause of an off-looking build is **invented values** — padding, sizes, radii, colours, type
+the model made up. Every value should trace to a source. In priority order:
+
+1. **The file's design system** (highest) — a variable / style / component already in the file. Reuse
+   and bind it (see below). `get_variable_defs` / `get_styles` / `scan_components` say what exists.
+2. **The source code / spec you were handed** — when building _from code_, the code already carries
+   exact values; read them off instead of re-deriving by eye. This is the mirror of codegen (which
+   reads exact values _out of_ Figma): building from code reads them _out of the code_.
+   - **Tailwind** → its scale: spacing `1/2/3/4/6/8/12/16` = `4/8/12/16/24/32/48/64`px (so `p-4`=16,
+     `gap-6`=24); radius `rounded-sm/-/-md/-lg/-xl/-2xl` = `2/4/6/8/12/16`px; text
+     `sm/base/lg/xl/2xl/3xl` = `14/16/18/20/24/30`px; `font-medium/semibold/bold` = `500/600/700`;
+     colour tokens → their hex (`slate-900`=#0F172A, `slate-500`=#64748B…). These are the defaults — a
+     `tailwind.config` overrides them, so prefer the project's config when you can see it.
+   - **CSS / inline styles** → read px / hex / rem directly (`1rem`=16px unless the project says
+     otherwise).
+   - **Design tokens in the code** (CSS vars, a theme object) → map each to the matching Figma
+     variable (source 1) if one exists, else carry its literal. Don't swap `p-6` for a guessed 32 —
+     it's 24.
+3. **A sensible scale** (only when neither applies — a vague description into an empty file) — pick
+   from a consistent scale, never one-off numbers:
+   - Spacing / padding / gap: the 8pt grid — `4, 8, 12, 16, 24, 32, 48, 64`.
+   - Type: `12, 14, 16, 20, 24, 32, 40` with a clear hierarchy (don't size every text differently).
+   - Radius: one of `4, 8, 12, 16`, consistent across siblings.
+   - Colour: a neutral ramp (background / surface / border / muted text / ink) + one accent — not a
+     fresh random hex per element.
+
+   Reuse the _same_ value for the same role across the design — repetition is what reads as
+   "designed". And prefer HUG/FILL sizing (below) so the layout computes sizes for you: the fewer raw
+   width/height numbers you invent, the fewer chances to get them wrong.
+
 ## Reference tokens, not literals
 
 Never hardcode a hex/px when the file has a token for it (`get_variable_defs` tells you what does).

--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -18,15 +18,23 @@ the model made up. Every value should trace to a source. In priority order:
    don't assume one. There are two kinds of value:
    - **Literal** (vanilla CSS, inline styles, CSS-in-JS, compiled SCSS) → read the px / hex / rem
      straight off (`1rem`=16px unless the project says otherwise).
-   - **Encoded / scaled** (utility classes, component-library props, named tokens) → resolve through
-     that system's scale / config / theme, don't eyeball. Find the system's own definition first
-     (a `tailwind.config`, a theme object, a `_variables.scss`, CSS custom properties) — a default
-     you assumed can be wrong. The most common case is **Tailwind**, as a worked example: spacing
+   - **Encoded / scaled** (utility classes, component-library props, named tokens — `p-4`,
+     `<Box p={4}>`, `var(--space-md)`) → don't eyeball; resolve the same three ways every time:
+     **(a)** spot which system it is, **(b)** find that system's value definition — its
+     config / theme / variables file, falling back to the system's documented default scale only when
+     the project doesn't override it, **(c)** look the token up there. The step is identical across
+     systems; only _where the scale lives_ and _the token syntax_ differ — e.g. Tailwind `p-4` (its
+     spacing scale) · Chakra `p={4}` (`theme.space[4]`) · MUI `sx={{ p: 2 }}` (`spacing(2)`, 8px
+     base) · SCSS `$space-md` (`_variables.scss`) · CSS `var(--space-md)` (its `:root` value) · plain
+     `padding: 16px` (literal). Don't hardcode a default you assumed — find the project's own
+     definition first.
+
+     For reference, **Tailwind's defaults** (the most common system): spacing
      `1/2/3/4/6/8/12/16`=`4/8/12/16/24/32/48/64`px (`p-4`=16, `gap-6`=24), radius
      `rounded-sm/-/-md/-lg/-xl/-2xl`=`2/4/6/8/12/16`px, text `sm/base/lg/xl/2xl/3xl`=
      `14/16/18/20/24/30`px, `font-medium/semibold/bold`=`500/600/700`, colour tokens→hex
-     (`slate-900`=#0F172A…) — **and the same approach (not these numbers) applies to UnoCSS,
-     Bootstrap spacers, Chakra/MUI scale props, or any project theme**: resolve to the actual value.
+     (`slate-900`=#0F172A…).
+
    - **Named design tokens** (CSS custom properties like `--space-md`, a theme object) → map each to
      the matching Figma variable (source 1) if one exists, else resolve to its literal value.
 

--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -13,17 +13,25 @@ the model made up. Every value should trace to a source. In priority order:
    and bind it (see below). `get_variable_defs` / `get_styles` / `scan_components` say what exists.
 2. **The source code / spec you were handed** — when building _from code_, the code already carries
    exact values; read them off instead of re-deriving by eye. This is the mirror of codegen (which
-   reads exact values _out of_ Figma): building from code reads them _out of the code_.
-   - **Tailwind** → its scale: spacing `1/2/3/4/6/8/12/16` = `4/8/12/16/24/32/48/64`px (so `p-4`=16,
-     `gap-6`=24); radius `rounded-sm/-/-md/-lg/-xl/-2xl` = `2/4/6/8/12/16`px; text
-     `sm/base/lg/xl/2xl/3xl` = `14/16/18/20/24/30`px; `font-medium/semibold/bold` = `500/600/700`;
-     colour tokens → their hex (`slate-900`=#0F172A, `slate-500`=#64748B…). These are the defaults — a
-     `tailwind.config` overrides them, so prefer the project's config when you can see it.
-   - **CSS / inline styles** → read px / hex / rem directly (`1rem`=16px unless the project says
-     otherwise).
-   - **Design tokens in the code** (CSS vars, a theme object) → map each to the matching Figma
-     variable (source 1) if one exists, else carry its literal. Don't swap `p-6` for a guessed 32 —
-     it's 24.
+   reads exact values _out of_ Figma): building from code reads them _out of the code_. Be
+   **provider-first** — resolve whatever styling system the code actually uses to its real px / hex;
+   don't assume one. There are two kinds of value:
+   - **Literal** (vanilla CSS, inline styles, CSS-in-JS, compiled SCSS) → read the px / hex / rem
+     straight off (`1rem`=16px unless the project says otherwise).
+   - **Encoded / scaled** (utility classes, component-library props, named tokens) → resolve through
+     that system's scale / config / theme, don't eyeball. Find the system's own definition first
+     (a `tailwind.config`, a theme object, a `_variables.scss`, CSS custom properties) — a default
+     you assumed can be wrong. The most common case is **Tailwind**, as a worked example: spacing
+     `1/2/3/4/6/8/12/16`=`4/8/12/16/24/32/48/64`px (`p-4`=16, `gap-6`=24), radius
+     `rounded-sm/-/-md/-lg/-xl/-2xl`=`2/4/6/8/12/16`px, text `sm/base/lg/xl/2xl/3xl`=
+     `14/16/18/20/24/30`px, `font-medium/semibold/bold`=`500/600/700`, colour tokens→hex
+     (`slate-900`=#0F172A…) — **and the same approach (not these numbers) applies to UnoCSS,
+     Bootstrap spacers, Chakra/MUI scale props, or any project theme**: resolve to the actual value.
+   - **Named design tokens** (CSS custom properties like `--space-md`, a theme object) → map each to
+     the matching Figma variable (source 1) if one exists, else resolve to its literal value.
+
+   Don't swap `p-6` for a guessed 32 — resolve it (Tailwind default: 24).
+
 3. **A sensible scale** (only when neither applies — a vague description into an empty file) — pick
    from a consistent scale, never one-off numbers:
    - Spacing / padding / gap: the 8pt grid — `4, 8, 12, 16, 24, 32, 48, 64`.


### PR DESCRIPTION
### Problem (the real "why builds look off")
figma-build's headline is "Build a Figma design **from code** or a description", but the skill only ever taught two value sources: **reuse the file's design system**, or **author a new token**. It treated the source code purely as a *pattern* source, **never as a value source** — and gave **zero** guidance for an empty file + vague description. So whenever there's no design system to reuse, the model **invents** padding / sizes / radii / colours / type → the build looks off. This is the true read/write asymmetry: not the tools (those are symmetric), but **grounding** — codegen always has exact values from `get_design_context`; build, on an empty file, had nothing to anchor to.

### Fix — a value-source priority, purely additive
New lead section in `write-rules.md`, **"Where every value comes from"**, with three sources in priority order:

1. **The file's design system** (reuse/bind — unchanged, this was the whole skill before).
2. **The source code/spec you were handed** — read exact values *out of the code*, the mirror of codegen reading them out of Figma. Includes a **Tailwind→px table** (`p-4`=16, `gap-6`=24, `rounded-lg`=8, `text-xl`=20, `slate-900`=#0F172A…), CSS/rem, and code design-tokens → Figma variables.
3. **A sensible scale** (only when neither applies) — 8pt spacing, a type scale, a radius set, a neutral ramp + one accent; reuse the same value for the same role.

Plus: SKILL.md router reframed to the three sources; verify steps now check **objective design health** (clipping, alignment, spacing consistency, type hierarchy) so a from-description build with no source still gets validated; and the stale **"no FILL/HUG enum"** line fixed to HUG/FILL/FIXED (#19 added it).

### Why equal-or-better
Every existing rule is **kept**; this only *adds* the next grounding layers. The only deletion is correcting an outdated/misleading line. Tailwind numbers verified against the default scale.

### Live verification
Built a badge from `<span class="px-3 py-1 rounded-full bg-blue-600 text-white text-xs font-semibold">` by extracting values: read back **padding 12/4, radius 999, fill #2563EB, text 12px Inter Semi Bold, white** — all matching the Tailwind scale — and the frame **HUG-sized itself to 101×23 with no hardcoded width/height** (vs. the eyeballed `112×26` I hardcoded for the same badge in the earlier demo). Gate green: typecheck · lint · format · knip · build · test.

> Note: this is LLM *guidance*, so full effect (the model reaching for code-extraction on its own) is best confirmed by a clean-session A/B; equal-or-better here rests on additive-only changes + verified numbers + the live proof that code-extraction lands correctly.