### PR TITLE
feat: surface per-run design-system token bindings on mixed TEXT runs

### DIFF
--- a/packages/plugin/src/handlers/get-design-context.ts
+++ b/packages/plugin/src/handlers/get-design-context.ts
@@ -21,6 +21,17 @@ const isDetailLevel = (value: unknown): value is DetailLevel =>
   typeof value === 'string' && (DETAIL_LEVELS as readonly string[]).includes(value);
 
 /**
+ * Strip Figma's trailing-comma artifact from *StyleId values (e.g. "S:abc,") so the id matches the
+ * `styles` resolution map key and joins cleanly downstream. Used for a node's own styleIds and for
+ * a mixed TEXT run's per-segment styleIds.
+ */
+const cleanStyleIds = (ids: Record<string, string>): Record<string, string> => {
+  const cleaned: Record<string, string> = {};
+  for (const [k, raw] of Object.entries(ids)) cleaned[k] = raw.replace(/,+$/, '');
+  return cleaned;
+};
+
+/**
  * Project a node down to the fields a given detail level exposes. Detail-gated on purpose:
  * get_design_context is the hot read path and defaults to `compact`, so minimal/compact read their
  * few values straight off the node and skip the full serializeFlatSync — which maps every
@@ -149,20 +160,19 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
       if (s.hyperlink !== undefined) seg.hyperlink = s.hyperlink;
       if (s.listOptions !== undefined) seg.listOptions = s.listOptions;
       if (s.indentation !== undefined) seg.indentation = s.indentation;
+      // Per-run token bindings — same shape (and trailing-comma cleaning) as a node's own, so
+      // collectRefs / resolveTokens resolve them to names alongside the node-level ones.
+      if (s.styleIds !== undefined)
+        seg.styleIds = cleanStyleIds(s.styleIds as Record<string, string>);
+      if (s.boundVariables !== undefined) seg.boundVariables = s.boundVariables;
       return seg;
     });
   }
   // Grounding fields (M3 P1): surface what serializeFlatSync already captured but
   // get_design_context used to drop. id→token-name resolution lands in P2 (top-level maps below);
   // globalVars dedup in P3.
-  if (flat.styleIds !== undefined) {
-    // Figma's *StyleId values carry a trailing comma artifact (e.g. "S:abc,"); strip it so the id
-    // matches the `styles` resolution map key and joins cleanly downstream.
-    const ids = flat.styleIds as Record<string, string>;
-    const cleaned: Record<string, string> = {};
-    for (const [k, raw] of Object.entries(ids)) cleaned[k] = raw.replace(/,+$/, '');
-    out.styleIds = cleaned;
-  }
+  if (flat.styleIds !== undefined)
+    out.styleIds = cleanStyleIds(flat.styleIds as Record<string, string>);
   if (flat.boundVariables !== undefined) out.boundVariables = flat.boundVariables;
   if (flat.componentProperties !== undefined) out.componentProperties = flat.componentProperties;
   return out;
@@ -174,15 +184,24 @@ const collectRefs = (
 ): { varIds: Set<string>; styleIds: Set<string> } => {
   const varIds = new Set<string>();
   const styleIds = new Set<string>();
-  const visit = (n: DesignContextNode): void => {
-    if (n.boundVariables) {
-      for (const ids of Object.values(n.boundVariables)) for (const id of ids) varIds.add(id);
+  // A node and a mixed-TEXT run carry the same binding shape; collect from either.
+  const collectFrom = (bearer: {
+    boundVariables?: Readonly<Record<string, readonly string[]>>;
+    styleIds?: unknown;
+  }): void => {
+    if (bearer.boundVariables) {
+      for (const ids of Object.values(bearer.boundVariables)) for (const id of ids) varIds.add(id);
     }
-    if (n.styleIds) {
-      for (const id of Object.values(n.styleIds as Record<string, string>)) {
+    if (bearer.styleIds) {
+      for (const id of Object.values(bearer.styleIds as Record<string, string>)) {
         if (id !== '') styleIds.add(id);
       }
     }
+  };
+  const visit = (n: DesignContextNode): void => {
+    collectFrom(n);
+    // Per-run token bindings on a mixed TEXT node resolve alongside the node-level ones.
+    if (n.segments) for (const seg of n.segments) collectFrom(seg);
     if (n.children) for (const c of n.children) visit(c);
   };
   for (const n of nodes) visit(n);

--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -272,6 +272,11 @@ const SEGMENT_FIELDS = [
   'hyperlink',
   'listOptions',
   'indentation',
+  // Per-run design-system bindings — the token grounding that a mixed node's node-level `mixed` fills
+  // would otherwise lose (an inline link bound to Primary/500 + Body/Bold).
+  'textStyleId',
+  'fillStyleId',
+  'boundVariables',
 ] as const;
 
 /** Break a mixed-style TEXT node into runs of uniform styling (so inline bold/links/colors survive). */
