### PR TITLE
docs(figma-build): cover Tailwind v4 (@theme, no config file)

### DIFF
--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -33,7 +33,10 @@ the model made up. Every value should trace to a source. In priority order:
      `1/2/3/4/6/8/12/16`=`4/8/12/16/24/32/48/64`px (`p-4`=16, `gap-6`=24), radius
      `rounded-sm/-/-md/-lg/-xl/-2xl`=`2/4/6/8/12/16`px, text `sm/base/lg/xl/2xl/3xl`=
      `14/16/18/20/24/30`px, `font-medium/semibold/bold`=`500/600/700`, colour tokens→hex
-     (`slate-900`=#0F172A…).
+     (`slate-900`=#0F172A…). **Tailwind v4** is different: there's no `tailwind.config` — the theme
+     lives in a CSS `@theme { --color-…: …; --spacing-…: …; }` block as custom properties, and some
+     stock defaults changed from v3 (the colour palette moved to OKLCH), so read the project's CSS
+     `@theme` rather than assuming the v3 values above.
 
    - **Named design tokens** (CSS custom properties like `--space-md`, a theme object) → map each to
      the matching Figma variable (source 1) if one exists, else resolve to its literal value.


### PR DESCRIPTION
### Gap
#23's value-resolution guidance named `tailwind.config` as the Tailwind anchor and listed v3 default values — but **Tailwind v4 has no config file**: the theme lives in a CSS `@theme { --color-…; --spacing-…; }` block, and some stock defaults changed (palette moved to OKLCH). A model following the example literally could look for a config that doesn't exist and fall back to v3 stock values (slightly wrong, especially colours).

### Fix
One sentence added to the Tailwind reference: v4 keeps its theme in CSS `@theme`, read it instead of assuming v3 values. Purely additive doc — completes the example for v4, the generic "find the project's own definition" principle was already correct.

Aligns with the existing v3/v4 dual-path note in project memory. Equal-or-better (doc-only, nothing removed). Format check passes.

> Follow-up: a v4 A/B (a `@theme`-based fixture) to confirm both arms read `@theme` — same protocol as the #23 A/B.