### PR TITLE
feat(read): carry paragraph fields & textAutoResize, refuse unknown get_design_context roots, widen get_node budgets

### DIFF
--- a/packages/plugin/src/handlers/get-design-context.ts
+++ b/packages/plugin/src/handlers/get-design-context.ts
@@ -136,6 +136,19 @@ const project = (node: SceneNode, detail: DetailLevel): DesignContextNode => {
     out.textTruncation = flat.textTruncation;
   }
   if (typeof flat.maxLines === 'number') out.maxLines = flat.maxLines;
+  // Paragraph structure + box sizing the serializer computes but this view used to drop (same miss
+  // class as the typography above). paragraphSpacing/Indent are style-level → dedupeStyles folds
+  // them into the textStyle bundle; textAutoResize is per-node behaviour → stays inline. Each is
+  // omitted at its no-op default (0 / WIDTH_AND_HEIGHT hug) so plain text stays clean.
+  if (typeof flat.paragraphSpacing === 'number' && flat.paragraphSpacing !== 0) {
+    out.paragraphSpacing = flat.paragraphSpacing;
+  }
+  if (typeof flat.paragraphIndent === 'number' && flat.paragraphIndent !== 0) {
+    out.paragraphIndent = flat.paragraphIndent;
+  }
+  if (flat.textAutoResize !== undefined && flat.textAutoResize !== 'WIDTH_AND_HEIGHT') {
+    out.textAutoResize = flat.textAutoResize;
+  }
   // A node-level hyperlink (whole text is one link → <a href>); partial links ride in segments below.
   if (flat.hyperlink !== undefined) out.hyperlink = flat.hyperlink;
   // Per-run styling of a mixed TEXT node — serializeFlatSync already computed this (only set when the