@@ -300,6 +305,22 @@ const serializeTextSegments = (text: TextNode): SerializedTextSegment[] => {
     if (s.listOptions != null && s.listOptions.type !== 'NONE')
       out.listOptions = s.listOptions.type;
     if (typeof s.indentation === 'number' && s.indentation > 0) out.indentation = s.indentation;
+    // Per-run design-system bindings (mirrors collectStyleLinks for a node): a run's shared fill/text
+    // style ids + variable bindings. Ids are carried raw here and resolved to token names downstream
+    // (get_design_context's resolveTokens), exactly like a node's own styleIds / boundVariables.
+    const styleIds: SerializedStyleIds = {};
+    if (typeof s.fillStyleId === 'string' && s.fillStyleId !== '') styleIds.fill = s.fillStyleId;
+    if (typeof s.textStyleId === 'string' && s.textStyleId !== '') styleIds.text = s.textStyleId;
+    if (Object.keys(styleIds).length > 0) out.styleIds = styleIds;
+    const bound = s.boundVariables;
+    if (typeof bound === 'object' && bound !== null) {
+      const result: Record<string, string[]> = {};
+      for (const [field, val] of Object.entries(bound)) {
+        const ids = aliasIds(val);
+        if (ids.length > 0) result[field] = ids;
+      }
+      if (Object.keys(result).length > 0) out.boundVariables = result;
+    }
     return out;
   });
 };

--- a/packages/plugin/test/handlers/get-design-context.test.ts
+++ b/packages/plugin/test/handlers/get-design-context.test.ts
@@ -570,6 +570,62 @@ describe('get_design_context handler', () => {
     expect(full.styles).toEqual({ 'S:text1': { name: 'Body/Bold', type: 'TEXT' } });
   });
 
