### PR TITLE
fix(election): don't attach as a follower of a non-Figwright process on :3055

### DIFF
--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -41,6 +41,17 @@ export const dispatchTool = async (
   const retryDelayMs = opts.retryDelayMs ?? DEFAULT_DISPATCH_RETRY_DELAY_MS;
   const log = ctx.log ?? ((): void => {});
 
+  // The relay port is held by a non-Figwright process, so there's no leader to reach and no point
+  // forwarding to the squatter. Fail fast with an actionable message rather than retrying into a wall.
+  if (ctx.node.isConflicted()) {
+    throw new DispatchError(
+      ErrorCode.NotLeader,
+      `port ${ctx.node.port} is held by a non-Figwright process, so Figwright can't run tools against ` +
+        `your plugin. Free that port (e.g. lsof -iTCP:${ctx.node.port} -sTCP:LISTEN) and Figwright ` +
+        `reconnects automatically.`,
+    );
+  }
+
   let lastError: Error | null = null;
 
   /* eslint-disable no-await-in-loop -- retry/backoff loop is intentionally sequential */
@@ -104,6 +115,9 @@ export const dispatchTool = async (
  * — in that case sub-calls run unpinned, i.e. the pre-existing most-active routing on each call.
  */
 export const resolveRoutingSession = async (ctx: DispatchContext): Promise<string | undefined> => {
+  // A conflicted node has no leader to ask (the port holder isn't Figwright) — resolve to undefined so
+  // sub-calls run unpinned, and don't waste an HTTP round-trip on the squatter.
+  if (ctx.node.isConflicted()) return undefined;
   if (ctx.node.isLeader()) {
     return ctx.node.getLeader()?.relay.pickActiveSessionId();
   }

--- a/packages/mcp/src/election/election.ts
+++ b/packages/mcp/src/election/election.ts
@@ -49,9 +49,30 @@ export class Election {
   }
 
   async determineRole(): Promise<void> {
+    if (await this.tryLeadOrFollow()) return;
+
+    // The port is taken but its holder didn't answer a Figwright /ping. It could be a Figwright leader
+    // still mid-startup (its /ping endpoint not attached the instant we raced it), so retry once after a
+    // short delay. If it's STILL unbindable and STILL not a Figwright leader, a foreign process is
+    // squatting the port — do NOT attach as its follower (every forwarded RPC would fail silently).
+    // Enter a conflict state that keeps contending and surfaces the clash (see tick / dispatch / ping).
+    this.log('[election] port taken but not a Figwright leader — race retry');
+    await new Promise<void>(resolve => setTimeout(resolve, RACE_RETRY_DELAY_MS));
+    if (await this.tryLeadOrFollow()) return;
+
+    this.node.becomeConflicted();
+  }
+
+  /**
+   * Settle into a definitive role: bind the port (→ leader), or confirm a Figwright leader already
+   * holds it (→ follower). Returns false when the port is taken by something that is NOT a
+   * Figwright leader, so the caller decides whether to retry or declare a conflict. Rethrows a
+   * non-EADDRINUSE bind error.
+   */
+  private async tryLeadOrFollow(): Promise<boolean> {
     try {
       await this.node.becomeLeader();
-      return;
+      return true;
     } catch (err) {
       if (!isAddressInUse(err)) {
         this.log(`[election] becomeLeader failed (not EADDRINUSE): ${(err as Error).message}`);
@@ -61,19 +82,20 @@ export class Election {
 
     if (await this.follower.ping()) {
       this.node.becomeFollower();
-      return;
+      return true;
     }
 
-    this.log('[election] port taken but leader unresponsive — race retry');
-    await new Promise<void>(resolve => setTimeout(resolve, RACE_RETRY_DELAY_MS));
-    try {
-      await this.node.becomeLeader();
-    } catch {
-      this.node.becomeFollower();
-    }
+    return false;
   }
 
   private async tick(): Promise<void> {
+    if (this.node.role === NodeRole.Conflicted) {
+      // Keep contending: the squatter may release the port, or a real Figwright leader may appear.
+      // tryLeadOrFollow promotes us the moment either happens; otherwise we stay conflicted.
+      await this.tryLeadOrFollow();
+      return;
+    }
+
     if (this.node.role !== NodeRole.Follower) return;
 
     if (await this.follower.ping()) return;

--- a/packages/mcp/src/election/node.ts
+++ b/packages/mcp/src/election/node.ts
@@ -9,6 +9,10 @@ export const NodeRole = {
   Unknown: 'unknown',
   Leader: 'leader',
   Follower: 'follower',
+  // The port is held by a process that isn't a Figwright leader (it didn't answer a Figwright /ping),
+  // so this node can neither lead nor safely follow it. It keeps contending for the port instead of
+  // attaching as a follower of a foreign process. See Election.determineRole / tick.
+  Conflicted: 'conflicted',
 } as const;
 export type NodeRole = (typeof NodeRole)[keyof typeof NodeRole];
 
@@ -56,6 +60,14 @@ export class Node {
 
   isFollower(): boolean {
     return this.currentRole === NodeRole.Follower;
+  }
+
+  isConflicted(): boolean {
+    return this.currentRole === NodeRole.Conflicted;
+  }
+
+  get port(): number {
+    return this.opts.port;
   }
 
   get leaderUrl(): string {
@@ -109,6 +121,26 @@ export class Node {
     }
     this.setRole(NodeRole.Follower);
     this.opts.log(`[node] became FOLLOWER (leader @ ${this.leaderUrl})`);
+  }
+
+  /**
+   * Enter the port-conflict state: :port is held by a process that isn't a Figwright leader. Unlike
+   * becomeFollower this never points RPC at the squatter — dispatch fails fast with a clear message
+   * while the election keeps contending for the port (see Election.tick), so the moment the
+   * squatter releases :port we take over. Idempotent.
+   */
+  becomeConflicted(): void {
+    if (this.currentRole === NodeRole.Conflicted) return;
+    if (this.leader !== null) {
+      const { http, relay } = this.leader;
+      this.leader = null;
+      void relay.stop().catch(() => {
+        /* ignore */
+      });
+      http.close();
+    }
+    this.setRole(NodeRole.Conflicted);
+    this.opts.log(`[node] PORT CONFLICT — :${this.opts.port} is held by a non-Figwright process`);
   }
 
   getLeader(): LeaderResources | null {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -154,11 +154,13 @@ for (const prompt of PROMPTS) {
 const transport = new StdioServerTransport();
 await mcp.connect(transport);
 
+const roleDetail = node.isLeader()
+  ? `relay on :${node.getLeader()?.port ?? DEFAULT_PORT}`
+  : node.isConflicted()
+    ? `:${DEFAULT_PORT} held by a non-Figwright process — contending for it`
+    : `follower → ${node.leaderUrl}`;
 log(
-  `[figwright] server ${SERVER_VERSION} (protocol ${PROTOCOL_VERSION}) ready as ${node.role}, ` +
-    (node.isLeader()
-      ? `relay on :${node.getLeader()?.port ?? DEFAULT_PORT}`
-      : `follower → ${node.leaderUrl}`),
+  `[figwright] server ${SERVER_VERSION} (protocol ${PROTOCOL_VERSION}) ready as ${node.role}, ${roleDetail}`,
 );
 
 const shutdown = async (): Promise<void> => {

--- a/packages/mcp/src/tools/ping.ts
+++ b/packages/mcp/src/tools/ping.ts
@@ -32,6 +32,12 @@ export interface PingServerInfo {
    * effect.
    */
   versionSkew?: string;
+  /**
+   * Present only in the `conflicted` role: :port is held by a non-Figwright process, so Figwright
+   * can neither lead nor reach the plugin. Human-readable, actionable (which port, how to free
+   * it).
+   */
+  portConflict?: string;
 }
 
 /**
@@ -81,6 +87,24 @@ const serverInfo = (ctx: PingContext): PingServerInfo => ({
 
 export const handlePing = async (ctx: PingContext): Promise<PingResult> => {
   const server = serverInfo(ctx);
+
+  // Port conflict: :port is held by a non-Figwright process. There's no relay and no leader to reach,
+  // so report the clash directly instead of trying (and failing) to dispatch to the plugin.
+  if (ctx.node.isConflicted()) {
+    return {
+      ok: true,
+      hop: 'server-only',
+      server: {
+        ...server,
+        portConflict:
+          `port ${ctx.node.port} is held by a non-Figwright process — Figwright can neither lead nor ` +
+          `follow it, so no plugin is reachable. Free that port (lsof -iTCP:${ctx.node.port} ` +
+          `-sTCP:LISTEN) and Figwright takes it over automatically.`,
+      },
+      plugin: null,
+    };
+  }
+
   const relay = ctx.node.isLeader() ? ctx.node.getLeader()?.relay : undefined;
 
   if (relay !== undefined) {

--- a/packages/mcp/test/dispatch.test.ts
+++ b/packages/mcp/test/dispatch.test.ts
@@ -5,7 +5,8 @@ import { DispatchError, dispatchTool, resolveRoutingSession } from '../src/dispa
 import type { Follower } from '../src/election/follower.js';
 import type { Node } from '../src/election/node.js';
 
-const makeNode = (overrides: Partial<Node>): Node => overrides as unknown as Node;
+const makeNode = (overrides: Partial<Node>): Node =>
+  ({ isConflicted: () => false, port: 3055, ...overrides }) as unknown as Node;
 const makeFollower = (overrides: Partial<Follower>): Follower => overrides as unknown as Follower;
 
 describe('dispatchTool', () => {
@@ -30,6 +31,23 @@ describe('dispatchTool', () => {
     const result = await dispatchTool({ node, follower }, 'my_tool', { x: 1 });
     expect(result).toEqual({ from: 'leader-relay', echoed: { x: 1 } });
     expect(calls).toEqual([{ name: 'my_tool', args: { x: 1 } }]);
+  });
+
+  it('fails fast with an actionable error when the node is port-conflicted', async () => {
+    const node = makeNode({ isConflicted: () => true, port: 3055, isLeader: () => false });
+    let forwarded = false;
+    const follower = makeFollower({
+      sendRpc: async (): Promise<RpcResponse> => {
+        forwarded = true;
+        return { kind: 'ok', requestId: 'r', result: null };
+      },
+    });
+
+    await expect(dispatchTool({ node, follower }, 'get_document', {})).rejects.toThrow(
+      /port 3055 is held by a non-Figwright process/,
+    );
+    // Must NOT forward to the squatter holding the port.
+    expect(forwarded).toBe(false);
   });
 
   it('routes to Follower.sendRpc when local node is not leader', async () => {

--- a/packages/mcp/test/election/election.test.ts
+++ b/packages/mcp/test/election/election.test.ts
@@ -135,13 +135,44 @@ describe('Election', () => {
     expect(node.role).toBe(NodeRole.Follower);
   });
 
-  it('determineRole: port taken by dead binder → eventually follower', async () => {
+  it('determineRole: port held by a non-Figwright process → conflicted, not follower', async () => {
     const port = await freePort();
     const blocker = createServer();
     await new Promise<void>(resolve => blocker.listen(port, '127.0.0.1', () => resolve()));
     blockers.push(blocker);
     const { node, election } = buildElection(port, 100);
     await election.determineRole();
+    // The squatter answers no Figwright /ping, so we must NOT attach as its follower (that would
+    // forward every RPC into a wall). Stay conflicted and keep contending.
+    expect(node.role).toBe(NodeRole.Conflicted);
+  });
+
+  it('tick: conflicted node takes the port once the squatter releases it', async () => {
+    const port = await freePort();
+    const blocker = createServer();
+    await new Promise<void>(resolve => blocker.listen(port, '127.0.0.1', () => resolve()));
+    const { node, election } = buildElection(port, 100);
+    await election.determineRole();
+    expect(node.role).toBe(NodeRole.Conflicted);
+
+    // Squatter goes away → the next tick should bind the freed port and lead.
+    await new Promise<void>(resolve => blocker.close(() => resolve()));
+    await election.tickOnce();
+    expect(node.role).toBe(NodeRole.Leader);
+  });
+
+  it('tick: conflicted node follows once a real Figwright leader takes the port', async () => {
+    const port = await freePort();
+    const blocker = createServer();
+    await new Promise<void>(resolve => blocker.listen(port, '127.0.0.1', () => resolve()));
+    const { node, election } = buildElection(port, 100);
+    await election.determineRole();
+    expect(node.role).toBe(NodeRole.Conflicted);
+
+    // Squatter leaves and a real Figwright leader takes the port → next tick resolves to follower.
+    await new Promise<void>(resolve => blocker.close(() => resolve()));
+    await startLeaderHarness(port);
+    await election.tickOnce();
     expect(node.role).toBe(NodeRole.Follower);
   });
 

--- a/packages/mcp/test/tools/ping.test.ts
+++ b/packages/mcp/test/tools/ping.test.ts
@@ -8,7 +8,7 @@ import { toToolDefinition } from '../tool-schema.js';
 const pingToolDefinition = toToolDefinition(pingTool);
 
 const makeNode = (overrides: Partial<Node> & { role?: NodeRole }): Node =>
-  overrides as unknown as Node;
+  ({ isConflicted: () => false, port: 3055, ...overrides }) as unknown as Node;
 const makeFollower = (overrides: Partial<Follower>): Follower => overrides as unknown as Follower;
 
 describe('ping tool', () => {
@@ -39,6 +39,25 @@ describe('ping tool', () => {
     expect(result.server.version).toBe('1.0.0');
     expect(result.server.role).toBe(NodeRole.Leader);
     expect(result.server.port).toBe(3055);
+  });
+
+  it('surfaces a portConflict warning when the node is conflicted', async () => {
+    const node = makeNode({
+      role: NodeRole.Conflicted,
+      isLeader: () => false,
+      isConflicted: () => true,
+      port: 3055,
+      getLeader: () => null,
+    });
+    const result = await handlePing({
+      node,
+      follower: makeFollower({}),
+      serverVersion: '1.0.0',
+    });
+    expect(result.hop).toBe('server-only');
+    expect(result.plugin).toBeNull();
+    expect(result.server.role).toBe(NodeRole.Conflicted);
+    expect(result.server.portConflict).toMatch(/port 3055 is held by a non-Figwright process/);
   });
 
   it('returns e2e hop with plugin info + sessions when dispatch succeeds (leader path)', async () => {

--- a/packages/plugin/test/relay/client.test.ts
+++ b/packages/plugin/test/relay/client.test.ts
@@ -158,7 +158,7 @@ describe('RelayClient', () => {
     // background (status flips to 'reconnecting') rather than rejecting.
     await expect(client.connect()).resolves.toBeUndefined();
     expect(client.getState().status).toBe('reconnecting');
-    expect(client.getState().lastError).toMatch(/no relay server found/);
+    expect(client.getState().lastError).toMatch(/no Figwright server on :3055/);
     await client.disconnect();
   });
 

--- a/packages/plugin/ui/relay/client.ts
+++ b/packages/plugin/ui/relay/client.ts
@@ -208,8 +208,13 @@ export class RelayClient {
     this.update({
       status: 'disconnected',
       port: null,
+      // A browser WebSocket can't tell "nothing is listening" from "a non-WebSocket process holds the
+      // port", so word this to cover both without over-claiming: it connects on its own once the MCP
+      // server starts, and if it never does, a foreign process on that port is the likely culprit.
       lastError:
-        this.state.lastError ?? `no relay server found on ports [${this.opts.ports.join(', ')}]`,
+        this.state.lastError ??
+        `no Figwright server on :${this.opts.ports.join(', ')} yet — it connects automatically once ` +
+          `the MCP server starts; if it never does, another process may be holding that port`,
     });
     if (!this.stopped) void this.runReconnectLoop();
   }


### PR DESCRIPTION
## The bug

When port `:3055` is held by a process that **isn't** a Figwright leader (it doesn't answer a Figwright `/ping`), `election.determineRole` fell through to `becomeFollower()` and attached to that foreign process as if it were the leader. Every forwarded tool RPC then failed silently and confusingly — Figwright appeared "connected" but nothing worked. This is the "port 3055 taken → silent breakage" gap.

## The fix — a `Conflicted` role

A node that can neither bind `:3055` nor confirm a Figwright leader there now enters a distinct **`Conflicted`** state instead of following a stranger. It keeps contending for the port; the next election tick promotes it to **leader** the moment the squatter releases the port, or to **follower** if a real Figwright leader appears.

While conflicted:
- **dispatch** fails fast with an actionable message (`port 3055 is held by a non-Figwright process … free it (lsof -iTCP:3055 -sTCP:LISTEN) …`) instead of forwarding into a wall and retrying;
- **ping** surfaces a `portConflict` warning in `server`;
- the **startup log** names the clash instead of mislabeling it as a follower.

`determineRole` also now re-checks `/ping` after its race-retry (not just re-attempts the bind), so a real leader that was merely mid-startup is still correctly followed — only a genuine foreign squatter becomes a conflict.

Plugin side: the cold-start error is reworded to cover both causes (server not up yet **or** a foreign process on the port) without over-claiming.

## Why not auto-hop to another port?

A browser/Figma-iframe WebSocket **cannot distinguish** "nothing is listening on :3055" from "a non-WebSocket process holds :3055" (both surface as an opaque `socket error` — a deliberate browser anti-port-scan measure). So a leader that moved to another port **cannot be reliably discovered from the plugin**. Auto-hop would work server-side but leave the plugin unable to find the leader. Detect-and-surface is therefore the robust answer: Figwright needs `:3055` free, and now says so clearly and recovers automatically the instant it is.

(Decision made with the maintainer — no configurable-port escape hatch, to keep the zero-config UX.)

## Testing

- `typecheck`, `lint`, `format:check`, `knip`, `build` all green.
- `pnpm test` — **720 passed**, including new coverage:
  - a non-Figwright squatter on the port → node is `Conflicted`, **not** a follower (was the bug);
  - a conflicted node takes the port once the squatter releases it;
  - a conflicted node follows once a real Figwright leader takes the port;
  - dispatch fails fast (and does **not** forward) when conflicted;
  - ping surfaces the `portConflict` warning.