### PR TITLE
feat(get_screenshot): auto-fit default raster scale & report exported size in the label

### DIFF
--- a/packages/mcp/src/tools/get-screenshot.ts
+++ b/packages/mcp/src/tools/get-screenshot.ts
@@ -8,18 +8,26 @@ export const GET_SCREENSHOT_TOOL_NAME = 'get_screenshot';
 export const getScreenshotTool: ToolSpec = {
   name: GET_SCREENSHOT_TOOL_NAME,
   description:
-    'Export nodes as base64 images: { images: [{ nodeId, format, base64, recovered?, empty? }] }. format is PNG ' +
-    '(default) / JPG / SVG; scale applies to raster formats (default 1). base64 is null for missing or ' +
-    'non-exportable nodes. Nodes that are fully clipped or off-canvas (carousels, masks, off-screen states) ' +
-    'are auto-recovered at their intrinsic bounds and flagged recovered:true. empty:true means the node ' +
-    'genuinely renders nothing even unclipped (hidden / no content) so the export is blank.',
+    'Export nodes as images the model can see, one image block per node: { images: [{ nodeId, format, ' +
+    'base64, width?, height?, scale?, recovered?, empty? }] }. format is PNG (default) / JPG / SVG. ' +
+    'scale applies to raster formats; when omitted, each node is auto-fitted to a legible size ' +
+    '(long edge into ~512–1536px: oversized frames scale down, tiny icons scale up ≤4x) — pass an ' +
+    'explicit scale to force one. Each raster label reports the exported width×height px and the ' +
+    'scale, the anchor for mapping raster px back to design px. base64 is null for missing or ' +
+    'non-exportable nodes. Nodes that are fully clipped or off-canvas (carousels, masks, off-screen ' +
+    'states) are auto-recovered at their intrinsic bounds and flagged recovered:true. empty:true ' +
+    'means the node genuinely renders nothing even unclipped (hidden / no content) so the export is blank.',
   inputShape: {
     nodeIds: z.array(z.string()).describe('Figma node ids to export'),
     format: z
       .enum(SCREENSHOT_FORMATS)
       .describe('Export format: PNG (default) / JPG / SVG')
       .optional(),
-    scale: z.number().min(0).describe('Raster scale factor (PNG/JPG), default 1').optional(),
+    scale: z
+      .number()
+      .positive()
+      .describe('Raster scale factor (PNG/JPG); omit to auto-fit each node to a legible size')
+      .optional(),
   },
   kind: 'read',
 };
@@ -47,12 +55,18 @@ export const screenshotContent = (result: GetScreenshotResult): ScreenshotConten
       : img.recovered
         ? ' — ↺ recovered (clipped/off-canvas; rendered at intrinsic bounds)'
         : '';
+    // Raster size + scale in the label anchors raster px ↔ design px (vital once the scale is
+    // auto-fitted). Absent on SVG and on results from an older plugin build — degrade to the bare label.
+    const dims =
+      img.width !== undefined && img.height !== undefined
+        ? ` ${img.width}×${img.height}px${img.scale !== undefined ? ` @${img.scale}x` : ''}`
+        : '';
     const mimeType = RASTER_MIME[img.format];
     if (mimeType === undefined) {
       const markup = Buffer.from(img.base64, 'base64').toString('utf8');
       blocks.push({ type: 'text', text: `${img.nodeId} (${img.format})${emptyNote}:\n${markup}` });
     } else {
-      blocks.push({ type: 'text', text: `${img.nodeId} (${img.format})${emptyNote}` });
+      blocks.push({ type: 'text', text: `${img.nodeId} (${img.format}${dims})${emptyNote}` });
       blocks.push({ type: 'image', data: img.base64, mimeType });
     }
   }