+  it("resolves a mixed TEXT run's per-segment token bindings into the top-level maps", async () => {
+    // A mixed node whose link run binds a text style + colour variable that appear ONLY per-segment
+    // (the node-level fills are `mixed`, so this is the only place the token survives).
+    const link = node({
+      id: 'lt',
+      type: 'TEXT',
+      characters: 'Agree to Terms',
+      fontName: Symbol('mixed'),
+      getStyledTextSegments: () => [
+        {
+          characters: 'Agree to ',
+          start: 0,
+          end: 9,
+          fontName: { family: 'Inter', style: 'Regular' },
+          fontSize: 14,
+          fills: [{ type: 'SOLID', color: { r: 0, g: 0, b: 0 }, visible: true, opacity: 1 }],
+          textDecoration: 'NONE',
+          textCase: 'ORIGINAL',
+          textStyleId: '',
+          fillStyleId: '',
+        },
+        {
+          characters: 'Terms',
+          start: 9,
+          end: 14,
+          fontName: { family: 'Inter', style: 'Bold' },
+          fontSize: 14,
+          fills: [{ type: 'SOLID', color: { r: 0, g: 0.4, b: 1 }, visible: true, opacity: 1 }],
+          textDecoration: 'UNDERLINE',
+          textCase: 'ORIGINAL',
+          textStyleId: 'S:linkstyle,',
+          fillStyleId: '',
+          boundVariables: { fills: { type: 'VARIABLE_ALIAS', id: 'VariableID:primary' } },
+        },
+      ],
+    });
+
+    const full = (await createGetDesignContextHandler(
+      fakeFigma({
+        selection: [link],
+        variables: { 'VariableID:primary': { name: 'Primary/500', resolvedType: 'COLOR' } },
+        styles: { 'S:linkstyle': { name: 'Link/Default', type: 'TEXT' } },
+      }),
+    )({ detail: 'full' })) as GetDesignContextResult;
+
+    // The segment carries the cleaned styleId + raw variable id …
+    const seg = full.nodes[0]?.segments?.[1];
+    expect(seg?.styleIds).toEqual({ text: 'S:linkstyle' });
+    expect(seg?.boundVariables).toEqual({ fills: ['VariableID:primary'] });
+    // … and those per-segment ids resolve into the deduped top-level token maps.
+    expect(full.styles).toEqual({ 'S:linkstyle': { name: 'Link/Default', type: 'TEXT' } });
+    expect(full.variables).toEqual({
+      'VariableID:primary': { name: 'Primary/500', type: 'COLOR' },
+    });
+  });
+
   it('omits token maps below full detail and when refs are unresolvable', async () => {
     const ref = node({
       id: 'r',

--- a/packages/plugin/test/serializer.test.ts
+++ b/packages/plugin/test/serializer.test.ts
@@ -940,6 +940,54 @@ describe('serializeFlat — typography', () => {
     // AUTO leading is the no-op → omitted, never emitted as `mixed`.
     expect(out.segments?.[1]?.lineHeight).toBeUndefined();
   });
+
+  it('carries per-run token bindings (styleIds + boundVariables) on a mixed run', () => {
+    const segments = [
+      {
+        characters: 'Agree to ',
+        start: 0,
+        end: 9,
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0, b: 0 } }],
+        textDecoration: 'NONE',
+        textCase: 'ORIGINAL',
+        textStyleId: '',
+        fillStyleId: '',
+      },
+      {
+        characters: 'Terms',
+        start: 9,
+        end: 14,
+        fontName: { family: 'Inter', style: 'Bold' },
+        fontSize: 14,
+        fills: [{ type: 'SOLID', visible: true, opacity: 1, color: { r: 0, g: 0.4, b: 1 } }],
+        textDecoration: 'UNDERLINE',
+        textCase: 'ORIGINAL',
+        // The link run binds a shared text style, a fill style, and a colour variable.
+        textStyleId: 'S:link,',
+        fillStyleId: 'S:brandfill,',
+        boundVariables: { fills: { type: 'VARIABLE_ALIAS', id: 'VariableID:primary' } },
+      },
+    ];
+    const out = serializeFlatSync(
+      fake({
+        type: 'TEXT',
+        characters: 'Agree to Terms',
+        fontName: Symbol('figma.mixed'),
+        fontSize: 14,
+        textCase: 'ORIGINAL',
+        textDecoration: Symbol('figma.mixed'),
+        getStyledTextSegments: () => segments,
+      }),
+    );
+    // The plain run carries no bindings (empty ids omitted).
+    expect(out.segments?.[0]?.styleIds).toBeUndefined();
+    expect(out.segments?.[0]?.boundVariables).toBeUndefined();
+    // The link run carries its style ids (raw, incl. Figma's trailing comma) + variable id list.
+    expect(out.segments?.[1]?.styleIds).toEqual({ text: 'S:link,', fill: 'S:brandfill,' });
+    expect(out.segments?.[1]?.boundVariables).toEqual({ fills: ['VariableID:primary'] });
+  });
 });
 
 describe('serializeTree', () => {

--- a/packages/shared/src/design-context.ts
+++ b/packages/shared/src/design-context.ts
@@ -60,6 +60,11 @@ export interface DesignContextTextSegment {
   hyperlink?: SerializedHyperlink;
   listOptions?: string;
   indentation?: number;
+  // Per-run design-system bindings (ids resolved to names in the top-level `styles` / `variables`
+  // maps, like a node's own). A run's shared text/fill style + variable bindings — the only place a
+  // token survives on a mixed TEXT node, whose node-level fills read `mixed`.
+  styleIds?: SerializedStyleIds;
+  boundVariables?: Readonly<Record<string, readonly string[]>>;
 }
 
 /**
@@ -315,6 +320,8 @@ export const DesignContextNodeSchema = z.lazy(() =>
           hyperlink: SerializedHyperlinkSchema.optional(),
           listOptions: z.string().optional(),
           indentation: z.number().optional(),
+          styleIds: SerializedStyleIdsSchema.optional(),
+          boundVariables: z.record(z.string(), z.array(z.string())).optional(),
         }),
       )
       .optional(),

--- a/packages/shared/src/serialized-node.ts
+++ b/packages/shared/src/serialized-node.ts
@@ -261,6 +261,12 @@ export const SerializedTextSegmentSchema = z.object({
   hyperlink: SerializedHyperlinkSchema.optional(),
   listOptions: z.string().optional(),
   indentation: z.number().optional(),
+  // Per-run design-system bindings: a run may link a shared text style (`text`) / fill style
+  // (`fill`) or bind variables (a colour token on `fills`, a size token on `fontSize`). A mixed TEXT
+  // node's node-level fills are `mixed`, so this is the only place a run's token binding survives —
+  // without it an inline link bound to Primary/500 + Body/Bold collapses to a bare hex.
+  styleIds: SerializedStyleIdsSchema.optional(),
+  boundVariables: z.record(z.string(), z.array(z.string())).optional(),
 });
 export type SerializedTextSegment = z.infer<typeof SerializedTextSegmentSchema>;
 

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -54,6 +54,13 @@ the obvious ones. These are ordered by how easily they're silently dropped.
     list items nested by depth, **not** newline-separated text with literal bullet characters. A
     node whose _whole_ text is one uniform link instead carries a node-level `hyperlink`; a fully
     uniform list still expands to a single `segment` so its `listOptions` survives.
+  - **Per-run tokens → a run's `styleIds` / `boundVariables` resolve like a node's own.** A run may
+    carry `styleIds` (`text` / `fill` → a shared text/fill style id) and `boundVariables` (e.g. a
+    colour token on `fills`), resolved to names in the top-level `styles` / `variables` maps just
+    like node-level bindings. Prefer the resolved token (the `Link/Default` text style, the
+    `Primary/500` colour) over the run's raw hex — on a mixed node the node-level fill reads `mixed`,
+    so a run's binding is the **only** place the inline link's colour/type token survives. Emit the
+    class/variable, not a one-off hex, so the link tracks the design system.
 - **Per-side borders.** When `strokeWeight` is `mixed`, the node carries `strokeWeights`
   `{ top, right, bottom, left }` — emit only the non-zero sides (`border-t` / `border-b` / …),
   **never a uniform `border`**. Collapsing a per-side stroke into a full border turns a table row


### PR DESCRIPTION
## What

Recovers a mixed TEXT node's **per-run token bindings** — the last of the "multiple dimensions collapsed to one" misses on the text path.

On a mixed node the node-level `fills` read `mixed`, so a run bound to a shared text/fill style or a colour variable lost its token entirely and codegen only saw a bare hex. Slice 1 (PR #31) recovered a run's visual style (bold / colour / underline) and structure (links / lists); this recovers its **design-system binding**.

## How

- `getStyledTextSegments` now also requests `textStyleId` / `fillStyleId` / `boundVariables`.
- Each segment carries `styleIds` (`fill` / `text`) + `boundVariables` (raw ids), mirroring a node's own bindings (reuses `SerializedStyleIds` + the existing `aliasIds` helper).
- In `get_design_context`: ids are cleaned of Figma's trailing-comma artifact, and — **the key wiring** — `collectRefs` now scans segments too, so `resolveTokens` resolves them into the same top-level `styles` / `variables` maps as node-level bindings.

Result: an inline link bound to `Primary/500` + `Link/Default` resolves to those **names**, not a one-off hex — so codegen emits the token, and the link tracks the design system.

## Persistent-or-better

Pure additive, full detail only, and only on nodes **already** emitting segments (the binding fields aren't in the `needsSegments` trigger, so no node newly expands). Worst case the LLM ignores extra keys.

## Verification

- **742 tests**, full gate green (typecheck / lint / format / knip / build / test). Includes the critical wiring test: a mixed run's per-segment ids resolve into the top-level token maps.
- Live round-trip is **deferred to the `set_text_range` slice** (next): there's no write tool yet for *range-level* bindings, so a mixed+bound node can't be built programmatically to read back. This is read-only with defensive `typeof` guards, so the worst failure mode is a field not surfacing (persistent), not wrong data. The upcoming `setRange*` writes will let us build such a node and round-trip-verify this slice.

## Context

Part of the read-fidelity sweep (follows #31). Next: `set_text_range` (`setRange*` writes) — the write-side mirror of the whole rich-text read surface, which also unlocks live round-trip verification of this slice.