### PR TITLE
feat: surface layout grids, dashed strokes & rich-text structure; add set_layout_grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **93 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **94 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **93 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **94 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/src/tools/create-grid-style.ts
+++ b/packages/mcp/src/tools/create-grid-style.ts
@@ -20,6 +20,7 @@ export const createGridStyleTool: ToolSpec = {
         count: z.number().optional(),
         gutterSize: z.number().optional(),
         alignment: z.enum(['MIN', 'MAX', 'CENTER', 'STRETCH']).optional(),
+        offset: z.number().optional(),
       }),
     ),
     description: z.string().optional(),

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -81,6 +81,7 @@ import { setCornerRadiusTool } from './set-corner-radius.js';
 import { setEffectsTool } from './set-effects.js';
 import { setFillsTool } from './set-fills.js';
 import { setInstancePropertiesTool } from './set-instance-properties.js';
+import { setLayoutGridsTool } from './set-layout-grids.js';
 import { setLayoutPropsTool } from './set-layout-props.js';
 import { setMaskTool } from './set-mask.js';
 import { setOpacityTool } from './set-opacity.js';
@@ -149,6 +150,7 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   resizeNodesTool,
   setAutoLayoutTool,
   setLayoutPropsTool,
+  setLayoutGridsTool,
   setBlendModeTool,
   setMaskTool,
   setArcTool,

--- a/packages/mcp/src/tools/set-layout-grids.ts
+++ b/packages/mcp/src/tools/set-layout-grids.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const SET_LAYOUT_GRIDS_TOOL_NAME = 'set_layout_grids';
+
+export const setLayoutGridsTool: ToolSpec = {
+  name: SET_LAYOUT_GRIDS_TOOL_NAME,
+  description:
+    "Set a frame's own layout grids — the responsive column/row scaffold laid over it (the 12-column " +
+    'grid, the 8pt baseline), distinct from auto-layout (set_auto_layout arranges children). Each ' +
+    'grid is COLUMNS / ROWS (count + gutterSize + alignment, e.g. a 12-col grid) or GRID (uniform ' +
+    "squares via sectionSize, a baseline). Replaces the frame's grids with the array given; pass [] " +
+    'to clear them. Only frames (and components/instances) carry layout grids. Returns { ok, nodeId }.',
+  inputShape: {
+    nodeId: z.string().describe('Frame (or component/instance) node id'),
+    grids: z
+      .array(
+        z.object({
+          pattern: z.enum(['GRID', 'ROWS', 'COLUMNS']),
+          visible: z.boolean(),
+          sectionSize: z
+            .number()
+            .optional()
+            .describe('Cell size for GRID; section size for ROWS/COLUMNS (ignored when STRETCH)'),
+          count: z.number().optional().describe('Number of columns/rows (ROWS/COLUMNS)'),
+          gutterSize: z.number().optional().describe('Gap between columns/rows (ROWS/COLUMNS)'),
+          alignment: z.enum(['MIN', 'MAX', 'CENTER', 'STRETCH']).optional(),
+        }),
+      )
+      .describe('Layout grids to set; [] clears all grids on the frame'),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/set-layout-grids.ts
+++ b/packages/mcp/src/tools/set-layout-grids.ts
@@ -26,6 +26,10 @@ export const setLayoutGridsTool: ToolSpec = {
           count: z.number().optional().describe('Number of columns/rows (ROWS/COLUMNS)'),
           gutterSize: z.number().optional().describe('Gap between columns/rows (ROWS/COLUMNS)'),
           alignment: z.enum(['MIN', 'MAX', 'CENTER', 'STRETCH']).optional(),
+          offset: z
+            .number()
+            .optional()
+            .describe('Page margin from the frame edge (ignored when CENTER)'),
         }),
       )
       .describe('Layout grids to set; [] clears all grids on the frame'),

--- a/packages/plugin/src/handlers/convert.ts
+++ b/packages/plugin/src/handlers/convert.ts
@@ -45,7 +45,7 @@ export const toFigmaLayoutGrid = (g: SerializedLayoutGrid): LayoutGrid => {
       alignment: g.alignment ?? 'STRETCH',
       gutterSize: g.gutterSize ?? 0,
       count: g.count ?? 1,
-      offset: 0,
+      offset: g.offset ?? 0,
       ...(g.sectionSize === undefined ? {} : { sectionSize: g.sectionSize }),
     } as LayoutGrid;
   }

--- a/packages/plugin/src/handlers/convert.ts
+++ b/packages/plugin/src/handlers/convert.ts
@@ -39,13 +39,16 @@ export const toFigmaLayoutGrid = (g: SerializedLayoutGrid): LayoutGrid => {
     return { pattern: 'GRID', visible: g.visible, sectionSize: g.sectionSize ?? 10 };
   }
   if (g.pattern === 'ROWS' || g.pattern === 'COLUMNS') {
+    const alignment = g.alignment ?? 'STRETCH';
     return {
       pattern: g.pattern,
       visible: g.visible,
-      alignment: g.alignment ?? 'STRETCH',
+      alignment,
       gutterSize: g.gutterSize ?? 0,
       count: g.count ?? 1,
-      offset: g.offset ?? 0,
+      // Figma rejects `offset` on a CENTER grid at runtime (it's ignored there) — only MIN/MAX/STRETCH
+      // accept it. Omit it for CENTER so a valid centered grid isn't rejected for carrying the key.
+      ...(alignment === 'CENTER' ? {} : { offset: g.offset ?? 0 }),
       ...(g.sectionSize === undefined ? {} : { sectionSize: g.sectionSize }),
     } as LayoutGrid;
   }

--- a/packages/plugin/src/handlers/get-design-context.ts
+++ b/packages/plugin/src/handlers/get-design-context.ts
@@ -76,6 +76,9 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
   if (flat.strokeWeight !== undefined) out.strokeWeight = flat.strokeWeight;
   if (flat.strokeWeights !== undefined) out.strokeWeights = flat.strokeWeights;
   if (flat.strokeAlign !== undefined) out.strokeAlign = flat.strokeAlign;
+  if (flat.dashPattern !== undefined) out.dashPattern = flat.dashPattern;
+  if (flat.strokeCap !== undefined) out.strokeCap = flat.strokeCap;
+  if (flat.strokeJoin !== undefined) out.strokeJoin = flat.strokeJoin;
   if (flat.effects !== undefined) out.effects = flat.effects;
   // Auto-layout / positioning — surfaced here (not just get_node) so codegen reads exact padding /
   // gap / justify / align / grid placement instead of inferring them from x/y/w/h geometry.
@@ -90,6 +93,10 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
   if (flat.gridChild !== undefined) out.gridChild = flat.gridChild;
   if (flat.constraints !== undefined) out.constraints = flat.constraints;
   if (flat.clipsContent !== undefined) out.clipsContent = flat.clipsContent;
+  // A frame's own layout grids (the explicit responsive column system) + scroll overflow — ground
+  // truth for breakpoints that codegen otherwise infers from geometry.
+  if (flat.layoutGrids !== undefined) out.layoutGrids = flat.layoutGrids;
+  if (flat.overflowDirection !== undefined) out.overflowDirection = flat.overflowDirection;
   if (flat.characters !== undefined) out.characters = flat.characters;
   if (flat.fontSize !== undefined) out.fontSize = flat.fontSize;
   if (flat.fontName !== undefined) out.fontName = flat.fontName;
@@ -118,21 +125,32 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
     out.textTruncation = flat.textTruncation;
   }
   if (typeof flat.maxLines === 'number') out.maxLines = flat.maxLines;
+  // A node-level hyperlink (whole text is one link → <a href>); partial links ride in segments below.
+  if (flat.hyperlink !== undefined) out.hyperlink = flat.hyperlink;
   // Per-run styling of a mixed TEXT node — serializeFlatSync already computed this (only set when the