--- a/packages/mcp/src/tools/save-screenshots.ts
+++ b/packages/mcp/src/tools/save-screenshots.ts
@@ -22,7 +22,7 @@ const inputShape = {
     .enum(SCREENSHOT_FORMATS)
     .describe('Export format: PNG (default) / JPG / SVG')
     .optional(),
-  scale: z.number().min(0).describe('Raster scale factor (PNG/JPG), default 1').optional(),
+  scale: z.number().positive().describe('Raster scale factor (PNG/JPG), default 1').optional(),
 };
 
 export const saveScreenshotsTool: ToolSpec = {
@@ -85,7 +85,9 @@ export const handleSaveScreenshots = async (
 
   const screenshotArgs: Record<string, unknown> = { nodeIds: args.nodeIds };
   if (args.format !== undefined) screenshotArgs.format = args.format;
-  if (args.scale !== undefined) screenshotArgs.scale = args.scale;
+  // Always pass an explicit scale: an omitted scale makes get_screenshot auto-fit the raster for
+  // model consumption, but files written to disk are user artifacts and must stay full-res.
+  screenshotArgs.scale = args.scale ?? 1;
 
   const { images } = (await dispatch(
     GET_SCREENSHOT_TOOL_NAME,

--- a/packages/mcp/test/tools/get-screenshot.test.ts
+++ b/packages/mcp/test/tools/get-screenshot.test.ts
@@ -19,6 +19,29 @@ describe('screenshotContent', () => {
     ]);
   });
 
+  it('labels a raster with its exported size + scale when the plugin reports them', () => {
+    const result: GetScreenshotResult = {
+      images: [
+        { nodeId: '1:1', format: 'PNG', base64: 'AAAA', width: 1536, height: 1000, scale: 0.5 },
+        {
+          nodeId: '1:2',
+          format: 'PNG',
+          base64: 'BBBB',
+          width: 96,
+          height: 96,
+          scale: 4,
+          recovered: true,
+        },
+      ],
+    };
+    const blocks = screenshotContent(result);
+    expect(blocks[0]).toEqual({ type: 'text', text: '1:1 (PNG 1536×1000px @0.5x)' });
+    expect(blocks[2]).toEqual({
+      type: 'text',
+      text: '1:2 (PNG 96×96px @4x) — ↺ recovered (clipped/off-canvas; rendered at intrinsic bounds)',
+    });
+  });
+
   it('returns SVG markup as readable text rather than an image block', () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
     const result: GetScreenshotResult = {

--- a/packages/mcp/test/tools/read-tools.test.ts
+++ b/packages/mcp/test/tools/read-tools.test.ts
@@ -186,7 +186,8 @@ describe('M1 read tools — definitions', () => {
       properties: {
         nodeIds: { type: 'array', items: { type: 'string' } },
         format: { type: 'string', enum: ['PNG', 'JPG', 'SVG'] },
-        scale: { type: 'number', minimum: 0 },
+        // .positive() — the plugin rejects scale <= 0, so the advertised schema must too
+        scale: { type: 'number', exclusiveMinimum: 0 },
       },
     });
   });

--- a/packages/mcp/test/tools/save-screenshots.test.ts
+++ b/packages/mcp/test/tools/save-screenshots.test.ts
@@ -44,7 +44,8 @@ describe('save_screenshots — definition', () => {
         nodeIds: { type: 'array', items: { type: 'string' } },
         outDir: { type: 'string' },
         format: { type: 'string', enum: ['PNG', 'JPG', 'SVG'] },
-        scale: { type: 'number', minimum: 0 },
+        // .positive() — the plugin rejects scale <= 0, so the advertised schema must too
+        scale: { type: 'number', exclusiveMinimum: 0 },
       },
     });
   });
@@ -102,7 +103,9 @@ describe('handleSaveScreenshots', () => {
       outDir: dir,
     })) as SaveScreenshotsResult;
 
-    expect(dispatched).toEqual({ tool: 'get_screenshot', args: { nodeIds: ['1:1'] } });
+    // scale:1 is always forwarded explicitly — an omitted scale would make get_screenshot auto-fit
+    // the raster for model consumption, but files on disk are user artifacts and stay full-res.
+    expect(dispatched).toEqual({ tool: 'get_screenshot', args: { nodeIds: ['1:1'], scale: 1 } });
     expect(result.saved[0]).toEqual({ nodeId: '1:1', format: 'PNG', path: join(dir, '1-1.png') });
     expect((await readFile(join(dir, '1-1.png'))).toString('base64')).toBe('AAAA');
   });

--- a/packages/plugin/src/handlers/get-screenshot.ts
+++ b/packages/plugin/src/handlers/get-screenshot.ts
@@ -22,6 +22,44 @@ interface ClipGeometry {
   visible?: boolean;
 }
 
