### PR TITLE
docs(tools): truthful, steering descriptions for get_node / get_selection / get_design_context

### DIFF
--- a/packages/mcp/src/tools/get-design-context.ts
+++ b/packages/mcp/src/tools/get-design-context.ts
@@ -8,17 +8,21 @@ export const GET_DESIGN_CONTEXT_TOOL_NAME = 'get_design_context';
 export const getDesignContextTool: ToolSpec = {
   name: GET_DESIGN_CONTEXT_TOOL_NAME,
   description:
-    'Get a depth-limited, token-efficient node tree for exploring large files — prefer this over ' +
-    'get_document. Starts from nodeId, else the current selection, else the current page. ' +
-    'depth limits child levels (omit or 0 = unlimited). detail is minimal / compact / full. ' +
-    'dedupeComponents collapses repeated component instances (children of an already-seen main ' +
-    'component are omitted and flagged deduped). A deduped instance still carries textOverrides — ' +
-    'the visible text it renders ({ name, characters }) — so per-instance content (card titles, ' +
-    'list items, form labels) is available without re-expanding the collapsed subtree.',
+    'Get a depth-limited, token-efficient node tree — the main design-grounding read; prefer it ' +
+    'over get_document / get_node for anything large. Starts from nodeId (a pasted Figma URL also ' +
+    'works), else the current selection; errors when neither is available. ' +
+    'detail: minimal (id/name/type) / compact (+ geometry; the default) / full — only full carries ' +
+    'styling, layout, text and design-system tokens resolved to names plus a deduped globalVars ' +
+    'style table, so always use full (with dedupeComponents: true) when generating code; compact ' +
+    'is for cheap structure scans. depth limits child levels (omit or 0 = unlimited; cut nodes are ' +
+    'flagged truncated). dedupeComponents collapses repeated instances of an already-expanded main ' +
+    'component (flagged deduped); a deduped instance still carries textOverrides ({ name, ' +
+    'characters } — the visible text it actually renders) and propertyOverrides (its per-instance ' +
+    'visual diffs), so per-instance content survives without re-expanding the collapsed subtree.',
   inputShape: {
     nodeId: z
       .string()
-      .describe('Root node id; omit to use the selection or current page')
+      .describe('Root node id (a pasted Figma URL also works); omit to use the selection')
       .optional(),
     depth: z
       .number()

--- a/packages/mcp/src/tools/get-node.ts
+++ b/packages/mcp/src/tools/get-node.ts
@@ -6,7 +6,15 @@ export const GET_NODE_TOOL_NAME = 'get_node';
 
 export const getNodeTool: ToolSpec = {
   name: GET_NODE_TOOL_NAME,
-  description: 'Return a single Figma node by id, with full recursive children subtree.',
-  inputShape: { nodeId: z.string().describe('Figma node id, e.g. "1:42"') },
+  description:
+    'Return one node by id with its full recursive subtree at maximum fidelity — every serialized ' +
+    'field (geometry, paints, effects, auto-layout, text with per-run segments, style/variable ids, ' +
+    'mainComponent), no depth limit, no deduplication. Best for inspecting a single component or a ' +
+    'node you are about to modify; for exploring or grounding anything large, prefer ' +
+    'get_design_context (depth-limited, deduped, tokens resolved to names). Returns { node }, ' +
+    'null when the id matches nothing.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id, e.g. "1:42"; a pasted Figma URL also works'),
+  },
   kind: 'read',
 };

--- a/packages/mcp/src/tools/get-selection.ts
+++ b/packages/mcp/src/tools/get-selection.ts
@@ -5,7 +5,11 @@ export const GET_SELECTION_TOOL_NAME = 'get_selection';
 export const getSelectionTool: ToolSpec = {
   name: GET_SELECTION_TOOL_NAME,
   description:
-    'Return the IDs and basic geometry of the currently selected nodes on the active Figma page.',
+    'Return the current selection on the active Figma page: { pageId, pageName, nodes }, where ' +
+    'each node is a full flat serialization — geometry, fills/strokes/effects, text properties, ' +
+    'style/variable ids, mainComponent — without children. The zero-argument "what is the user ' +
+    'looking at" call: use it to identify the selected node ids (and page), then walk deeper with ' +
+    'get_design_context or get_node. An empty nodes array means nothing is selected.',
   inputShape: {},
   kind: 'read',
 };


### PR DESCRIPTION
## What

Description-only upgrades to three of the four hottest read tools (no behaviour change; `get_screenshot`'s description rides in #36 with its behaviour):

- **`get_selection` said 'IDs and basic geometry' — that was wrong.** It returns a full flat serialization per selected node (fills/strokes/effects/text properties/style-variable ids/mainComponent). A description that understates the payload makes the model re-fetch data it already has. Now truthful, and positions the tool as the zero-argument 'what is the user looking at' call.
- **`get_node`** now spells out its max-fidelity / no-depth-limit / no-dedupe semantics and steers large-tree exploration to `get_design_context`.
- **`get_design_context`** drops the stale 'else the current page' claim (whole-page scans have been refused for a while), documents what each detail level actually carries, and bakes in the codegen steering (`detail: full` + `dedupeComponents: true`) that previously lived only in the figma-codegen skill / prompt — so a bare MCP client without the skill gets the same guidance.
- All three `nodeId` input descriptions note that **a pasted Figma URL works** (`normalizeIdArgs` has accepted URLs for a long time; the schemas never said so, so models extracted ids by hand).

Also serves the Glama re-score backlog (tool-description quality is the scoring lever).

## Tests

751 tests green; typecheck / lint / format:check / knip / build all pass. The only description assertion (`get_selection` contains 'select') still holds.