-  // node is genuinely mixed), get_design_context just used to drop it. Carry it so inline bold / links
-  // / coloured spans survive instead of collapsing to a single `mixed` marker. fills are simplified to
-  // hex like every other paint in this view.
+  // node is genuinely mixed, carries a partial link, or is a list), get_design_context just used to
+  // drop it. Carry it so inline bold / links / list items survive instead of collapsing to a single
+  // `mixed` marker. fills are simplified to hex like every other paint in this view; the structural
+  // per-run fields (hyperlink / listOptions / indentation) and leading/tracking pass through as-is.
   if (flat.segments !== undefined) {
-    out.segments = flat.segments.map(s => ({
-      characters: s.characters,
-      start: s.start,
-      end: s.end,
-      fontName: s.fontName,
-      fontSize: s.fontSize,
-      fills: s.fills.map(simplifyPaint),
-      textDecoration: s.textDecoration,
-      textCase: s.textCase,
-    }));
+    out.segments = flat.segments.map(s => {
+      const seg: NonNullable<DesignContextNode['segments']>[number] = {
+        characters: s.characters,
+        start: s.start,
+        end: s.end,
+        fontName: s.fontName,
+        fontSize: s.fontSize,
+        fills: s.fills.map(simplifyPaint),
+        textDecoration: s.textDecoration,
+        textCase: s.textCase,
+      };
+      if (s.lineHeight !== undefined) seg.lineHeight = s.lineHeight;
+      if (s.letterSpacing !== undefined) seg.letterSpacing = s.letterSpacing;
+      if (s.hyperlink !== undefined) seg.hyperlink = s.hyperlink;
+      if (s.listOptions !== undefined) seg.listOptions = s.listOptions;
+      if (s.indentation !== undefined) seg.indentation = s.indentation;
+      return seg;
+    });
   }
   // Grounding fields (M3 P1): surface what serializeFlatSync already captured but
   // get_design_context used to drop. id→token-name resolution lands in P2 (top-level maps below);

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -73,6 +73,7 @@ import { createSetCornerRadiusHandler } from './set-corner-radius.js';
 import { createSetEffectsHandler } from './set-effects.js';
 import { createSetFillsHandler } from './set-fills.js';
 import { createSetInstancePropertiesHandler } from './set-instance-properties.js';
+import { createSetLayoutGridsHandler } from './set-layout-grids.js';
 import { createSetLayoutPropsHandler } from './set-layout-props.js';
 import { createSetMaskHandler } from './set-mask.js';
 import { createSetOpacityHandler } from './set-opacity.js';
@@ -115,6 +116,7 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     resize_nodes: createResizeNodesHandler(figmaCtx),
     set_auto_layout: createSetAutoLayoutHandler(figmaCtx),
     set_layout_props: createSetLayoutPropsHandler(figmaCtx),
+    set_layout_grids: createSetLayoutGridsHandler(figmaCtx),
     set_position: createSetPositionHandler(figmaCtx),
     set_blend_mode: createSetBlendModeHandler(figmaCtx),
     set_mask: createSetMaskHandler(figmaCtx),

--- a/packages/plugin/src/handlers/set-layout-grids.ts
+++ b/packages/plugin/src/handlers/set-layout-grids.ts
@@ -1,0 +1,37 @@
+import type { MutateResult, SerializedLayoutGrid } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { toFigmaLayoutGrid } from './convert.js';
+
+/**
+ * Replace a frame's own layout grids (its responsive column/row scaffold) — the mirror of the
+ * `layoutGrids` read field. Distinct from auto-layout: this is the visual grid overlaid on the
+ * frame (the 12-col system, the 8pt baseline), not the arrangement of children. Only BaseFrameMixin
+ * nodes (FRAME / COMPONENT / COMPONENT_SET / INSTANCE) carry `layoutGrids`. Passing `[]` clears
+ * them.
+ */
+export const createSetLayoutGridsHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; grids?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('set_layout_grids: nodeId must be a string');
+    }
+    if (!Array.isArray(p.grids)) {
+      throw new TypeError('set_layout_grids: grids must be an array');
+    }
+
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !('layoutGrids' in node)) {
+      throw new Error(
+        `set_layout_grids: node ${p.nodeId} not found or does not support layout grids`,
+      );
+    }
+
+    (node as BaseFrameMixin).layoutGrids = (p.grids as SerializedLayoutGrid[]).map(
+      toFigmaLayoutGrid,
+    );
+
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -536,14 +536,17 @@ const enrichWithMixins = (node: SceneNode, base: SerializedNode): SerializedNode
     if (link !== null && !linkMixed && typeof link === 'object') {
       out.hyperlink = { type: link.type, value: link.value };
     }
-    // A list carries no node-level accessor, so probe once (cheap range read) to know whether the
-    // text is bulleted/numbered. A uniform list has uniform style → wouldn't trip the style-mix test,
-    // yet its <ol>/<ul> structure must survive; segments (split on listOptions/indentation) recover it
-    // — a flat uniform list stays a single segment, a nested one splits by depth.
-    const len = typeof text.characters === 'string' ? text.characters.length : 0;
+    // A list carries no node-level accessor, so probe (a cheap range read) to know whether the text is
+    // bulleted/numbered — a uniform list has uniform style and wouldn't trip the style-mix test, yet
+    // its <ol>/<ul> structure must survive; segments (split on listOptions/indentation) recover it.
+    // Gate the probe on a hard line break: a list is inherently multi-line (one paragraph per item),
+    // so single-line text (the bulk of nodes — labels, buttons, headings) can't be a meaningful list
+    // and skips the probe entirely. This keeps the hot path free of a per-text-node call while still
+    // catching every real list. (A one-item single-line list is missed, as it already was on main.)
+    const chars = typeof text.characters === 'string' ? text.characters : '';
     let hasList = false;
-    if (len > 0 && typeof text.getRangeListOptions === 'function') {
-      const lo = text.getRangeListOptions(0, len);
+    if (chars.includes('\n') && typeof text.getRangeListOptions === 'function') {
+      const lo = text.getRangeListOptions(0, chars.length);
       hasList =
         typeof lo === 'symbol' || (typeof lo === 'object' && lo !== null && lo.type !== 'NONE');
     }
@@ -660,5 +663,10 @@ export const serializeLayoutGrid = (grid: LayoutGrid): SerializedLayoutGrid => {
     alignment: grid.alignment,
   };
   if (typeof grid.sectionSize === 'number') out.sectionSize = grid.sectionSize;
+  // offset = the page margin between the grid and the frame edge (→ container horizontal padding).
+  // Omit the no-op (0) and the CENTER case (which ignores offset) so only a real margin surfaces.
+  if (typeof grid.offset === 'number' && grid.offset !== 0 && grid.alignment !== 'CENTER') {
+    out.offset = grid.offset;
+  }
   return out;
 };

--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -257,21 +257,51 @@ const collectStyleLinks = (node: SceneNode, out: SerializedNode): void => {
   }
 };
 