+// Auto-fit window for the default raster scale (only when the caller omits `scale`). Vision models
+// downsample anything past ~1.5k px on the long edge, so a bigger export is pure payload (and, on a
+// huge frame, disconnect risk) with zero fidelity gain — while a 24px icon at 1x is illegibly small.
+// Saved files are different: save_screenshots passes an explicit scale so disk artifacts stay full-res.
+const TARGET_LONG_EDGE = 1536;
+const MIN_LONG_EDGE = 512;
+const MAX_UPSCALE = 4;
+
+/** Fit the long edge into [MIN, TARGET]: oversized scales down, tiny scales up (capped), else 1. */
+const autoFitScale = (box: { width: number; height: number }): number => {
+  const long = Math.max(box.width, box.height);
+  if (!(long > 0)) return 1;
+  const raw =
+    long > TARGET_LONG_EDGE
+      ? TARGET_LONG_EDGE / long
+      : Math.min(MAX_UPSCALE, Math.max(1, MIN_LONG_EDGE / long));
+  // Two decimals keep the reported scale (and the export constraint) readable without moving the
+  // output size by more than a few px.
+  return Math.round(raw * 100) / 100;
+};
+
+/**
+ * Report the raster's pixel size + effective scale so the consumer can map raster px back to design
+ * px (essential once the scale is auto-fitted, and for recovered intrinsic-bounds exports).
+ * Computed from bounds × scale (±1px of Figma's own rounding — advisory, not measurement). SVG
+ * carries its own dimensions in the markup; unknown bounds stay unreported.
+ */
+const attachRasterDims = (
+  image: ScreenshotImage,
+  box: { width: number; height: number } | null | undefined,
+  scale: number,
+): void => {
+  if (image.format === 'SVG' || box == null || !(box.width > 0) || !(box.height > 0)) return;
+  image.width = Math.round(box.width * scale);
+  image.height = Math.round(box.height * scale);
+  image.scale = scale;
+};
+
 export const createGetScreenshotHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
   async params => {
@@ -43,10 +81,11 @@ export const createGetScreenshotHandler =
     }
 
     const format: ScreenshotFormat = isFormat(p.format) ? p.format : 'PNG';
-    const scale = typeof p.scale === 'number' ? p.scale : 1;
+    // Explicit scale is honored exactly; omitted scale auto-fits per node (see autoFitScale).
+    const requestedScale = typeof p.scale === 'number' ? p.scale : undefined;
     // useAbsoluteBounds renders the node at its own bounding box instead of its (clipped) render
     // region — see the recovery path below. We only ever turn it on for that recovery.
-    const makeSettings = (useAbsoluteBounds: boolean): ExportSettings =>
+    const makeSettings = (useAbsoluteBounds: boolean, scale: number): ExportSettings =>
       format === 'SVG'
         ? { format: 'SVG', ...(useAbsoluteBounds ? { useAbsoluteBounds } : {}) }
         : {
@@ -68,8 +107,14 @@ export const createGetScreenshotHandler =
         // Anything else takes the normal path, which is also the only one that keeps overflowing effects
         // (drop shadows, blur) intact. PAGE/DOCUMENT lack the property → undefined, never null.
         if (geom.absoluteRenderBounds !== null) {
-          const bytes = await node.exportAsync(makeSettings(false));
-          return { nodeId, format, base64: figmaCtx.base64Encode(bytes) };
+          // The render bounds are what this path exports; PAGE/DOCUMENT lack them → fall back to the
+          // bounding box, else give up on fitting/reporting and export at 1x like before.
+          const box = geom.absoluteRenderBounds ?? geom.absoluteBoundingBox;
+          const scale = requestedScale ?? (box != null ? autoFitScale(box) : 1);
+          const bytes = await node.exportAsync(makeSettings(false, scale));
+          const image: ScreenshotImage = { nodeId, format, base64: figmaCtx.base64Encode(bytes) };
+          attachRasterDims(image, box, scale);
+          return image;
         }
 
         // The node would export blank. If it has a real bounding box and isn't intentionally hidden, the
@@ -80,10 +125,13 @@ export const createGetScreenshotHandler =
         const box = geom.absoluteBoundingBox;
         const recoverable =
           geom.visible !== false && box != null && box.width > 0 && box.height > 0;
-        const bytes = await node.exportAsync(makeSettings(recoverable));
+        // A blank isn't worth fitting — keep it at 1x unless the caller asked for a scale.
+        const scale = requestedScale ?? (recoverable ? autoFitScale(box) : 1);
+        const bytes = await node.exportAsync(makeSettings(recoverable, scale));
         const image: ScreenshotImage = { nodeId, format, base64: figmaCtx.base64Encode(bytes) };
         if (recoverable) image.recovered = true;
         else image.empty = true;
+        attachRasterDims(image, box, scale);
         return image;
       }),
     );

