### PR TITLE
feat(set_text_properties): write paragraphSpacing / paragraphIndent

### DIFF
--- a/packages/mcp/src/tools/set-text-properties.ts
+++ b/packages/mcp/src/tools/set-text-properties.ts
@@ -20,9 +20,11 @@ export const setTextPropertiesTool: ToolSpec = {
   name: SET_TEXT_PROPERTIES_TOOL_NAME,
   description:
     "Set a TEXT node's typography and layout/overflow properties. Typography: fontName " +
-    '({ family, style }), fontSize, lineHeight, letterSpacing, textCase, textDecoration — these ' +
-    'load the required fonts first. Layout/overflow: textTruncation (ellipsis), maxLines (line ' +
-    'clamp), textAutoResize. Any field may be omitted to leave it unchanged. maxLines applies when ' +
+    '({ family, style }), fontSize, lineHeight, letterSpacing, textCase, textDecoration, ' +
+    'paragraphSpacing / paragraphIndent (px between / indenting the paragraphs the text splits ' +
+    'into at "\\n" — the write half of the same fields get_design_context reads) — these load the ' +
+    'required fonts first. Layout/overflow: textTruncation (ellipsis), maxLines (line clamp), ' +
+    'textAutoResize. Any field may be omitted to leave it unchanged. maxLines applies when ' +
     'textTruncation is ENDING. Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string().describe('TEXT node id'),
@@ -34,6 +36,16 @@ export const setTextPropertiesTool: ToolSpec = {
     fontSize: z.number().positive().optional().describe('Font size in px'),
     lineHeight: lineHeight.optional(),
     letterSpacing: letterSpacing.optional(),
+    paragraphSpacing: z
+      .number()
+      .min(0)
+      .optional()
+      .describe('Space between paragraphs in px (paragraphs split at "\\n")'),
+    paragraphIndent: z
+      .number()
+      .min(0)
+      .optional()
+      .describe('First-line indent of each paragraph in px'),
     textCase: z
       .enum(['ORIGINAL', 'UPPER', 'LOWER', 'TITLE', 'SMALL_CAPS', 'SMALL_CAPS_FORCED'])
       .optional(),

--- a/packages/mcp/test/tools/write-tools.test.ts
+++ b/packages/mcp/test/tools/write-tools.test.ts
@@ -194,7 +194,7 @@ describe('M2 write tool definitions', () => {
     expect(createInstanceToolDefinition.inputSchema.required).toBeUndefined();
   });
 
-  it('set_text_properties requires nodeId; truncation/maxLines/autoResize optional', () => {
+  it('set_text_properties requires nodeId; truncation/maxLines/autoResize/paragraph optional', () => {
     expect(setTextPropertiesToolDefinition.name).toBe(SET_TEXT_PROPERTIES_TOOL_NAME);
     expect(setTextPropertiesToolDefinition.inputSchema).toMatchObject({
       required: ['nodeId'],
@@ -202,6 +202,8 @@ describe('M2 write tool definitions', () => {
         textTruncation: { enum: ['DISABLED', 'ENDING'] },
         maxLines: { anyOf: [{ type: 'number' }, { type: 'null' }] },
         textAutoResize: { enum: ['NONE', 'HEIGHT', 'WIDTH_AND_HEIGHT', 'TRUNCATE'] },
+        paragraphSpacing: { type: 'number', minimum: 0 },
+        paragraphIndent: { type: 'number', minimum: 0 },
       },
     });
   });

--- a/packages/plugin/src/handlers/set-text-properties.ts
+++ b/packages/plugin/src/handlers/set-text-properties.ts
@@ -4,10 +4,11 @@ import type { SandboxToolHandler } from '../dispatcher.js';
 
 /**
  * Set a TEXT node's typography + layout/overflow props. Typography (fontName/fontSize/lineHeight/
- * letterSpacing/textCase/textDecoration) mutates the node's runs, so Figma requires every font on
- * the node — plus the target fontName, if changing it — to be loaded first. Layout/overflow props
- * (textAutoResize/truncation/maxLines) are node-level and need no font load. Applied in order
- * autoResize → truncation → maxLines because maxLines only takes effect once truncation is ENDING.
+ * letterSpacing/textCase/textDecoration/paragraphSpacing/paragraphIndent) mutates the node's runs,
+ * so Figma requires every font on the node — plus the target fontName, if changing it — to be
+ * loaded first. Layout/overflow props (textAutoResize/truncation/maxLines) are node-level and need
+ * no font load. Applied in order autoResize → truncation → maxLines because maxLines only takes
+ * effect once truncation is ENDING.
  */
 export const createSetTextPropertiesHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
@@ -20,12 +21,26 @@ export const createSetTextPropertiesHandler =
       letterSpacing?: unknown;
       textCase?: unknown;
       textDecoration?: unknown;
+      paragraphSpacing?: unknown;
+      paragraphIndent?: unknown;
       textTruncation?: unknown;
       maxLines?: unknown;
       textAutoResize?: unknown;
     };
     if (typeof p.nodeId !== 'string')
       throw new TypeError('set_text_properties: nodeId must be a string');
+    if (
+      p.paragraphSpacing !== undefined &&
+      (typeof p.paragraphSpacing !== 'number' || p.paragraphSpacing < 0)
+    ) {
+      throw new TypeError('set_text_properties: paragraphSpacing must be a non-negative number');
+    }
+    if (
+      p.paragraphIndent !== undefined &&
+      (typeof p.paragraphIndent !== 'number' || p.paragraphIndent < 0)
+    ) {
+      throw new TypeError('set_text_properties: paragraphIndent must be a non-negative number');
+    }
     if (p.textAutoResize !== undefined && typeof p.textAutoResize !== 'string') {
       throw new TypeError('set_text_properties: textAutoResize must be a string');
     }
@@ -50,7 +65,9 @@ export const createSetTextPropertiesHandler =
       p.lineHeight !== undefined ||
       p.letterSpacing !== undefined ||
       p.textCase !== undefined ||
-      p.textDecoration !== undefined;
+      p.textDecoration !== undefined ||
+      p.paragraphSpacing !== undefined ||
+      p.paragraphIndent !== undefined;
     if (settingTypography) {
       const fonts: FontName[] =
         text.fontName === figmaCtx.mixed && text.characters.length > 0
@@ -66,6 +83,8 @@ export const createSetTextPropertiesHandler =
       if (p.textCase !== undefined) text.textCase = p.textCase as TextNode['textCase'];
       if (p.textDecoration !== undefined)
         text.textDecoration = p.textDecoration as TextNode['textDecoration'];
+      if (p.paragraphSpacing !== undefined) text.paragraphSpacing = p.paragraphSpacing as number;
+      if (p.paragraphIndent !== undefined) text.paragraphIndent = p.paragraphIndent as number;
     }
 
     if (p.textAutoResize !== undefined)

--- a/packages/plugin/test/handlers/set-text-properties.test.ts
+++ b/packages/plugin/test/handlers/set-text-properties.test.ts
@@ -89,6 +89,26 @@ describe('set_text_properties handler', () => {
     });
   });
 
+  it('sets paragraphSpacing / paragraphIndent after loading fonts (they mutate text layout)', async () => {
+    const loadFontAsync = vi.fn<() => Promise<void>>(async () => {});
+    const node = {
+      id: '1:1',
+      type: 'TEXT',
+      characters: 'First paragraph.\nSecond paragraph.',
+      fontName: { family: 'Inter', style: 'Regular' },
+      paragraphSpacing: 0,
+      paragraphIndent: 0,
+    };
+    await createSetTextPropertiesHandler(fakeFigma(node, loadFontAsync))({
+      nodeId: '1:1',
+      paragraphSpacing: 12,
+      paragraphIndent: 24,
+    });
+
+    expect(loadFontAsync).toHaveBeenCalledWith({ family: 'Inter', style: 'Regular' });
+    expect(node).toMatchObject({ paragraphSpacing: 12, paragraphIndent: 24 });
+  });
+
   it('does not load fonts when only layout/overflow props change', async () => {
     const loadFontAsync = vi.fn<() => Promise<void>>(async () => {});
     const node = { id: '1:1', type: 'TEXT', textAutoResize: 'NONE' };
@@ -117,5 +137,18 @@ describe('set_text_properties handler', () => {
         maxLines: 'x',
       }),
     ).rejects.toThrow(/maxLines/);
+    // Figma rejects negative paragraph values at the API boundary — refuse before touching the node.
+    await expect(
+      createSetTextPropertiesHandler(fakeFigma({ id: '1:1', type: 'TEXT' }))({
+        nodeId: '1:1',
+        paragraphSpacing: -1,
+      }),
+    ).rejects.toThrow(/paragraphSpacing/);
+    await expect(
+      createSetTextPropertiesHandler(fakeFigma({ id: '1:1', type: 'TEXT' }))({
+        nodeId: '1:1',
+        paragraphIndent: -1,
+      }),
+    ).rejects.toThrow(/paragraphIndent/);
   });
 });