-const SEGMENT_FIELDS = ['fontName', 'fontSize', 'fills', 'textDecoration', 'textCase'] as const;
+// Per-run fields we break a mixed TEXT node on. Beyond the 5 style basics we ask for the structural
+// runs — hyperlink (→ <a>), listOptions (→ <ol>/<ul>), indentation (list nesting) — plus per-run
+// lineHeight/letterSpacing, so inline links / list items / leading changes survive instead of
+// collapsing to a single `mixed` marker.
+const SEGMENT_FIELDS = [
+  'fontName',
+  'fontSize',
+  'fills',
+  'textDecoration',
+  'textCase',
+  'lineHeight',
+  'letterSpacing',
+  'hyperlink',
+  'listOptions',
+  'indentation',
+] as const;
 
 /** Break a mixed-style TEXT node into runs of uniform styling (so inline bold/links/colors survive). */
 const serializeTextSegments = (text: TextNode): SerializedTextSegment[] => {
   const segments = text.getStyledTextSegments([...SEGMENT_FIELDS]);
-  return segments.map(s => ({
-    characters: s.characters,
-    start: s.start,
-    end: s.end,
-    fontName: { family: s.fontName.family, style: s.fontName.style },
-    fontSize: s.fontSize,
-    fills: Array.isArray(s.fills) ? s.fills.map(p => serializePaint(p as Paint)) : [],
-    textDecoration: s.textDecoration,
-    textCase: s.textCase,
-  }));
+  return segments.map(s => {
+    const out: SerializedTextSegment = {
+      characters: s.characters,
+      start: s.start,
+      end: s.end,
+      fontName: { family: s.fontName.family, style: s.fontName.style },
+      fontSize: s.fontSize,
+      fills: Array.isArray(s.fills) ? s.fills.map(p => serializePaint(p as Paint)) : [],
+      textDecoration: s.textDecoration,
+      textCase: s.textCase,
+    };
+    // Per-run leading / tracking, only when they carry a concrete non-default value (AUTO leading /
+    // 0 tracking are the no-ops). A segment is a uniform run, so these are never `mixed` on a real
+    // node — skip the MIXED fallback so a run stays lean rather than emitting a meaningless marker.
+    const lh = serializeLineHeight(s.lineHeight);
+    if (lh !== MIXED && lh.unit !== 'AUTO') out.lineHeight = lh;
+    const ls = serializeLetterSpacing(s.letterSpacing);
+    if (ls !== MIXED && ls.value !== 0) out.letterSpacing = ls;
+    // Structural runs: an inline link, a list item (ORDERED/UNORDERED) at some indentation depth.
+    if (s.hyperlink != null) out.hyperlink = { type: s.hyperlink.type, value: s.hyperlink.value };
+    if (s.listOptions != null && s.listOptions.type !== 'NONE')
+      out.listOptions = s.listOptions.type;
+    if (typeof s.indentation === 'number' && s.indentation > 0) out.indentation = s.indentation;
+    return out;
+  });
 };
 
 const collectComponentProperties = (node: SceneNode, out: SerializedNode): void => {
@@ -399,6 +429,17 @@ const enrichWithMixins = (node: SceneNode, base: SerializedNode): SerializedNode
       }
       const align = (node as { strokeAlign?: unknown }).strokeAlign;
       if (typeof align === 'string') out.strokeAlign = align;
+      // Dash pattern (px on/off runs) → dashed/dotted borders and SVG stroke-dasharray. Empty = solid
+      // (the common case) → omit. strokeCap (line ends / arrowheads) omitted at NONE; strokeJoin
+      // omitted at the MITER default. These matter for dividers, LINE and VECTOR strokes.
+      const dash = (node as { dashPattern?: unknown }).dashPattern;
+      if (Array.isArray(dash) && dash.length > 0 && dash.every(d => typeof d === 'number')) {
+        out.dashPattern = dash as number[];
+      }
+      const cap = (node as { strokeCap?: unknown }).strokeCap;
+      if (typeof cap === 'string' && cap !== 'NONE') out.strokeCap = cap;
+      const join = (node as { strokeJoin?: unknown }).strokeJoin;
+      if (typeof join === 'string' && join !== 'MITER') out.strokeJoin = join;
     }
   }
   if ('effects' in node) {
@@ -451,6 +492,20 @@ const enrichWithMixins = (node: SceneNode, base: SerializedNode): SerializedNode
   ) {
     out.clipsContent = (node as { clipsContent: boolean }).clipsContent;
   }
+  // A frame's own layout grids — the explicit responsive column system (12-col, baseline) a designer
+  // sets up. This is ground-truth breakpoint structure codegen otherwise infers; emit only when the
+  // frame actually defines grids. overflowDirection is the scroll axis of a clipping frame (→
+  // overflow-x/y), omitted at NONE.
+  if ('layoutGrids' in node) {
+    const grids = (node as { layoutGrids?: unknown }).layoutGrids;
+    if (Array.isArray(grids) && grids.length > 0) {
+      out.layoutGrids = grids.map(g => serializeLayoutGrid(g as LayoutGrid));
+    }
+  }
+  if ('overflowDirection' in node) {
+    const dir = (node as { overflowDirection?: unknown }).overflowDirection;
+    if (typeof dir === 'string' && dir !== 'NONE') out.overflowDirection = dir;
+  }
 
   collectStyleLinks(node, out);
   collectComponentProperties(node, out);
@@ -472,14 +527,37 @@ const enrichWithMixins = (node: SceneNode, base: SerializedNode): SerializedNode
     out.maxLines = text.maxLines;
     if (typeof text.paragraphSpacing === 'number') out.paragraphSpacing = text.paragraphSpacing;
     if (typeof text.paragraphIndent === 'number') out.paragraphIndent = text.paragraphIndent;
-    // Only expand per-run styling when the node is actually mixed (uniform text needs no segments).
-    const isMixed =
+    // Node-level hyperlink: a uniform link over the whole node → <a href>. `hyperlink` is an object
+    // when uniform, figma.mixed (a symbol) when only part of the text links (surfaced per-run in
+    // segments), null when none. Emit only the uniform-object case; mixed drives needsSegments below.
+    // Detect mixed via `typeof === 'symbol'` (the file's type-guard idiom, no figma.mixed ref).
+    const link = text.hyperlink;
+    const linkMixed = typeof link === 'symbol';
+    if (link !== null && !linkMixed && typeof link === 'object') {
+      out.hyperlink = { type: link.type, value: link.value };
+    }
+    // A list carries no node-level accessor, so probe once (cheap range read) to know whether the
+    // text is bulleted/numbered. A uniform list has uniform style → wouldn't trip the style-mix test,
+    // yet its <ol>/<ul> structure must survive; segments (split on listOptions/indentation) recover it
+    // — a flat uniform list stays a single segment, a nested one splits by depth.
+    const len = typeof text.characters === 'string' ? text.characters.length : 0;
+    let hasList = false;
+    if (len > 0 && typeof text.getRangeListOptions === 'function') {
+      const lo = text.getRangeListOptions(0, len);
+      hasList =
+        typeof lo === 'symbol' || (typeof lo === 'object' && lo !== null && lo.type !== 'NONE');
+    }
+    // Expand per-run styling when the node varies in style, carries a partial link, or is a list —
+    // uniform plain text needs no segments.
+    const needsSegments =
       out.fontSize === MIXED ||
       out.fontName === MIXED ||
       out.fills === MIXED ||
       out.textCase === MIXED ||
-      out.textDecoration === MIXED;
-    if (isMixed && typeof text.getStyledTextSegments === 'function') {
+      out.textDecoration === MIXED ||
+      linkMixed ||
+      hasList;
+    if (needsSegments && typeof text.getStyledTextSegments === 'function') {
       out.segments = serializeTextSegments(text);
     }
   }

--- a/packages/plugin/test/handlers/get-design-context.test.ts
+++ b/packages/plugin/test/handlers/get-design-context.test.ts
@@ -252,6 +252,81 @@ describe('get_design_context handler', () => {
     expect(compact.nodes[0]?.segments).toBeUndefined();
   });
 
