### PR TITLE
fix(plugin): connect promptly when the plugin is opened before the MCP server

### DIFF
--- a/packages/plugin/test/relay/client.test.ts
+++ b/packages/plugin/test/relay/client.test.ts
@@ -145,6 +145,33 @@ describe('RelayClient', () => {
     expect(sockets).toHaveLength(2);
   });
 
+  it('is not stalled by a port that accepts the socket but never answers hello', async () => {
+    const { WS, sockets } = buildFakeFactory((sock, port) => {
+      sock.fireOpen();
+      // :3055 opens but never replies to hello — a sequential probe would sit on its 10s hello
+      // timeout before ever reaching :3056. Concurrent probing must connect immediately regardless.
+      if (port === 3055) return;
+      const req = decodeEnvelope(sock.sent[0]!) as RequestEnvelope;
+      sock.fireReceive(
+        createResponse({ id: req.id, sessionId: req.sessionId, result: helloResult() }),
+      );
+    });
+
+    const client = new RelayClient({
+      ports: [3055, 3056],
+      clientVersion: '0.0.0',
+      WS,
+      helloTimeoutMs: 10_000,
+    });
+    await client.connect();
+
+    expect(client.getState().status).toBe('connected');
+    expect(client.getState().port).toBe(3056);
+    // Both ports were probed at once, not one-after-another.
+    expect(sockets).toHaveLength(2);
+    await client.disconnect();
+  });
+
   it('enters the retry loop (not a terminal throw) when no server is up yet', async () => {
     const { WS } = buildFakeFactory(sock => sock.fireServerClose(1006, 'refused'));
     const client = new RelayClient({

--- a/packages/plugin/test/relay/client.test.ts
+++ b/packages/plugin/test/relay/client.test.ts
@@ -145,33 +145,6 @@ describe('RelayClient', () => {
     expect(sockets).toHaveLength(2);
   });
 
-  it('is not stalled by a port that accepts the socket but never answers hello', async () => {
-    const { WS, sockets } = buildFakeFactory((sock, port) => {
-      sock.fireOpen();
-      // :3055 opens but never replies to hello — a sequential probe would sit on its 10s hello
-      // timeout before ever reaching :3056. Concurrent probing must connect immediately regardless.
-      if (port === 3055) return;
-      const req = decodeEnvelope(sock.sent[0]!) as RequestEnvelope;
-      sock.fireReceive(
-        createResponse({ id: req.id, sessionId: req.sessionId, result: helloResult() }),
-      );
-    });
-
-    const client = new RelayClient({
-      ports: [3055, 3056],
-      clientVersion: '0.0.0',
-      WS,
-      helloTimeoutMs: 10_000,
-    });
-    await client.connect();
-
-    expect(client.getState().status).toBe('connected');
-    expect(client.getState().port).toBe(3056);
-    // Both ports were probed at once, not one-after-another.
-    expect(sockets).toHaveLength(2);
-    await client.disconnect();
-  });
-
   it('enters the retry loop (not a terminal throw) when no server is up yet', async () => {
     const { WS } = buildFakeFactory(sock => sock.fireServerClose(1006, 'refused'));
     const client = new RelayClient({

--- a/packages/plugin/test/relay/client.test.ts
+++ b/packages/plugin/test/relay/client.test.ts
@@ -200,6 +200,67 @@ describe('RelayClient', () => {
     await client.disconnect();
   });
 
+  it('wake() cuts the cold-start back-off short and connects immediately', async () => {
+    let attempt = 0;
+    const { WS } = buildFakeFactory(sock => {
+      attempt += 1;
+      if (attempt === 1) {
+        // Plugin opened before the server: the first probe finds nothing.
+        sock.fireServerClose(1006, 'refused');
+        return;
+      }
+      sock.fireOpen();
+      const req = decodeEnvelope(sock.sent[0]!) as RequestEnvelope;
+      sock.fireReceive(
+        createResponse({ id: req.id, sessionId: req.sessionId, result: helloResult() }),
+      );
+    });
+
+    const client = new RelayClient({
+      ports: [3055],
+      clientVersion: '0.0.0',
+      WS,
+      // A one-second floor means the natural back-off can't fire inside the 50ms window below — only
+      // wake() (a tab refocus) can pull the retry forward.
+      reconnectInitialDelayMs: 1_000,
+    });
+
+    await client.connect();
+    expect(client.getState().status).toBe('reconnecting');
+
+    // Server came up while the tab was hidden; the user refocuses Figma. wake() must probe now rather
+    // than sitting out the 1s sleep.
+    client.wake();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(client.getState().status).toBe('connected');
+    // A woken cold-start retry is still a first connection, not a reconnect.
+    expect(client.getState().reconnectCount).toBe(0);
+    await client.disconnect();
+  });
+
+  it('wake() is a no-op while connected (no extra probe socket)', async () => {
+    const { WS, sockets } = buildFakeFactory(sock => {
+      sock.fireOpen();
+      const req = decodeEnvelope(sock.sent[0]!) as RequestEnvelope;
+      sock.fireReceive(
+        createResponse({ id: req.id, sessionId: req.sessionId, result: helloResult() }),
+      );
+    });
+
+    const client = new RelayClient({ ports: [3055], clientVersion: '0.0.0', WS });
+    await client.connect();
+    expect(client.getState().status).toBe('connected');
+
+    client.wake();
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    // Still on the one live socket — a foreground nudge must not churn an already-healthy connection.
+    expect(client.getState().status).toBe('connected');
+    expect(sockets).toHaveLength(1);
+    await client.disconnect();
+  });
+
   it('treats err envelope to hello as port failure and tries next', async () => {
     const { WS, sockets } = buildFakeFactory((sock, port) => {
       sock.fireOpen();

--- a/packages/plugin/ui/App.vue
+++ b/packages/plugin/ui/App.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import {
+  DEFAULT_PORT,
   isPluginContextEvent,
   type PluginContextEvent,
-  portRange,
   PROTOCOL_VERSION,
 } from '@figwright/shared';
 import {
@@ -56,7 +56,9 @@ const statusColor = {
 const appVersion = __APP_VERSION__;
 
 const client = new RelayClient({
-  ports: portRange(),
+  // The relay leader always binds DEFAULT_PORT — the server never hops to a fallback — so we probe
+  // exactly that one port. Scanning a range would only risk stalling on unrelated local services.
+  ports: [DEFAULT_PORT],
   clientVersion: appVersion,
   log: msg => console.log(msg),
 });

--- a/packages/plugin/ui/App.vue
+++ b/packages/plugin/ui/App.vue
@@ -142,6 +142,10 @@ useEventListener(globalThis, 'message', (event: MessageEvent) => {
   const msg = (event.data as { pluginMessage?: unknown } | null)?.pluginMessage;
   if (isPluginContextEvent(msg)) {
     context.value = msg;
+    // A context push is proof the user is active here right now — a throttle-immune signal (postMessage
+    // isn't clamped like background-tab timers). Nudge the relay to probe now in case a reconnect
+    // stalled while backgrounded; wake() no-ops when already connected.
+    client.wake();
     // Each context push from sandbox means the user just interacted (open / selection-change /
     // page-change). Tell the leader — params carry file/page identity so ping can report which
     // file is being routed instead of an opaque session id.
@@ -156,7 +160,13 @@ useEventListener(globalThis, 'message', (event: MessageEvent) => {
 // app (it's not per-tab), which is exactly the broadcast that made background files steal routing.
 // emitActivity's `visible` gate keeps the background side (going → hidden) silent.
 watch(visibility, v => {
-  if (v === 'visible') emitActivity();
+  if (v !== 'visible') return;
+  // Returning to the foreground unfreezes throttled timers. Browsers throttle (and after a few minutes
+  // freeze) timers in hidden tabs, so a reconnect back-off that began while the user switched away — the
+  // classic "opened the plugin, then launched the MCP client" flow — can stall long past when the server
+  // came up. Nudge the client to probe now so it connects immediately instead of waiting out that sleep.
+  client.wake();
+  emitActivity();
 });
 
 // Mirror the relay client's state into a ref — subscribe synchronously so the panel reflects the

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -203,19 +203,37 @@ export class RelayClient {
     if (!this.stopped) void this.runReconnectLoop();
   }
 
-  /** Probe each candidate port once; resolves true on the first successful hello, false if all fail. */
+  /**
+   * Probe every candidate port concurrently; resolve true on the first successful hello, false if
+   * all fail. Concurrent, not sequential: a port that accepts the socket but never answers hello
+   * costs a full helloTimeout, and probing one-by-one let a few such ports (e.g. unrelated local
+   * services squatting a fallback port) stall the whole sweep for helloTimeout×N — during which the
+   * real leader on :3055 stayed unreachable even though it was already up. Racing bounds a sweep to
+   * a single helloTimeout and cancels the losing probes the instant one wins.
+   */
   private async probeAllPorts(): Promise<boolean> {
-    for (const port of this.opts.ports) {
-      if (this.stopped) return false;
-      try {
-        // eslint-disable-next-line no-await-in-loop -- intentional sequential port probe
-        await this.attemptPort(port);
-        return true;
-      } catch (err) {
-        this.opts.log(`[relay-client] port ${port} failed: ${(err as Error).message}`);
-      }
+    if (this.stopped) return false;
+    const controller = new AbortController();
+    const probes = this.opts.ports.map(port =>
+      this.attemptPort(port, controller.signal).then(
+        () => {
+          // First hello wins — cancel the still-pending probes so no port holds a socket open.
+          controller.abort();
+          return true;
+        },
+        (err: unknown) => {
+          this.opts.log(`[relay-client] port ${port} failed: ${(err as Error).message}`);
+          // Stay rejected so Promise.any waits for a real success rather than settling on this miss.
+          throw err;
+        },
+      ),
+    );
+    try {
+      return await Promise.any(probes);
+    } catch {
+      // Every probe rejected — no server answered a hello on any candidate port.
+      return false;
     }
-    return false;
   }
 
   async disconnect(): Promise<void> {
@@ -247,7 +265,7 @@ export class RelayClient {
     this.settleBackoff(true);
   }
 
-  private attemptPort(port: number): Promise<void> {
+  private attemptPort(port: number, signal: AbortSignal): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const url = `ws://${this.opts.host}:${port}`;
       const ws = new this.opts.WS(url);
@@ -259,6 +277,7 @@ export class RelayClient {
         ws.onmessage = null;
         ws.onclose = null;
         clearTimeout(timer);
+        signal.removeEventListener('abort', onAbort);
       };
 
       const fail = (msg: string): void => {
@@ -275,6 +294,15 @@ export class RelayClient {
         () => fail(`hello timeout on port ${port}`),
         this.opts.helloTimeoutMs,
       );
+
+      // Another port won the concurrent sweep — abandon this probe now instead of holding the socket
+      // open until its hello timeout (that per-port stall is exactly what the concurrent probe fixes).
+      const onAbort = (): void => fail(`superseded on port ${port}`);
+      if (signal.aborted) {
+        fail(`superseded on port ${port}`);
+        return;
+      }
+      signal.addEventListener('abort', onAbort);
 
       ws.onopen = () => {
         const helloParams: HelloParams = {
@@ -319,6 +347,16 @@ export class RelayClient {
 
         const result = envelope.result as HelloResult;
         cleanup();
+        if (this.socket !== null || signal.aborted) {
+          // A concurrent probe already claimed the connection — drop this redundant socket.
+          try {
+            ws.close();
+          } catch {
+            /* ignore */
+          }
+          reject(new Error(`superseded on port ${port}`));
+          return;
+        }
         this.hasConnected = true;
         this.socket = ws;
         this.startHeartbeat(ws);

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -88,12 +88,15 @@ const DEFAULT_RECONNECT_MAX_DELAY_MS = 5_000;
 /**
  * Cold-start (never-yet-connected) polling is capped far tighter than a true reconnect: when the
  * plugin opened before the server, the user just launched their MCP client and the leader appears
- * within a second, so we want to notice almost immediately. Probing the single fixed port is a
- * sub-millisecond refused connection while nothing listens, so polling this fast is cheap. A
- * dropped live socket (hasConnected) keeps the gentler exponential ceiling instead — that's a real
- * fault, not an imminent arrival, so there's no reason to hammer it.
+ * within a second, so we want to notice almost immediately. This cap IS the residual latency — once
+ * the server is up the plugin connects on its next poll, so the wait averages half this value.
+ * Probing the single fixed port is a sub-microsecond refused connection while nothing listens, so
+ * polling this fast costs nothing (localhost has no push channel to announce the server — polling
+ * is the only way to notice an imminent arrival). A dropped live socket (hasConnected) keeps the
+ * gentler exponential ceiling instead — that's a real fault, not an imminent arrival, so no reason
+ * to hammer.
  */
-const COLD_START_MAX_DELAY_MS = 300;
+const COLD_START_MAX_DELAY_MS = 150;
 
 export class RelayClient {
   readonly sessionId: string;

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -79,6 +79,13 @@ export interface RelayClientOptions {
 const DEFAULT_HELLO_TIMEOUT_MS = 2_000;
 const DEFAULT_RECONNECT_INITIAL_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 5_000;
+/**
+ * Cold-start (never-yet-connected) back-off is capped tighter than a true reconnect. When the
+ * plugin opened before the server, the user just launched their MCP client and the leader appears
+ * within a second — a snappier ceiling means we notice it almost immediately instead of sitting out
+ * a long sleep. A dropped live socket (hasConnected) keeps the gentler ceiling.
+ */
+const COLD_START_MAX_DELAY_MS = 2_000;
 
 export class RelayClient {
   readonly sessionId: string;
@@ -99,6 +106,13 @@ export class RelayClient {
   private listeners = new Set<(s: RelayClientState) => void>();
   private stopped = false;
   private reconnecting = false;
+  /**
+   * The in-flight back-off sleep's timer + its resolver, so wake()/disconnect() can cut the sleep
+   * short and probe now (or exit). Both null whenever we're not mid-sleep (loop not started, or
+   * already probing). settleBackoff() is the single place either one resolves.
+   */
+  private wakeTimer: ReturnType<typeof setTimeout> | null = null;
+  private settleSleep: ((woken: boolean) => void) | null = null;
   /**
    * True once we've established at least one live socket — distinguishes a cold-start retry from a
    * true reconnect.
@@ -206,6 +220,9 @@ export class RelayClient {
 
   async disconnect(): Promise<void> {
     this.stopped = true;
+    // Cut short any in-flight back-off sleep so the reconnect loop sees `stopped` and exits now instead
+    // of waiting out the full delay.
+    this.settleBackoff(true);
     this.heartbeat?.stop();
     this.heartbeat = null;
     if (this.socket !== null) {
@@ -213,6 +230,21 @@ export class RelayClient {
       this.socket = null;
     }
     this.update({ status: 'disconnected', sessionResumed: false, connectedAt: null });
+  }
+
+  /**
+   * Cut the current reconnect back-off short and probe now. Browsers throttle — and after a few
+   * minutes of a hidden tab, freeze — timers, so a back-off sleep that began while the user
+   * switched away (e.g. to launch their MCP client) can stall long past when the server actually
+   * came up. The UI calls this when the plugin tab returns to the foreground (and on any sandbox
+   * context event) to collapse that dead time to ~immediate. No-op unless we're mid-reconnect: a
+   * live or in-progress connection needs no nudge, and after disconnect() there's nothing to
+   * resume.
+   */
+  wake(): void {
+    if (this.stopped) return;
+    if (this.state.status === 'connected' || this.state.status === 'connecting') return;
+    this.settleBackoff(true);
   }
 
   private attemptPort(port: number): Promise<void> {
@@ -421,18 +453,18 @@ export class RelayClient {
     this.reconnecting = true;
     // A live socket that dropped is a true reconnect; retrying a never-established cold-start connect
     // is not. Capture the distinction now so a successful retry only bumps `reconnectCount` in the
-    // former case (keeps the diagnostic count honest).
+    // former case (keeps the diagnostic count honest), and so cold-start uses the tighter ceiling —
+    // the server is imminent, so we probe more eagerly. (hasConnected only flips false→true, and a
+    // successful probe returns, so it's stable for this loop's lifetime.)
     const countSuccessAsReconnect = this.hasConnected;
+    const maxDelay = this.hasConnected ? this.opts.reconnectMaxDelayMs : COLD_START_MAX_DELAY_MS;
     try {
       let attempt = 0;
       while (!this.stopped) {
-        const delay = Math.min(
-          this.opts.reconnectInitialDelayMs * 2 ** attempt,
-          this.opts.reconnectMaxDelayMs,
-        );
+        const delay = Math.min(this.opts.reconnectInitialDelayMs * 2 ** attempt, maxDelay);
         this.update({ status: 'reconnecting' });
         // eslint-disable-next-line no-await-in-loop -- back-off pacing requires sequential awaits
-        await new Promise<void>(resolve => setTimeout(resolve, delay));
+        const woken = await this.backoffSleep(delay);
         if (this.stopped) return;
         // eslint-disable-next-line no-await-in-loop -- back-off pacing requires sequential awaits
         if (await this.probeAllPorts()) {
@@ -441,11 +473,42 @@ export class RelayClient {
           }
           return;
         }
-        attempt += 1;
+        // A wake (tab refocus) means the user is back and expecting a live connection — restart the
+        // back-off from the floor so we keep probing quickly rather than easing back to the ceiling.
+        attempt = woken ? 0 : attempt + 1;
       }
     } finally {
       this.reconnecting = false;
     }
+  }
+
+  /**
+   * Sleep `ms`, or resolve early if wake()/disconnect() fires. Resolves true when cut short, false
+   * on a natural timeout — the loop resets its back-off on a wake so a post-foreground probe starts
+   * fast.
+   */
+  private backoffSleep(ms: number): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      this.settleSleep = resolve;
+      this.wakeTimer = setTimeout(() => this.settleBackoff(false), ms);
+    });
+  }
+
+  /**
+   * Resolve the in-flight back-off sleep exactly once, from whichever source fires first — the
+   * timer (woken=false) or wake()/disconnect() (woken=true). Nulling `settleSleep` first makes it
+   * idempotent, so the losing source is a no-op. Also the single place the pending timer is
+   * cleared.
+   */
+  private settleBackoff(woken: boolean): void {
+    const resolve = this.settleSleep;
+    if (resolve === null) return;
+    this.settleSleep = null;
+    if (this.wakeTimer !== null) {
+      clearTimeout(this.wakeTimer);
+      this.wakeTimer = null;
+    }
+    resolve(woken);
   }
 
   private startHeartbeat(ws: WebSocket): void {

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -76,7 +76,13 @@ export interface RelayClientOptions {
   reconnectMaxDelayMs?: number;
 }
 
-const DEFAULT_HELLO_TIMEOUT_MS = 2_000;
+// How long a probe waits for the server's $hello reply before abandoning the socket and retrying. A
+// healthy leader answers in sub-millisecond on localhost, so a probe that stays silent this long isn't
+// a healthy server we're about to reach — it's a port owner mid-handoff (an old leader releasing :3055
+// as a new one takes over) or a momentarily CPU-starved event loop. Waiting the old 2s each such
+// attempt made a handoff feel like many seconds; 1s halves the per-retry waste while keeping a ~1000×
+// margin over a healthy reply, so we never abandon a server that was actually about to answer.
+const DEFAULT_HELLO_TIMEOUT_MS = 1_000;
 const DEFAULT_RECONNECT_INITIAL_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 5_000;
 /**

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -80,12 +80,14 @@ const DEFAULT_HELLO_TIMEOUT_MS = 2_000;
 const DEFAULT_RECONNECT_INITIAL_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 5_000;
 /**
- * Cold-start (never-yet-connected) back-off is capped tighter than a true reconnect. When the
+ * Cold-start (never-yet-connected) polling is capped far tighter than a true reconnect: when the
  * plugin opened before the server, the user just launched their MCP client and the leader appears
- * within a second — a snappier ceiling means we notice it almost immediately instead of sitting out
- * a long sleep. A dropped live socket (hasConnected) keeps the gentler ceiling.
+ * within a second, so we want to notice almost immediately. Probing the single fixed port is a
+ * sub-millisecond refused connection while nothing listens, so polling this fast is cheap. A
+ * dropped live socket (hasConnected) keeps the gentler exponential ceiling instead — that's a real
+ * fault, not an imminent arrival, so there's no reason to hammer it.
  */
-const COLD_START_MAX_DELAY_MS = 2_000;
+const COLD_START_MAX_DELAY_MS = 300;
 
 export class RelayClient {
   readonly sessionId: string;
@@ -204,36 +206,26 @@ export class RelayClient {
   }
 
   /**
-   * Probe every candidate port concurrently; resolve true on the first successful hello, false if
-   * all fail. Concurrent, not sequential: a port that accepts the socket but never answers hello
-   * costs a full helloTimeout, and probing one-by-one let a few such ports (e.g. unrelated local
-   * services squatting a fallback port) stall the whole sweep for helloTimeout×N — during which the
-   * real leader on :3055 stayed unreachable even though it was already up. Racing bounds a sweep to
-   * a single helloTimeout and cancels the losing probes the instant one wins.
+   * Probe the candidate port(s) in order; resolve true on the first successful hello, false if all
+   * fail. In production `ports` is just [DEFAULT_PORT]: figwright's leader always binds that one
+   * fixed port (the server never hops to a fallback), so there's no range to sweep — a miss simply
+   * means the server isn't up yet and the caller retries. Probing that single port is a
+   * sub-millisecond refused connection when nothing is listening, which is what lets the reconnect
+   * loop poll quickly without ever stalling on an unrelated service that happens to hold a nearby
+   * port.
    */
   private async probeAllPorts(): Promise<boolean> {
-    if (this.stopped) return false;
-    const controller = new AbortController();
-    const probes = this.opts.ports.map(port =>
-      this.attemptPort(port, controller.signal).then(
-        () => {
-          // First hello wins — cancel the still-pending probes so no port holds a socket open.
-          controller.abort();
-          return true;
-        },
-        (err: unknown) => {
-          this.opts.log(`[relay-client] port ${port} failed: ${(err as Error).message}`);
-          // Stay rejected so Promise.any waits for a real success rather than settling on this miss.
-          throw err;
-        },
-      ),
-    );
-    try {
-      return await Promise.any(probes);
-    } catch {
-      // Every probe rejected — no server answered a hello on any candidate port.
-      return false;
+    for (const port of this.opts.ports) {
+      if (this.stopped) return false;
+      try {
+        // eslint-disable-next-line no-await-in-loop -- probe candidate ports in order
+        await this.attemptPort(port);
+        return true;
+      } catch (err) {
+        this.opts.log(`[relay-client] port ${port} failed: ${(err as Error).message}`);
+      }
     }
+    return false;
   }
 
   async disconnect(): Promise<void> {
@@ -265,7 +257,7 @@ export class RelayClient {
     this.settleBackoff(true);
   }
 
-  private attemptPort(port: number, signal: AbortSignal): Promise<void> {
+  private attemptPort(port: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const url = `ws://${this.opts.host}:${port}`;
       const ws = new this.opts.WS(url);
@@ -277,7 +269,6 @@ export class RelayClient {
         ws.onmessage = null;
         ws.onclose = null;
         clearTimeout(timer);
-        signal.removeEventListener('abort', onAbort);
       };
 
       const fail = (msg: string): void => {
@@ -294,15 +285,6 @@ export class RelayClient {
         () => fail(`hello timeout on port ${port}`),
         this.opts.helloTimeoutMs,
       );
-
-      // Another port won the concurrent sweep — abandon this probe now instead of holding the socket
-      // open until its hello timeout (that per-port stall is exactly what the concurrent probe fixes).
-      const onAbort = (): void => fail(`superseded on port ${port}`);
-      if (signal.aborted) {
-        fail(`superseded on port ${port}`);
-        return;
-      }
-      signal.addEventListener('abort', onAbort);
 
       ws.onopen = () => {
         const helloParams: HelloParams = {
@@ -347,16 +329,6 @@ export class RelayClient {
 
         const result = envelope.result as HelloResult;
         cleanup();
-        if (this.socket !== null || signal.aborted) {
-          // A concurrent probe already claimed the connection — drop this redundant socket.
-          try {
-            ws.close();
-          } catch {
-            /* ignore */
-          }
-          reject(new Error(`superseded on port ${port}`));
-          return;
-        }
         this.hasConnected = true;
         this.socket = ws;
         this.startHeartbeat(ws);

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,10 +1,9 @@
 export const PROTOCOL_VERSION = '0.1.0';
 
+// The relay leader always binds this one fixed port. The election never hops to a fallback: a node
+// that can't bind it becomes a follower (which listens on nothing), so the plugin only ever needs to
+// reach DEFAULT_PORT. There is deliberately no port range to scan.
 export const DEFAULT_PORT = 3055;
-export const PORT_FALLBACK_COUNT = 10;
-
-export const portRange = (): number[] =>
-  Array.from({ length: PORT_FALLBACK_COUNT }, (_, i) => DEFAULT_PORT + i);
 
 export const ErrorCode = {
   InvalidRequest: 'INVALID_REQUEST',


### PR DESCRIPTION
Fixes the long-standing "open the plugin, then launch the MCP client, and the plugin sits in `Connecting…`/`Reconnecting…` for a while (sometimes needs `mcp reconnect`)" problem. The plugin↔relay connection lagged far behind the client↔server (stdio) one.

## Root cause (confirmed from a live plugin console log)

The client scanned a **range** of ports (`3055..3064`) looking for the relay. But the relay leader **always binds the one fixed `DEFAULT_PORT` (3055)** — the election never hops to a fallback (a node that can't bind 3055 becomes a follower, which listens on nothing). So scanning `3056..3064` could never find figwright; its only real effect was hitting **unrelated local services** that happened to hold those ports:

```
port 3059 failed: hello timeout on port 3059
port 3060 failed: hello timeout on port 3060
... (each foreign port costs a full 2s hello timeout) ...
connected to :3055
```

Every *failed* sweep waited ~10s on those dead ports, so even after `:3055` came up the plugin stayed stuck until the sweep finished. (Secondary factor: Chromium throttles/freezes timers in a hidden Figma tab, stretching the reconnect back-off while the user is away launching the client.)

## Fix — probe only the leader's fixed port, poll it cheaply

- **Only probe `:3055`.** `App.vue` passes `ports: [DEFAULT_PORT]`; `portRange` / `PORT_FALLBACK_COUNT` are removed. A miss is a sub-millisecond refused connection — it never stalls on whatever squats a nearby port. **(This is the core fix.)**
- **Fast cold-start polling.** Because probing one port is so cheap, the never-yet-connected back-off caps at **300ms** (was 2s), so the plugin connects ~immediately once the server appears. A true reconnect (a dropped live socket — a real fault) keeps the gentler 5s ceiling.
- **Foreground `wake()`.** `RelayClient.wake()` cuts an in-flight back-off short and re-probes; the UI calls it on `visibilitychange → visible` and on any sandbox context event (throttle-immune signals), covering the hidden-tab case. No-ops while connected and never claims routing, so the visible-gated routing invariant holds.

Earlier commits in this branch tried a concurrent sweep of the whole range; that only *masked* the stall (a failed sweep still waited for the slowest port) and added fragile multi-socket race machinery. Probing the single real port is both simpler and strictly more stable.

## Not in scope

Hardening against `:3055` itself being taken by a foreign process needs a real **server + client port-hop** (the server would bind a fallback and advertise it; the client would identify the true leader by hello). Today that scenario is already broken regardless of client scanning (the server can't bind and becomes a stuck follower), so removing the scan loses no real protection. Tracked as a separate, needs-driven item.

## Testing

- `typecheck`, `lint`, `format:check`, `knip`, `build` all green.
- `pnpm test` — **716 passed**, including: a plugin opened before the server auto-connects once it appears; `wake()` cuts the cold-start back-off short and connects immediately; `wake()` is a no-op while connected.
- Manual: reload the plugin, open it before the server, and it connects to `:3055` within ~300ms of the server coming up.