@@ -502,7 +515,23 @@ export const createGetDesignContextHandler =
     let roots: readonly SceneNode[];
     if (typeof p.nodeId === 'string') {
       const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
-      roots = node !== null && isSceneNode(node) ? [node] : [];
+      // A miss used to return { nodes: [] } — indistinguishable from an empty design, so the caller
+      // (an LLM, or component_map/icon_map reusing this handler) walked on with nothing and produced
+      // silently-wrong output. Refuse loudly with the id instead, like the empty-selection case.
+      if (node === null) {
+        throw new Error(
+          `get_design_context: node "${p.nodeId}" not found in this file. Check the id (a pasted ` +
+            'Figma URL works too), or select the target in Figma and call without nodeId.',
+        );
+      }
+      if (!isSceneNode(node)) {
+        throw new Error(
+          `get_design_context: "${p.nodeId}" is a ${node.type}, not a frame/layer. Pass a frame or ` +
+            'layer id, or select nodes on that page and call without nodeId — grounding a whole ' +
+            'page is too large and ambiguous.',
+        );
+      }
+      roots = [node];
     } else if (figmaCtx.currentPage.selection.length > 0) {
       roots = figmaCtx.currentPage.selection;
     } else {

--- a/packages/plugin/test/handlers/get-design-context.test.ts
+++ b/packages/plugin/test/handlers/get-design-context.test.ts
@@ -103,6 +103,9 @@ describe('get_design_context handler', () => {
       textAlignVertical: 'TOP', // default → omitted
       textTruncation: 'ENDING',
       maxLines: 2,
+      paragraphSpacing: 12,
+      paragraphIndent: 24,
+      textAutoResize: 'HEIGHT',
     });
     const full = (await createGetDesignContextHandler(fakeFigma({ selection: [text] }))({
       detail: 'full',
@@ -112,6 +115,7 @@ describe('get_design_context handler', () => {
     // the shared text-style attributes are deduped into the bundle, not left inline
     expect(n?.lineHeight).toBeUndefined();
     expect(n?.textCase).toBeUndefined();
+    expect(n?.paragraphSpacing).toBeUndefined();
     expect(full.globalVars?.styles[n!.textStyle!]).toEqual({
       fontFamily: 'Inter',
       fontStyle: 'Bold',
@@ -120,12 +124,16 @@ describe('get_design_context handler', () => {
       letterSpacing: { unit: 'PERCENT', value: 5 },
       textCase: 'UPPER',
       textDecoration: 'UNDERLINE',
+      paragraphSpacing: 12,
+      paragraphIndent: 24,
     });
     // per-node behaviour stays inline; the TOP vertical default is dropped as noise
     expect(n?.textAlignHorizontal).toBe('CENTER');
     expect(n?.textAlignVertical).toBeUndefined();
     expect(n?.textTruncation).toBe('ENDING');
     expect(n?.maxLines).toBe(2);
+    // HEIGHT = fixed width + auto height — the width is a real wrap constraint, so it surfaces
+    expect(n?.textAutoResize).toBe('HEIGHT');
   });
 
   it('omits no-op default typography (plain left-aligned body text stays clean)', async () => {
@@ -143,6 +151,9 @@ describe('get_design_context handler', () => {
       textAlignVertical: 'TOP',
       textTruncation: 'DISABLED',
       maxLines: null,
+      paragraphSpacing: 0,
+      paragraphIndent: 0,
+      textAutoResize: 'WIDTH_AND_HEIGHT',
     });
     const full = (await createGetDesignContextHandler(fakeFigma({ selection: [text] }))({
       detail: 'full',
@@ -156,6 +167,10 @@ describe('get_design_context handler', () => {
     expect(n?.textAlignHorizontal).toBeUndefined();
     expect(n?.textTruncation).toBeUndefined();
     expect(n?.maxLines).toBeUndefined();
+    // 0 spacing/indent and the WIDTH_AND_HEIGHT (hug) default are no-ops → omitted
+    expect(n?.paragraphSpacing).toBeUndefined();
+    expect(n?.paragraphIndent).toBeUndefined();
+    expect(n?.textAutoResize).toBeUndefined();
     // bundle is just the font — no default typography baked in
     expect(full.globalVars?.styles[n!.textStyle!]).toEqual({
       fontFamily: 'Inter',
@@ -650,13 +665,18 @@ describe('get_design_context handler', () => {
     expect(full.nodes[0]?.boundVariables).toEqual({ fills: ['VariableID:9:9'] }); // raw id stays as fallback
   });
 
-  it('resolves a nodeId root, returning empty for misses', async () => {
+  it('resolves a nodeId root, and refuses a miss / non-scene node instead of returning empty', async () => {
     const target = node({ id: '1:2' });
+    const page = { id: '0:1', name: 'Page 1', type: 'PAGE' } as unknown as BaseNode;
     const handler = createGetDesignContextHandler(
-      fakeFigma({ lookup: { '1:2': target as unknown as BaseNode } }),
+      fakeFigma({ lookup: { '1:2': target as unknown as BaseNode, '0:1': page } }),
     );
     expect(((await handler({ nodeId: '1:2' })) as GetDesignContextResult).nodes[0]?.id).toBe('1:2');
-    expect(((await handler({ nodeId: 'nope' })) as GetDesignContextResult).nodes).toEqual([]);
+    // A miss used to yield { nodes: [] } — indistinguishable from an empty design, so callers
+    // walked on with nothing. It must be a loud, actionable error carrying the id instead.
+    await expect(handler({ nodeId: 'nope' })).rejects.toThrow(/"nope" not found/);
+    // A PAGE/DOCUMENT id is not groundable either — same loud refusal, naming the type.
+    await expect(handler({ nodeId: '0:1' })).rejects.toThrow(/is a PAGE/);
   });
 
   it('attaches a breakpoint hint when the selection spans width buckets — even at compact', async () => {

--- a/packages/shared/src/design-context-dedupe.ts
+++ b/packages/shared/src/design-context-dedupe.ts
@@ -127,6 +127,8 @@ interface TextStyleBundle {
   letterSpacing?: SerializedLetterSpacing;
   textCase?: string;
   textDecoration?: string;
+  paragraphSpacing?: number;
+  paragraphIndent?: number;
 }
 
 /**
@@ -205,6 +207,16 @@ export const dedupeStyles = (
       if (typeof n.textDecoration === 'string' && n.textDecoration !== MIXED) {
         bundle.textDecoration = n.textDecoration;
         delete out.textDecoration;
+      }
+      // Paragraph structure is style-level too (a Figma text style carries both) and never `mixed`
+      // (node-level props), so present always means a real non-zero value → fold unconditionally.
+      if (typeof n.paragraphSpacing === 'number') {
+        bundle.paragraphSpacing = n.paragraphSpacing;
+        delete out.paragraphSpacing;
+      }
+      if (typeof n.paragraphIndent === 'number') {
+        bundle.paragraphIndent = n.paragraphIndent;
+        delete out.paragraphIndent;
       }
       out.textStyle = register(bundle, 'text');
       delete out.fontSize;

--- a/packages/shared/src/design-context.ts
+++ b/packages/shared/src/design-context.ts
@@ -170,12 +170,27 @@ export interface DesignContextNode {
   letterSpacing?: SerializedLetterSpacing | typeof MIXED;
   textCase?: string | typeof MIXED;
   textDecoration?: string | typeof MIXED;
+  /**
+   * Space between paragraphs (px) and first-line indent (px) — without them multi-paragraph text
+   * (article bodies, FAQs) renders with the paragraphs butted together / unindented. Style-level
+   * like lineHeight (a Figma text style carries both), so dedup folds them into the textStyle
+   * bundle. Omitted at the 0 default.
+   */
+  paragraphSpacing?: number;
+  paragraphIndent?: number;
   // Per-node text behaviour (not part of the shared style) — stays inline: the same heading style is
   // centered here, left there; truncation/maxLines vary per instance. → text-align / line-clamp.
   textAlignHorizontal?: string;
   textAlignVertical?: string;
   textTruncation?: string;
   maxLines?: number | null;
+  /**
+   * How the text box sizes: NONE = fixed box, HEIGHT = fixed width + auto height (the width is a
+   * real wrap constraint), TRUNCATE = legacy ellipsis. Omitted at the WIDTH_AND_HEIGHT (hug)
+   * default. Outside auto-layout this is the only signal whether width/height are constraints to
+   * emit or just the text's own rendered size.
+   */
+  textAutoResize?: string;
   /**
    * Node-level hyperlink (the whole text is one link → `<a href>`); partial links live in
    * `segments`.
@@ -298,10 +313,13 @@ export const DesignContextNodeSchema = z.lazy(() =>
     letterSpacing: z.union([SerializedLetterSpacingSchema, z.literal(MIXED)]).optional(),
     textCase: z.union([z.string(), z.literal(MIXED)]).optional(),
     textDecoration: z.union([z.string(), z.literal(MIXED)]).optional(),
+    paragraphSpacing: z.number().optional(),
+    paragraphIndent: z.number().optional(),
     textAlignHorizontal: z.string().optional(),
     textAlignVertical: z.string().optional(),
     textTruncation: z.string().optional(),
     maxLines: z.number().nullable().optional(),
+    textAutoResize: z.string().optional(),
     hyperlink: SerializedHyperlinkSchema.optional(),
     // Simplified paints are opaque here (hex lives in `color`), mirroring globalVars' z.unknown().
     segments: z

--- a/packages/shared/src/tool-budgets.ts
+++ b/packages/shared/src/tool-budgets.ts
@@ -30,6 +30,11 @@ const HEAVY_TOOLS: ReadonlySet<string> = new Set([
   'export_pdf',
   'get_document',
   'get_design_context',
+  // Full recursive subtree serialization with no depth limit or dedupe (per mixed TEXT a
+  // getStyledTextSegments call, per INSTANCE an async main-component resolve) — on a large frame
+  // this is at least as heavy as get_design_context, which already has the wide budget.
+  'get_node',
+  'get_nodes_info',
   'scan_text_nodes',
   'scan_nodes_by_types',
 ]);

--- a/packages/shared/test/design-context-dedupe.test.ts
+++ b/packages/shared/test/design-context-dedupe.test.ts
@@ -168,6 +168,26 @@ describe('dedupeStyles', () => {
     });
   });
 
+  it('folds paragraphSpacing / paragraphIndent into the textStyle bundle (style-level, like lineHeight)', () => {
+    const body: DesignContextNode = {
+      ...textNode('body', 'Inter', 'Regular', 16),
+      paragraphSpacing: 12,
+      paragraphIndent: 24,
+    };
+    const { nodes, globalVars } = dedupeStyles([body]);
+
+    // folded into the bundle, inline copies dropped
+    expect(nodes[0]?.paragraphSpacing).toBeUndefined();
+    expect(nodes[0]?.paragraphIndent).toBeUndefined();
+    expect(globalVars.styles[nodes[0]!.textStyle!]).toEqual({
+      fontFamily: 'Inter',
+      fontStyle: 'Regular',
+      fontSize: 16,
+      paragraphSpacing: 12,
+      paragraphIndent: 24,
+    });
+  });
+
   it("emits a node's own style refs before its children (no shadow-on-child misattribution)", () => {
     const card: DesignContextNode = {
       id: 'card',

--- a/packages/shared/test/tool-budgets.test.ts
+++ b/packages/shared/test/tool-budgets.test.ts
@@ -23,6 +23,10 @@ describe('tool budgets', () => {
       'export_pdf',
       'get_document',
       'get_design_context',
+      // Unbounded full-subtree serializations — at least as heavy as get_design_context on a large
+      // frame, so they get the same window instead of the 30s default that beheaded big trees.
+      'get_node',
+      'get_nodes_info',
       'scan_text_nodes',
       'scan_nodes_by_types',
     ]) {

--- a/skills/figma-codegen/references/grounding.md
+++ b/skills/figma-codegen/references/grounding.md
@@ -34,10 +34,17 @@ the obvious ones. These are ordered by how easily they're silently dropped.
   `uppercase`/`lowercase`/`capitalize` — **the characters in the tree are the original casing, so a
   dropped `UPPER` ships a lowercase button**), `textDecoration` (`UNDERLINE`/`STRIKETHROUGH` →
   `underline`/`line-through` — a link with no underline is the classic miss), `lineHeight`
-  (`{unit,value}` → `leading-*`; absent = font default), and `letterSpacing` (`{unit,value}` →
-  `tracking-*`; absent = 0). Per-node (inline, not in the bundle): `textAlignHorizontal`/`Vertical`
-  (`CENTER`/`RIGHT`/`JUSTIFIED` → `text-center`/`text-right`/`text-justify`; absent = left/top) and
-  `textTruncation: 'ENDING'` + `maxLines` (→ `line-clamp-N` / `truncate`). Each is omitted when it's
+  (`{unit,value}` → `leading-*`; absent = font default), `letterSpacing` (`{unit,value}` →
+  `tracking-*`; absent = 0), `paragraphSpacing` (px between the paragraphs `characters` splits into
+  at `\n` → margin between the `<p>`s you emit; absent = 0, the paragraphs butt together), and
+  `paragraphIndent` (px first-line indent → `text-indent`). Per-node (inline, not in the bundle):
+  `textAlignHorizontal`/`Vertical` (`CENTER`/`RIGHT`/`JUSTIFIED` → `text-center`/`text-right`/
+  `text-justify`; absent = left/top), `textTruncation: 'ENDING'` + `maxLines` (→ `line-clamp-N` /
+  `truncate`), and `textAutoResize` — how the text box sizes, the signal for whether its
+  width/height are real constraints: absent = hug (the box is just the text's own rendered size —
+  don't emit a width), `HEIGHT` = fixed width + auto height (the width is a wrap constraint — emit
+  it), `NONE` = fixed box (emit both, mind clipping); inside auto-layout trust
+  `layoutSizingHorizontal/Vertical` instead. Each is omitted when it's
   the no-op default, so anything present is real intent — translate it, don't drop it.
   - **Mixed (inline) styling → read `segments`.** When a value reads `"mixed"` (e.g. `fontSize` or
     `textDecoration`), the node carries `segments` — each a run of uniform styling with its own


### PR DESCRIPTION
## What

Three hot-path read hardenings, all strictly additive / equal-or-better:

1. **`get_design_context` silently dropped `paragraphSpacing` / `paragraphIndent` / `textAutoResize`** — the serializer computed them and `SerializedNode` carried them, but `project()` never copied them and `DesignContextNode` lacked the fields (the recurring *computed-but-dropped-on-the-way-out* miss class). Multi-paragraph text (article bodies, FAQs) rendered with paragraphs butted together; absolutely-positioned text had no signal whether its width is a real wrap constraint. `paragraphSpacing`/`Indent` are style-level → folded into the `textStyle` bundle by dedup (a Figma text style carries both); `textAutoResize` stays inline. All omitted at their no-op defaults (0 / `WIDTH_AND_HEIGHT`), so plain text payloads are unchanged. `grounding.md` documents the translation.

2. **Unknown `nodeId` no longer returns a silent empty tree.** `{ nodes: [] }` was indistinguishable from an empty design, so the caller (an LLM, or `component_map`/`icon_map` which reuse this handler) walked on and produced silently-wrong output. It now throws an actionable error naming the id (separate message for a PAGE/DOCUMENT id), mirroring the existing empty-selection refusal.

3. **`get_node` / `get_nodes_info` join `HEAVY_TOOLS`.** Both are unbounded full-subtree serializations — at least as heavy as `get_design_context` on a large frame — yet sat on the 30s default budget and got beheaded by the sandbox timer where the overlapping tools got 120s.

## Equal-or-better

- New fields emit only at non-default values; existing outputs are byte-identical for text without paragraph structure.
- The dedupe fold only extends the `textStyle` bundle for nodes that actually carry the fields; content-hash ids change only for those.
- The nodeId refusal converts a silent-wrong path into a loud actionable one — `component_map`/`icon_map` previously produced empty mappings for a bad id, now surface the real cause.
- Budget widening only raises ceilings; no timer ordering changes (sandbox < relay < follower nesting preserved).

## Tests

752 tests green (was 751); typecheck / lint / format:check / knip / build all pass.