+  it("surfaces a frame's layoutGrids + overflowDirection at full detail (breakpoint ground truth)", async () => {
+    const frame = node({
+      id: 'fr',
+      type: 'FRAME',
+      layoutGrids: [
+        { pattern: 'COLUMNS', visible: true, count: 12, gutterSize: 24, alignment: 'STRETCH' },
+      ],
+      overflowDirection: 'VERTICAL',
+    });
+    const full = (await createGetDesignContextHandler(fakeFigma({ selection: [frame] }))({
+      detail: 'full',
+    })) as GetDesignContextResult;
+    expect(full.nodes[0]?.layoutGrids).toEqual([
+      { pattern: 'COLUMNS', visible: true, count: 12, gutterSize: 24, alignment: 'STRETCH' },
+    ]);
+    expect(full.nodes[0]?.overflowDirection).toBe('VERTICAL');
+
+    // Not surfaced below full (the hot exploration default stays lean).
+    const compact = (await createGetDesignContextHandler(fakeFigma({ selection: [frame] }))({
+      detail: 'compact',
+    })) as GetDesignContextResult;
+    expect(compact.nodes[0]?.layoutGrids).toBeUndefined();
+  });
+
+  it('carries per-run hyperlink / listOptions / indentation through to the segments (structure survives)', async () => {
+    const list = node({
+      id: 'lt',
+      type: 'TEXT',
+      characters: 'Read the docs\nStar the repo',
+      fontName: { family: 'Inter', style: 'Regular' },
+      fontSize: 14,
+      textCase: 'ORIGINAL',
+      textDecoration: 'NONE',
+      // A uniform list is style-uniform, so the list probe (not a style mix) is what forces segments.
+      getRangeListOptions: () => ({ type: 'ORDERED' }),
+      getStyledTextSegments: () => [
+        {
+          characters: 'Read the docs\n',
+          start: 0,
+          end: 14,
+          fontName: { family: 'Inter', style: 'Regular' },
+          fontSize: 14,
+          fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 }, visible: true, opacity: 1 }],
+          textDecoration: 'NONE',
+          textCase: 'ORIGINAL',
+          listOptions: { type: 'ORDERED' },
+          indentation: 1,
+          hyperlink: { type: 'URL', value: 'https://x.dev/docs' },
+        },
+        {
+          characters: 'Star the repo',
+          start: 14,
+          end: 27,
+          fontName: { family: 'Inter', style: 'Regular' },
+          fontSize: 14,
+          fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 }, visible: true, opacity: 1 }],
+          textDecoration: 'NONE',
+          textCase: 'ORIGINAL',
+          listOptions: { type: 'ORDERED' },
+          indentation: 1,
+        },
+      ],
+    });
+    const full = (await createGetDesignContextHandler(fakeFigma({ selection: [list] }))({
+      detail: 'full',
+    })) as GetDesignContextResult;
+    expect(full.nodes[0]?.segments?.[0]).toMatchObject({
+      listOptions: 'ORDERED',
+      indentation: 1,
+      hyperlink: { type: 'URL', value: 'https://x.dev/docs' },
+    });
+    expect(full.nodes[0]?.segments?.[1]?.listOptions).toBe('ORDERED');
+    expect(full.nodes[0]?.segments?.[1]?.hyperlink).toBeUndefined();
+  });
+
   it('uses the selection, and throws when nothing is selected', async () => {
     const sel = node({ id: 'sel' });
     const pageNode = node({ id: 'page' });

--- a/packages/plugin/test/handlers/set-layout-grids.test.ts
+++ b/packages/plugin/test/handlers/set-layout-grids.test.ts
@@ -1,0 +1,58 @@
+import type { MutateResult } from '@figwright/shared';
+import { describe, expect, it } from 'vitest';
+
+import { createSetLayoutGridsHandler } from '../../src/handlers/set-layout-grids.js';
+
+const fakeFigma = (lookup: Record<string, unknown>): typeof figma =>
+  ({ getNodeByIdAsync: async (id: string) => lookup[id] ?? null }) as unknown as typeof figma;
+
+describe('set_layout_grids handler', () => {
+  it('sets a 12-column grid on a frame (the responsive column scaffold)', async () => {
+    const frame = { id: '1:1', layoutGrids: [] as unknown[] };
+    const handler = createSetLayoutGridsHandler(fakeFigma({ '1:1': frame }));
+    const result = (await handler({
+      nodeId: '1:1',
+      grids: [
+        { pattern: 'COLUMNS', visible: true, count: 12, gutterSize: 24, alignment: 'STRETCH' },
+      ],
+    })) as MutateResult;
+    expect(frame.layoutGrids).toEqual([
+      {
+        pattern: 'COLUMNS',
+        visible: true,
+        count: 12,
+        gutterSize: 24,
+        alignment: 'STRETCH',
+        offset: 0,
+      },
+    ]);
+    expect(result).toEqual({ ok: true, nodeId: '1:1' });
+  });
+
+  it('sets a uniform GRID (baseline) grid', async () => {
+    const frame = { id: '1:1', layoutGrids: [] as unknown[] };
+    const handler = createSetLayoutGridsHandler(fakeFigma({ '1:1': frame }));
+    await handler({ nodeId: '1:1', grids: [{ pattern: 'GRID', visible: true, sectionSize: 8 }] });
+    expect(frame.layoutGrids).toEqual([{ pattern: 'GRID', visible: true, sectionSize: 8 }]);
+  });
+
+  it('clears grids when passed an empty array', async () => {
+    const frame = {
+      id: '1:1',
+      layoutGrids: [{ pattern: 'GRID', visible: true, sectionSize: 8 }] as unknown[],
+    };
+    const handler = createSetLayoutGridsHandler(fakeFigma({ '1:1': frame }));
+    await handler({ nodeId: '1:1', grids: [] });
+    expect(frame.layoutGrids).toEqual([]);
+  });
+
+  it('rejects a bad nodeId, non-array grids, missing nodes, and nodes without layout grids', async () => {
+    const handler = createSetLayoutGridsHandler(
+      fakeFigma({ '1:1': { id: '1:1', layoutGrids: [] }, '2:2': { id: '2:2' } }),
+    );
+    await expect(handler({ grids: [] })).rejects.toThrow(/nodeId/);
+    await expect(handler({ nodeId: '1:1', grids: 'nope' })).rejects.toThrow(/must be an array/);
+    await expect(handler({ nodeId: '9:9', grids: [] })).rejects.toThrow(/not found/);
+    await expect(handler({ nodeId: '2:2', grids: [] })).rejects.toThrow(/does not support/);
+  });
+});

--- a/packages/plugin/test/handlers/set-layout-grids.test.ts
+++ b/packages/plugin/test/handlers/set-layout-grids.test.ts
@@ -36,6 +36,36 @@ describe('set_layout_grids handler', () => {
     expect(result).toEqual({ ok: true, nodeId: '1:1' });
   });
 
+  it('omits offset on a CENTER grid (Figma rejects the key there)', async () => {
+    const frame = { id: '1:1', layoutGrids: [] as unknown[] };
+    const handler = createSetLayoutGridsHandler(fakeFigma({ '1:1': frame }));
+    await handler({
+      nodeId: '1:1',
+      // A CENTER grid needs sectionSize and must NOT carry offset; the converter drops offset here.
+      grids: [
+        {
+          pattern: 'COLUMNS',
+          visible: true,
+          count: 6,
+          alignment: 'CENTER',
+          sectionSize: 64,
+          offset: 40,
+        },
+      ],
+    });
+    expect(frame.layoutGrids).toEqual([
+      {
+        pattern: 'COLUMNS',
+        visible: true,
+        count: 6,
+        gutterSize: 0,
+        alignment: 'CENTER',
+        sectionSize: 64,
+      },
+    ]);
+    expect((frame.layoutGrids[0] as { offset?: number }).offset).toBeUndefined();
+  });
+
   it('sets a uniform GRID (baseline) grid', async () => {
     const frame = { id: '1:1', layoutGrids: [] as unknown[] };
     const handler = createSetLayoutGridsHandler(fakeFigma({ '1:1': frame }));

--- a/packages/plugin/test/handlers/set-layout-grids.test.ts
+++ b/packages/plugin/test/handlers/set-layout-grids.test.ts
@@ -13,7 +13,14 @@ describe('set_layout_grids handler', () => {
     const result = (await handler({
       nodeId: '1:1',
       grids: [
-        { pattern: 'COLUMNS', visible: true, count: 12, gutterSize: 24, alignment: 'STRETCH' },
+        {
+          pattern: 'COLUMNS',
+          visible: true,
+          count: 12,
+          gutterSize: 24,
+          alignment: 'STRETCH',
+          offset: 32,
+        },
       ],
     })) as MutateResult;
     expect(frame.layoutGrids).toEqual([
@@ -23,7 +30,7 @@ describe('set_layout_grids handler', () => {
         count: 12,
         gutterSize: 24,
         alignment: 'STRETCH',
-        offset: 0,
+        offset: 32,
       },
     ]);
     expect(result).toEqual({ ok: true, nodeId: '1:1' });

--- a/packages/plugin/test/serializer.test.ts
+++ b/packages/plugin/test/serializer.test.ts
@@ -295,6 +295,36 @@ describe('serializeFlat — strokes / effects / auto layout', () => {
     expect(out.strokeWeight).toBe(MIXED);
   });
 
+  it('surfaces dashPattern / non-default strokeCap / strokeJoin on a dashed stroke', () => {
+    const out = serializeFlatSync(
+      fake({
+        strokes: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        strokeWeight: 1,
+        dashPattern: [4, 2],
+        strokeCap: 'ROUND',
+        strokeJoin: 'ROUND',
+      }),
+    );
+    expect(out.dashPattern).toEqual([4, 2]);
+    expect(out.strokeCap).toBe('ROUND');
+    expect(out.strokeJoin).toBe('ROUND');
+  });
+
+  it('omits dashPattern (empty=solid) and the no-op strokeCap NONE / strokeJoin MITER', () => {
+    const out = serializeFlatSync(
+      fake({
+        strokes: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        strokeWeight: 1,
+        dashPattern: [],
+        strokeCap: 'NONE',
+        strokeJoin: 'MITER',
+      }),
+    );
+    expect(out.dashPattern).toBeUndefined();
+    expect(out.strokeCap).toBeUndefined();
+    expect(out.strokeJoin).toBeUndefined();
+  });
+
   it('surfaces per-side strokeWeights when strokeWeight is mixed (e.g. a top/bottom-only border)', () => {
     const out = serializeFlatSync(
       fake({
@@ -567,6 +597,33 @@ describe('serializeFlat — layout sizing / constraints / clipsContent', () => {
   it('serializes clipsContent', () => {
     expect(serializeFlatSync(fake({ clipsContent: true })).clipsContent).toBe(true);
   });
+
+  it("surfaces a frame's own layoutGrids (the responsive column system)", () => {
+    const out = serializeFlatSync(
+      fake({
+        type: 'FRAME',
+        layoutGrids: [
+          { pattern: 'COLUMNS', visible: true, count: 12, gutterSize: 24, alignment: 'STRETCH' },
+        ],
+      }),
+    );
+    expect(out.layoutGrids).toEqual([
+      { pattern: 'COLUMNS', visible: true, count: 12, gutterSize: 24, alignment: 'STRETCH' },
+    ]);
+  });
+
+  it('omits layoutGrids when the frame defines none', () => {
+    expect(serializeFlatSync(fake({ type: 'FRAME', layoutGrids: [] })).layoutGrids).toBeUndefined();
+  });
+
+  it('surfaces overflowDirection on a scrolling frame, omits the NONE default', () => {
+    expect(
+      serializeFlatSync(fake({ type: 'FRAME', overflowDirection: 'VERTICAL' })).overflowDirection,
+    ).toBe('VERTICAL');
+    expect(
+      serializeFlatSync(fake({ type: 'FRAME', overflowDirection: 'NONE' })).overflowDirection,
+    ).toBeUndefined();
+  });
 });
 
 describe('serializeFlat — style links / component properties', () => {
@@ -708,6 +765,154 @@ describe('serializeFlat — typography', () => {
       }),
     );
     expect(out.segments).toBeUndefined();
+  });
+
+  it('surfaces a node-level uniform hyperlink (whole text is one link)', () => {
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'Docs',
+        fontSize: 14,
+        fontName: { family: 'Inter', style: 'Regular' },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        hyperlink: { type: 'URL', value: 'https://x.dev' },
+        getStyledTextSegments: () => [],
+      }),
+    );
+    expect(out.hyperlink).toEqual({ type: 'URL', value: 'https://x.dev' });
+  });
+
+  it('expands segments for a partial hyperlink even when the 5 style basics are uniform', () => {
+    const segments = [
+      {
+        characters: 'Agree to ',
+        start: 0,
+        end: 9,
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+      },
+      {
+        characters: 'Terms',
+        start: 9,
+        end: 14,
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+        hyperlink: { type: 'URL', value: 'https://x.dev/terms' },
+      },
+    ];
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'Agree to Terms',
+        fontSize: 14,
+        fontName: { family: 'Inter', style: 'Regular' },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        // A partial link makes the node's hyperlink `mixed` (a symbol) → no node-level link, expand runs.
+        hyperlink: Symbol('figma.mixed'),
+        getStyledTextSegments: () => segments,
+      }),
+    );
+    expect(out.hyperlink).toBeUndefined();
+    expect(out.segments).toHaveLength(2);
+    expect(out.segments?.[1]?.hyperlink).toEqual({ type: 'URL', value: 'https://x.dev/terms' });
+    expect(out.segments?.[0]?.hyperlink).toBeUndefined();
+  });
+
+  it('expands segments for a uniform list (probed via getRangeListOptions) and carries listOptions', () => {
+    const segments = [
+      {
+        characters: 'One\nTwo',
+        start: 0,
+        end: 7,
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+        listOptions: { type: 'UNORDERED' },
+        indentation: 1,
+      },
+    ];
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'One\nTwo',
+        fontSize: 14,
+        fontName: { family: 'Inter', style: 'Regular' },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        getRangeListOptions: () => ({ type: 'UNORDERED' }),
+        getStyledTextSegments: () => segments,
+      }),
+    );
+    expect(out.segments).toHaveLength(1);
+    expect(out.segments?.[0]?.listOptions).toBe('UNORDERED');
+    expect(out.segments?.[0]?.indentation).toBe(1);
+  });
+
+  it('does not expand segments when the list probe reports NONE', () => {
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'plain',
+        fontSize: 14,
+        fontName: { family: 'Inter', style: 'Regular' },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        getRangeListOptions: () => ({ type: 'NONE' }),
+        getStyledTextSegments: () => [],
+      }),
+    );
+    expect(out.segments).toBeUndefined();
+  });
+
+  it('carries per-run lineHeight only when non-default, never a mixed marker', () => {
+    const segments = [
+      {
+        characters: 'A',
+        start: 0,
+        end: 1,
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+        lineHeight: { unit: 'PIXELS', value: 22 },
+      },
+      {
+        characters: 'B',
+        start: 1,
+        end: 2,
+        fontName: { family: 'Inter', style: 'Bold' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+        lineHeight: { unit: 'AUTO' },
+      },
+    ];
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'AB',
+        fontName: Symbol('figma.mixed'),
+        fontSize: 14,
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        getStyledTextSegments: () => segments,
+      }),
+    );
+    expect(out.segments?.[0]?.lineHeight).toEqual({ unit: 'PIXELS', value: 22 });
+    // AUTO leading is the no-op → omitted, never emitted as `mixed`.
+    expect(out.segments?.[1]?.lineHeight).toBeUndefined();
   });
 });
 