--- a/skills/figma-build/references/write-rules.md
+++ b/skills/figma-build/references/write-rules.md
@@ -124,3 +124,9 @@ reads as separate text). Each range takes the same props as a read segment — `
 `<ol>`/`<ul>` items — plus design-system bindings `textStyleId` / `fillStyleId` / `boundVariables`, so
 the link tracks `Primary/500` rather than a one-off hex. Set the whole string first (`create_text` /
 `set_text`), then style the ranges.
+
+The same one-node rule applies to **multi-paragraph body text** (an article body, an FAQ answer,
+legal copy): keep the paragraphs in one `TEXT` node separated by `\n` and set the source's
+`p + p { margin }` / `text-indent` as `paragraphSpacing` / `paragraphIndent` via
+`set_text_properties` — don't fake the rhythm by splitting each paragraph into its own node in an
+auto-layout stack (that turns one flowing text into N boxes and reads back as unrelated nodes).


### PR DESCRIPTION
## What

The write half of the paragraph fields `get_design_context` learned to read in #35. Building multi-paragraph body text (article bodies, FAQ answers, legal copy) from source with `p + p { margin }` / `text-indent` previously had no write path short of splitting each paragraph into its own node in an auto-layout stack — which turns one flowing text into N boxes and reads back as unrelated nodes.

- **Two optional fields on the existing `set_text_properties`** — no new tool, tool count unchanged. Omitted = untouched, like every other field on the setter.
- Both mutate text layout, so they join the **font-load group** (same as `lineHeight`/`letterSpacing`): the handler loads the node's fonts first.
- **Negative values refused** before touching the node (Figma rejects them at the API boundary; we fail with the field name instead).
- `write-rules.md` documents the one-node multi-paragraph rule alongside the existing `set_text_range` rich-text guidance.

## Equal-or-better

Purely additive: existing calls carry neither field and behave byte-identically. Closes the read↔write symmetry gap from #35 and unlocks the full live round-trip (write non-zero `paragraphSpacing` → read it back in the `textStyle` bundle).

## Tests

756 tests green (handler font-load + negative-refusal + schema assertion); typecheck / lint / format:check / knip / build all pass.