--- a/packages/plugin/test/handlers/get-screenshot.test.ts
+++ b/packages/plugin/test/handlers/get-screenshot.test.ts
@@ -94,7 +94,15 @@ describe('get_screenshot handler', () => {
       base64: 'b64(1)',
       empty: true,
     });
-    expect(result.images[1]).toEqual({ nodeId: '1:6', format: 'PNG', base64: 'b64(3)' }); // no empty
+    // no empty flag; the tiny 10×10 node auto-fits up (×4 cap) and reports its raster size
+    expect(result.images[1]).toEqual({
+      nodeId: '1:6',
+      format: 'PNG',
+      base64: 'b64(3)',
+      width: 40,
+      height: 40,
+      scale: 4,
+    });
   });
 
   it('recovers a fully-clipped node via useAbsoluteBounds instead of shipping blank', async () => {
@@ -111,17 +119,21 @@ describe('get_screenshot handler', () => {
     } as unknown as BaseNode;
     const handler = createGetScreenshotHandler(fakeFigma({ '1:7': clippedWithBox }, calls));
     const result = (await handler({ nodeIds: ['1:7'] })) as GetScreenshotResult;
+    // The 150×100 intrinsic box auto-fits up to the 512px legibility floor (512/150 → 3.41).
     expect(result.images[0]).toEqual({
       nodeId: '1:7',
       format: 'PNG',
       base64: 'b64(4)',
       recovered: true,
+      width: 512,
+      height: 341,
+      scale: 3.41,
     });
     // Exported once, with useAbsoluteBounds so Figma renders the node's own box, not the clipped region.
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({
       format: 'PNG',
-      constraint: { type: 'SCALE', value: 1 },
+      constraint: { type: 'SCALE', value: 3.41 },
       useAbsoluteBounds: true,
     });
   });
@@ -140,13 +152,65 @@ describe('get_screenshot handler', () => {
     } as unknown as BaseNode;
     const handler = createGetScreenshotHandler(fakeFigma({ '1:8': hidden }, calls));
     const result = (await handler({ nodeIds: ['1:8'] })) as GetScreenshotResult;
+    // A blank isn't auto-fitted (scale stays 1); its box size is still reported for context.
     expect(result.images[0]).toEqual({
       nodeId: '1:8',
       format: 'PNG',
       base64: 'b64(1)',
       empty: true,
+      width: 50,
+      height: 50,
+      scale: 1,
     });
     expect(calls[0]?.useAbsoluteBounds).toBeUndefined();
+  });
+
+  it('auto-fits an oversized frame down (long edge → 1536) and reports the raster size', async () => {
+    const calls: ExportCall[] = [];
+    const big = {
+      id: '2:1',
+      absoluteRenderBounds: { x: 0, y: 0, width: 3072, height: 2000 },
+      exportAsync: async (settings: ExportCall) => {
+        calls.push(settings);
+        return new Uint8Array([7]);
+      },
+    } as unknown as BaseNode;
+    const handler = createGetScreenshotHandler(fakeFigma({ '2:1': big }, calls));
+    const result = (await handler({ nodeIds: ['2:1'] })) as GetScreenshotResult;
+    expect(calls[0]).toEqual({ format: 'PNG', constraint: { type: 'SCALE', value: 0.5 } });
+    expect(result.images[0]).toEqual({
+      nodeId: '2:1',
+      format: 'PNG',
+      base64: 'b64(1)',
+      width: 1536,
+      height: 1000,
+      scale: 0.5,
+    });
+  });
+
+  it('keeps a mid-size node at 1x, and honors an explicit scale over auto-fit', async () => {
+    const calls: ExportCall[] = [];
+    const mkNode = (id: string, width: number, height: number): BaseNode =>
+      ({
+        id,
+        absoluteRenderBounds: { x: 0, y: 0, width, height },
+        exportAsync: async (settings: ExportCall) => {
+          calls.push(settings);
+          return new Uint8Array([1]);
+        },
+      }) as unknown as BaseNode;
+    const lookup = { '3:1': mkNode('3:1', 800, 600), '3:2': mkNode('3:2', 3072, 2000) };
+
+    // 800×600 sits inside the [512, 1536] window → no fitting
+    const handler = createGetScreenshotHandler(fakeFigma(lookup, calls));
+    const mid = (await handler({ nodeIds: ['3:1'] })) as GetScreenshotResult;
+    expect(calls[0]?.constraint).toEqual({ type: 'SCALE', value: 1 });
+    expect(mid.images[0]).toMatchObject({ width: 800, height: 600, scale: 1 });
+
+    // explicit scale wins even on an oversized node (the old behaviour stays reachable)
+    const forced = (await handler({ nodeIds: ['3:2'], scale: 1 })) as GetScreenshotResult;
+    expect(calls[1]?.constraint).toEqual({ type: 'SCALE', value: 1 });
+    expect(forced.images[0]).toMatchObject({ width: 3072, height: 2000, scale: 1 });
   });
 
   it('throws on empty/invalid nodeIds, bad format, or non-positive scale', async () => {

--- a/packages/shared/src/queries.ts
+++ b/packages/shared/src/queries.ts
@@ -37,6 +37,15 @@ export const ScreenshotImageSchema = z.object({
   base64: z.string().nullable(),
   empty: z.boolean().optional(),
   recovered: z.boolean().optional(),
+  /**
+   * Raster export size (px) + the effective export scale — the anchor for mapping raster px back to
+   * design px, essential when the scale was auto-fitted (omitted `scale` fits the long edge to a
+   * legible window) or the node was recovered at intrinsic bounds. Computed from bounds × scale
+   * (±1px of Figma's own rounding). Absent for SVG and when the node's bounds are unknown.
+   */
+  width: z.number().optional(),
+  height: z.number().optional(),
+  scale: z.number().optional(),
 });
 export type ScreenshotImage = z.infer<typeof ScreenshotImageSchema>;
 


### PR DESCRIPTION
## What

Two upgrades to the hottest visual-grounding tool, plus a schema consistency fix:

1. **Auto-fit default scale.** With `scale` omitted, each node's raster export is fitted so its long edge lands in **[512, 1536]px**: oversized frames scale down — vision models downsample beyond ~1.5k px anyway, so a 3000px-tall page at 1× was pure payload (and UI-thread msgpack / disconnect risk) with zero fidelity gain — and tiny icons scale up (≤4×) so a 24px glyph is actually legible instead of a smudge. An **explicit `scale` is honored exactly**, so the old behaviour stays reachable.
2. **Exported size in the label.** Raster results now carry `width`/`height`/`scale`, surfaced in the per-image text label (`1:1 (PNG 1536×1000px @0.5x)`) — the anchor for mapping raster px back to design px, essential once the scale is auto-fitted or a clipped node was recovered at intrinsic bounds. SVG and old-plugin results simply omit the fields and degrade to the bare label.
3. **`scale` schema `.min(0)` → `.positive()`** on `get_screenshot` + `save_screenshots` — the plugin already threw on `scale <= 0`; the advertised schema now agrees.

## Equal-or-better

- What the model *sees* is equal or better in both directions: downscaled big frames match what the vision pipeline produced anyway (at a fraction of the payload), upscaled icons are strictly more legible. Explicit `scale` keeps exact old behaviour.
- **`save_screenshots` is exempt by construction** — it now always forwards an explicit scale (default 1), so files on disk (user artifacts: image assets, exported comps) stay full-res.
- `icon_map`'s SVG fallback path is untouched (SVG ignores scale).
- Blanks (`empty:true`) are not fitted — no point scaling a blank.
- Version skew tolerated both ways: an older plugin sends no dims → bare label; an older server ignores the extra fields.

## Tests

754 tests green (3 new: oversized down-fit, mid-size 1×/explicit-scale honored, dims label); typecheck / lint / format:check / knip / build all pass.