--- a/packages/plugin/test/serializer.test.ts
+++ b/packages/plugin/test/serializer.test.ts
@@ -858,19 +858,45 @@ describe('serializeFlat — typography', () => {
     expect(out.segments?.[0]?.indentation).toBe(1);
   });
 
-  it('does not expand segments when the list probe reports NONE', () => {
+  it('skips the list probe entirely for single-line text (the hot-path perf gate)', () => {
+    let probed = false;
     const out = serializeFlatSync(
       fake({
         type: 'TEXT',
-        characters: 'plain',
+        characters: 'Buy now', // no newline → can't be a list → never probed
         fontSize: 14,
         fontName: { family: 'Inter', style: 'Regular' },
         textCase: 'ORIGINAL',
         textDecoration: 'NONE',
-        getRangeListOptions: () => ({ type: 'NONE' }),
+        getRangeListOptions: () => {
+          probed = true;
+          return { type: 'UNORDERED' };
+        },
         getStyledTextSegments: () => [],
       }),
     );
+    expect(probed).toBe(false);
+    expect(out.segments).toBeUndefined();
+  });
+
+  it('probes multi-line text but expands no segments when it is not a list (NONE)', () => {
+    let probed = false;
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'line one\nline two', // multi-line, but a plain paragraph, not a list
+        fontSize: 14,
+        fontName: { family: 'Inter', style: 'Regular' },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        getRangeListOptions: () => {
+          probed = true;
+          return { type: 'NONE' };
+        },
+        getStyledTextSegments: () => [],
+      }),
+    );
+    expect(probed).toBe(true);
     expect(out.segments).toBeUndefined();
   });
 
@@ -1061,5 +1087,39 @@ describe('serializeLayoutGrid', () => {
       sectionSize: 8,
     } as unknown as LayoutGrid);
     expect(out).toEqual({ pattern: 'GRID', visible: true, sectionSize: 8 });
+  });
+
+  it('surfaces a non-zero offset (the page margin) on a row/column grid', () => {
+    const out = serializeLayoutGrid({
+      pattern: 'COLUMNS',
+      visible: true,
+      count: 12,
+      gutterSize: 24,
+      alignment: 'STRETCH',
+      offset: 32,
+    } as unknown as LayoutGrid);
+    expect(out.offset).toBe(32);
+  });
+
+  it('omits offset when it is 0 or when alignment is CENTER (which ignores it)', () => {
+    const zero = serializeLayoutGrid({
+      pattern: 'COLUMNS',
+      visible: true,
+      count: 12,
+      gutterSize: 24,
+      alignment: 'STRETCH',
+      offset: 0,
+    } as unknown as LayoutGrid);
+    expect(zero.offset).toBeUndefined();
+
+    const centered = serializeLayoutGrid({
+      pattern: 'COLUMNS',
+      visible: true,
+      count: 12,
+      gutterSize: 24,
+      alignment: 'CENTER',
+      offset: 32,
+    } as unknown as LayoutGrid);
+    expect(centered.offset).toBeUndefined();
   });
 });

--- a/packages/shared/src/design-context.ts
+++ b/packages/shared/src/design-context.ts
@@ -9,6 +9,8 @@ import {
   SerializedEffectSchema,
   SerializedFontNameSchema,
   SerializedGridChildSchema,
+  SerializedHyperlinkSchema,
+  SerializedLayoutGridSchema,
   SerializedLetterSpacingSchema,
   SerializedLineHeightSchema,
   SerializedMainComponentSchema,
@@ -21,6 +23,8 @@ import type {
   SerializedConstraints,
   SerializedEffect,
   SerializedGridChild,
+  SerializedHyperlink,
+  SerializedLayoutGrid,
   SerializedLetterSpacing,
   SerializedLineHeight,
   SerializedMainComponent,
@@ -48,6 +52,14 @@ export interface DesignContextTextSegment {
   fills: readonly SimplifiedPaint[];
   textDecoration: string;
   textCase: string;
+  // Per-run structural bits the node-level `mixed` markers flag but can't locate: an inline link
+  // (→ `<a>`), a list item (→ `<ol>`/`<ul>`) at some indentation, or per-run leading/tracking.
+  // Each omitted at its no-op default so a plain run stays lean.
+  lineHeight?: SerializedLineHeight | typeof MIXED;
+  letterSpacing?: SerializedLetterSpacing | typeof MIXED;
+  hyperlink?: SerializedHyperlink;
+  listOptions?: string;
+  indentation?: number;
 }
 
 /**
@@ -110,6 +122,12 @@ export interface DesignContextNode {
    */
   strokeWeights?: { top: number; right: number; bottom: number; left: number };
   strokeAlign?: string;
+  /** Dash pattern (px on/off) → `border-style: dashed`/`dotted`; omitted for a solid stroke. */
+  dashPattern?: readonly number[];
+  /** Stroke line cap (ROUND / SQUARE / arrows); omitted when NONE. */
+  strokeCap?: string;
+  /** Stroke line join (ROUND / BEVEL); omitted at the MITER default. */
+  strokeJoin?: string;
   effects?: readonly SerializedEffect[];
   // auto-layout / positioning — surfaced to the main grounding tool (not just get_node) so codegen
   // reads exact padding / gap / justify / align instead of inferring them from geometry. H/V carry
@@ -124,6 +142,18 @@ export interface DesignContextNode {
   gridChild?: SerializedGridChild;
   constraints?: SerializedConstraints;
   clipsContent?: boolean;
+  /**
+   * A frame's own layout grids (COLUMNS / ROWS / GRID) — the explicit responsive column scaffold a
+   * designer defines (12-col, baseline). Ground-truth breakpoint structure codegen otherwise
+   * infers; present only on frames that define grids. Distinct from `layout` (auto-layout of
+   * children).
+   */
+  layoutGrids?: readonly SerializedLayoutGrid[];
+  /**
+   * Scroll behaviour of a clipping frame (HORIZONTAL / VERTICAL / BOTH) → overflow; omitted when
+   * NONE.
+   */
+  overflowDirection?: string;
   characters?: string;
   fontSize?: number | typeof MIXED;
   fontName?: z.infer<typeof SerializedFontNameSchema> | typeof MIXED;
@@ -141,6 +171,11 @@ export interface DesignContextNode {
   textAlignVertical?: string;
   textTruncation?: string;
   maxLines?: number | null;
+  /**
+   * Node-level hyperlink (the whole text is one link → `<a href>`); partial links live in
+   * `segments`.
+   */
+  hyperlink?: SerializedHyperlink;
   // Per-run styling of a *mixed* TEXT node — the only way to recover which characters carry the
   // inline bold / link / coloured span that the node-level `mixed` markers flag but can't locate.
   // Present only when the node is actually mixed (so uniform text stays clean).
@@ -236,6 +271,9 @@ export const DesignContextNodeSchema = z.lazy(() =>
       .object({ top: z.number(), right: z.number(), bottom: z.number(), left: z.number() })
       .optional(),
     strokeAlign: z.string().optional(),
+    dashPattern: z.array(z.number()).optional(),
+    strokeCap: z.string().optional(),
+    strokeJoin: z.string().optional(),
     effects: z.array(SerializedEffectSchema).optional(),
     layout: SerializedAutoLayoutSchema.optional(),
     layoutSizingHorizontal: z.string().optional(),
@@ -246,6 +284,8 @@ export const DesignContextNodeSchema = z.lazy(() =>
     gridChild: SerializedGridChildSchema.optional(),
     constraints: SerializedConstraintsSchema.optional(),
     clipsContent: z.boolean().optional(),
+    layoutGrids: z.array(SerializedLayoutGridSchema).optional(),
+    overflowDirection: z.string().optional(),
     characters: z.string().optional(),
     fontSize: z.union([z.number(), z.literal(MIXED)]).optional(),
     fontName: z.union([SerializedFontNameSchema, z.literal(MIXED)]).optional(),
@@ -257,6 +297,7 @@ export const DesignContextNodeSchema = z.lazy(() =>
     textAlignVertical: z.string().optional(),
     textTruncation: z.string().optional(),
     maxLines: z.number().nullable().optional(),
+    hyperlink: SerializedHyperlinkSchema.optional(),
     // Simplified paints are opaque here (hex lives in `color`), mirroring globalVars' z.unknown().
     segments: z
       .array(
@@ -269,6 +310,11 @@ export const DesignContextNodeSchema = z.lazy(() =>
           fills: z.array(z.unknown()),
           textDecoration: z.string(),
           textCase: z.string(),
+          lineHeight: z.union([SerializedLineHeightSchema, z.literal(MIXED)]).optional(),
+          letterSpacing: z.union([SerializedLetterSpacingSchema, z.literal(MIXED)]).optional(),
+          hyperlink: SerializedHyperlinkSchema.optional(),
+          listOptions: z.string().optional(),
+          indentation: z.number().optional(),
         }),
       )
       .optional(),

--- a/packages/shared/src/serialized-node.ts
+++ b/packages/shared/src/serialized-node.ts
@@ -227,7 +227,20 @@ export const SerializedMainComponentSchema = z.object({
 });
 export type SerializedMainComponent = z.infer<typeof SerializedMainComponentSchema>;
 
-/** A run of uniformly-styled characters within a mixed-style TEXT node (→ inline spans / links). */
+/** A hyperlink target on a text run or node: a URL, or an in-file NODE link (`value` is the id). */
+export const SerializedHyperlinkSchema = z.object({
+  type: z.string(),
+  value: z.string(),
+});
+export type SerializedHyperlink = z.infer<typeof SerializedHyperlinkSchema>;
+
+/**
+ * A run of uniformly-styled characters within a mixed-style TEXT node (→ inline spans / links).
+ * `lineHeight` / `letterSpacing` are per-run overrides (omitted at their no-op default so a plain
+ * run stays lean); `hyperlink` makes the run an `<a>`; `listOptions` (ORDERED / UNORDERED) makes it
+ * a list item (`<ol>` / `<ul>`); `indentation` is the list/blockquote nesting depth. The last three
+ * are the structural bits the node-level `mixed` markers flag but can't locate.
+ */
 export const SerializedTextSegmentSchema = z.object({
   characters: z.string(),
   start: z.number(),
@@ -237,6 +250,11 @@ export const SerializedTextSegmentSchema = z.object({
   fills: z.array(SerializedPaintSchema),
   textDecoration: z.string(),
   textCase: z.string(),
+  lineHeight: z.union([SerializedLineHeightSchema, z.literal(MIXED)]).optional(),
+  letterSpacing: z.union([SerializedLetterSpacingSchema, z.literal(MIXED)]).optional(),
+  hyperlink: SerializedHyperlinkSchema.optional(),
+  listOptions: z.string().optional(),
+  indentation: z.number().optional(),
 });
 export type SerializedTextSegment = z.infer<typeof SerializedTextSegmentSchema>;
 
@@ -281,6 +299,16 @@ export interface SerializedNode {
    */
   strokeWeights?: { top: number; right: number; bottom: number; left: number };
   strokeAlign?: string;
+  /**
+   * Dash pattern (px on/off run lengths) → `border-style: dashed` / `dotted` and SVG
+   * `stroke-dasharray`. Omitted when empty (a solid stroke), so only genuinely dashed/dotted
+   * borders carry it.
+   */
+  dashPattern?: readonly number[];
+  /** Stroke line cap (ROUND / SQUARE / arrow heads); omitted when NONE. Matters for LINE / VECTOR. */
+  strokeCap?: string;
+  /** Stroke line join (ROUND / BEVEL); omitted at the MITER default. */
+  strokeJoin?: string;
   effects?: readonly SerializedEffect[];
   layout?: SerializedAutoLayout;
   // how this node sizes/positions itself inside an auto-layout parent
@@ -294,6 +322,18 @@ export interface SerializedNode {
   // non-auto-layout positioning
   constraints?: SerializedConstraints;
   clipsContent?: boolean;
+  /**
+   * A frame's own layout grids (COLUMNS / ROWS / GRID) — the explicit responsive column system a
+   * designer sets up (12-col, 8px baseline). This is the ground-truth breakpoint scaffold codegen
+   * otherwise has to infer; present only on frames that actually define grids. Distinct from
+   * `layout` (auto-layout flex/grid of children).
+   */
+  layoutGrids?: readonly SerializedLayoutGrid[];
+  /**
+   * Scroll behaviour of a clipping frame (HORIZONTAL / VERTICAL / BOTH) → overflow; omitted when
+   * NONE.
+   */
+  overflowDirection?: string;
   // design-system links (→ tokens / shared styles for codegen)
   styleIds?: SerializedStyleIds;
   boundVariables?: Readonly<Record<string, readonly string[]>>;
@@ -315,6 +355,12 @@ export interface SerializedNode {
   maxLines?: number | null;
   paragraphSpacing?: number;
   paragraphIndent?: number;
+  /**
+   * A node-level hyperlink (the whole text is a link → `<a href>`). Present only when the entire
+   * node carries one uniform link; a link on only part of the text surfaces per-run in `segments`
+   * instead.
+   */
+  hyperlink?: SerializedHyperlink;
   /** Present only for mixed-style TEXT: per-run styling so rich text isn't flattened. */
   segments?: readonly SerializedTextSegment[];
   children?: readonly SerializedNode[];
@@ -367,6 +413,9 @@ export const SerializedNodeSchema = z.lazy(() =>
       })
       .optional(),
     strokeAlign: z.string().optional(),
+    dashPattern: z.array(z.number()).optional(),
+    strokeCap: z.string().optional(),
+    strokeJoin: z.string().optional(),
     effects: z.array(SerializedEffectSchema).optional(),
     layout: SerializedAutoLayoutSchema.optional(),
     layoutSizingHorizontal: z.string().optional(),
@@ -377,6 +426,8 @@ export const SerializedNodeSchema = z.lazy(() =>
     gridChild: SerializedGridChildSchema.optional(),
     constraints: SerializedConstraintsSchema.optional(),
     clipsContent: z.boolean().optional(),
+    layoutGrids: z.array(SerializedLayoutGridSchema).optional(),
+    overflowDirection: z.string().optional(),
     styleIds: SerializedStyleIdsSchema.optional(),
     boundVariables: z.record(z.string(), z.array(z.string())).optional(),
     componentProperties: z.record(z.string(), SerializedComponentPropertySchema).optional(),
@@ -395,6 +446,7 @@ export const SerializedNodeSchema = z.lazy(() =>
     maxLines: z.number().nullable().optional(),
     paragraphSpacing: z.number().optional(),
     paragraphIndent: z.number().optional(),
+    hyperlink: SerializedHyperlinkSchema.optional(),
     segments: z.array(SerializedTextSegmentSchema).optional(),
     children: z.array(SerializedNodeSchema).optional(),
   }),

--- a/packages/shared/src/serialized-node.ts
+++ b/packages/shared/src/serialized-node.ts
@@ -106,7 +106,12 @@ export const SerializedEffectSchema = z.object({
 });
 export type SerializedEffect = z.infer<typeof SerializedEffectSchema>;
 
-/** `pattern` is ROWS / COLUMNS / GRID; column/row grids add count / gutterSize / alignment. */
+/**
+ * `pattern` is ROWS / COLUMNS / GRID; column/row grids add count / gutterSize / alignment / offset.
+ * `offset` is the margin between the grid and the frame edge — the responsive container's
+ * horizontal page margin (→ container padding); omitted when 0 or when alignment is CENTER (which
+ * ignores it).
+ */
 export const SerializedLayoutGridSchema = z.object({
   pattern: z.string(),
   visible: z.boolean(),
@@ -114,6 +119,7 @@ export const SerializedLayoutGridSchema = z.object({
   count: z.number().optional(),
   gutterSize: z.number().optional(),
   alignment: z.string().optional(),
+  offset: z.number().optional(),
 });
 export type SerializedLayoutGrid = z.infer<typeof SerializedLayoutGridSchema>;
 

--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -80,6 +80,13 @@ Set the value, then bind it — there are **three** binding paths by what's bein
   `set_position` — for a top-level frame, or for an overlay / badge after
   `layoutPositioning: 'ABSOLUTE'` (prefer `set_position` over a `move_nodes` delta that first needs
   the current x/y read back).
+- **Responsive column scaffold → `set_layout_grids`, not `set_auto_layout`.** These are orthogonal:
+  `set_auto_layout` arranges a frame's _children_ (flex/grid); `set_layout_grids` overlays the frame's
+  own **layout grid** — the `COLUMNS` grid (a 12-col system: `count` + `gutterSize` + `alignment`) or a
+  `GRID` baseline (`sectionSize`, e.g. 8pt) a designer aligns content to. When you're reproducing a
+  page that has an explicit column system (the input code's container `grid-cols-12` / max-width +
+  gutters), set it as a real layout grid so it round-trips and codegen reads the breakpoint structure
+  back. Pass `[]` to clear.
 
 ## Sizing: HUG, FILL, FIXED (the same enum codegen reads)
 

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -42,10 +42,18 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   - **Mixed (inline) styling → read `segments`.** When a value reads `"mixed"` (e.g. `fontSize` or
     `textDecoration`), the node carries `segments` — each a run of uniform styling with its own
     `characters`, `fontName`, `fontSize`, `fills` (hex), `textDecoration`, `textCase` over offsets
-    `start`/`end`. These describe runs **within** the node's `characters` (not extra text) — emit each
-    as its own span: the underlined/coloured `Privacy Policy` inside a sentence, the bold word in a
-    label, the smaller `/mo` after a price. Dropping them flattens the whole string to one style (a
-    link with no underline, a price with no emphasis) — the classic mixed-text miss.
+    `start`/`end` (plus per-run `lineHeight`/`letterSpacing` when they differ). These describe runs
+    **within** the node's `characters` (not extra text) — emit each as its own span: the
+    underlined/coloured `Privacy Policy` inside a sentence, the bold word in a label, the smaller
+    `/mo` after a price. Dropping them flattens the whole string to one style (a link with no
+    underline, a price with no emphasis) — the classic mixed-text miss.
+  - **Inline links & lists → `segments` carry structure, not just style.** A run may carry
+    `hyperlink` (`{ type: 'URL' | 'NODE', value }`) → emit an `<a href>` (or router link for a
+    `NODE` target); a partial link is the reason a whole node reads mixed. A run may carry
+    `listOptions` (`ORDERED` / `UNORDERED`) with an `indentation` depth → emit real `<ol>`/`<ul>`
+    list items nested by depth, **not** newline-separated text with literal bullet characters. A
+    node whose _whole_ text is one uniform link instead carries a node-level `hyperlink`; a fully
+    uniform list still expands to a single `segment` so its `listOptions` survives.
 - **Per-side borders.** When `strokeWeight` is `mixed`, the node carries `strokeWeights`
   `{ top, right, bottom, left }` — emit only the non-zero sides (`border-t` / `border-b` / …),
   **never a uniform `border`**. Collapsing a per-side stroke into a full border turns a table row
@@ -55,6 +63,12 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   `box-shadow 0 0 0 Npx <colour>`, **never a plain `border`**, so it doesn't grow the box or shift
   its position (selection rings / focus outlines are `OUTSIDE`). `CENTER` straddles the edge (half the
   weight each side).
+- **Dashed / dotted strokes & line ends.** A stroke may carry `dashPattern` (px on/off run lengths)
+  → `border-style: dashed` (or `dotted` for short even runs), and for an SVG line/divider
+  `stroke-dasharray`. Without it a dashed separator or a cut-line renders solid. A `LINE` / `VECTOR`
+  stroke may also carry `strokeCap` (`ROUND` / `SQUARE`, or an arrowhead like `ARROW_LINES`) →
+  `stroke-linecap` / an SVG marker, and `strokeJoin` (`ROUND` / `BEVEL`) → `stroke-linejoin`; both
+  are omitted at their no-op defaults (`NONE` / `MITER`), so anything present is real intent.
 - **Per-corner radius.** When `cornerRadius` is `mixed`, the node carries `cornerRadii`
   `{ topLeft, topRight, bottomRight, bottomLeft }` — round only those corners (`rounded-t` /
   `rounded-tl` / …), **never a uniform radius**. A card rounded on one edge, a tab, or a chat bubble
@@ -111,6 +125,18 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   width exceeds its content — prefer `min-w-*` over a hard `w-*`**: Figma has no native min-width, so a
   designer expresses "at least this wide, but let longer/i18n text grow" as `FIXED`. Reserve a hard
   `w-*` for things that are genuinely a fixed size (sidebars, fixed cards, avatars).
+- **Layout grids — the frame's own responsive column system (don't infer breakpoints, read them).**
+  A frame may carry `layoutGrids`: `COLUMNS` / `ROWS` with a `count` (e.g. 12), `gutterSize`, and
+  `alignment`, or a uniform `GRID` with `sectionSize` (an 8px baseline). This is the designer's
+  **explicit** responsive scaffold — map a `COLUMNS` grid straight to your CSS grid / container
+  (`grid-cols-12 gap-[gutter]`, the page `max-w` + padding from the grid's margins) instead of
+  reverse-engineering column widths from child geometry. When several breakpoint frames each carry a
+  `count: 12` columns grid, that's the shared track system across breakpoints — keep the columns
+  fixed and let the gutters/margins flex. A uniform `GRID` is the spacing baseline: round paddings/
+  gaps to it. This is ground truth the geometry only approximates, so prefer it.
+- **Scroll overflow.** A clipping frame may carry `overflowDirection` (`HORIZONTAL` / `VERTICAL` /
+  `BOTH`) — the axis the content scrolls on. Emit `overflow-x-auto` / `overflow-y-auto` / `overflow-auto`
+  (a horizontal card carousel, a scrollable panel), don't just clip it. Omitted (`NONE`) means no scroll.
 - **Absolute positioning & constraints — a node placed by coordinates, not flow.** Two
   mutually-exclusive signals say "this isn't in an auto-layout flow"; read the anchor so it survives a
   resize instead of being hardcoded to a corner.

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -126,11 +126,12 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   designer expresses "at least this wide, but let longer/i18n text grow" as `FIXED`. Reserve a hard
   `w-*` for things that are genuinely a fixed size (sidebars, fixed cards, avatars).
 - **Layout grids — the frame's own responsive column system (don't infer breakpoints, read them).**
-  A frame may carry `layoutGrids`: `COLUMNS` / `ROWS` with a `count` (e.g. 12), `gutterSize`, and
-  `alignment`, or a uniform `GRID` with `sectionSize` (an 8px baseline). This is the designer's
-  **explicit** responsive scaffold — map a `COLUMNS` grid straight to your CSS grid / container
-  (`grid-cols-12 gap-[gutter]`, the page `max-w` + padding from the grid's margins) instead of
-  reverse-engineering column widths from child geometry. When several breakpoint frames each carry a
+  A frame may carry `layoutGrids`: `COLUMNS` / `ROWS` with a `count` (e.g. 12), `gutterSize`,
+  `alignment`, and `offset` (the page margin from the frame edge → container horizontal padding), or
+  a uniform `GRID` with `sectionSize` (an 8px baseline). This is the designer's **explicit**
+  responsive scaffold — map a `COLUMNS` grid straight to your CSS grid / container (`grid-cols-12
+gap-[gutter]`, the page `max-w` + `px-[offset]`) instead of reverse-engineering column widths and
+  margins from child geometry. When several breakpoint frames each carry a
   `count: 12` columns grid, that's the shared track system across breakpoints — keep the columns
   fixed and let the gutters/margins flex. A uniform `GRID` is the spacing baseline: round paddings/
   gaps to it. This is ground truth the geometry only approximates, so prefer it.


### PR DESCRIPTION
## What

A read-side fidelity sweep of the `get_design_context` grounding path, plus the write-side mirror for layout grids.

Motivation: exhaustively diffed the `@figma/plugin-typings` surface against our tools. The highest-leverage gaps weren't missing *features* — they were **silent dimension drops** on the main grounding path. A new feature only helps designs that use it; a dropped dimension corrupts **every** read. Each gap below maps to concrete wrong output produced *today*.

Every read field is **additive** and emitted only when present / non-default → worst case the LLM ignores an extra key, so no existing design regresses.

## Read fields added

| Field | Wrong output it fixes |
|-------|----------------------|
| **`layoutGrids`** | A frame's own responsive column system (12-col / 8pt baseline) was invisible — `serializeLayoutGrid` existed but was never wired into node serialization, so codegen had to *guess* breakpoints instead of reading the designer's explicit scaffold. |
| **`dashPattern` / `strokeCap` / `strokeJoin`** | Dashed/dotted borders and line caps rendered as `solid`. |
| **Text `hyperlink`** (node-level + per-run) | Inline `<a href>` links collapsed to plain text. |
| **Segment `listOptions` / `indentation`** | `<ol>`/`<ul>` lists flattened to one line. A uniform list is style-uniform, so a cheap `getRangeListOptions` probe triggers segment expansion; segments now split on the structural fields. |
| **Per-run `lineHeight` / `letterSpacing`** | Mixed-text runs lost their leading/tracking (concrete values only, never a `mixed` marker). |
| **`overflowDirection`** | Scrolling frames lost `overflow-scroll`. |

## Write tool added

**`set_layout_grids`** — read↔write symmetry with the `layoutGrids` read field. It's the write side of a frame's column/row scaffold, **orthogonal to `set_auto_layout`** (which arranges children; this overlays the grid). Reuses the existing `toFigmaLayoutGrid` converter and mirrors `create_grid_style`'s input shape. Pass `[]` to clear.

## Docs

Grounding updated on both sides: `figma-codegen/grounding.md` (read → CSS translation) and `figma-build/write-rules.md` (write, with the `set_auto_layout` vs `set_layout_grids` distinction).

## Verification

- **94 tools, 736 tests**; full gate green (typecheck / lint / format / knip / build / test).
- **Live round-trip verified** in Figma: `set_layout_grids` wrote `COLUMNS(count 12, gutter 24, STRETCH) + GRID(8)`, and `get_design_context detail:full` read it back unchanged. `dashPattern` regression-checked in the same read.

## Deferred (follow-ups)

- Text range writes (`setRange*`: hyperlink / list / per-run font-size-color) — a coherent slice of its own.
- `inferredAutoLayout` read hint (flexbox for absolutely-positioned designs) — needs a live perf measurement + misuse guard.
- `Variable.codeSyntax` read.