### PR TITLE
feat(set_variable_code_syntax): declare a variable's code-side token name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **95 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **96 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **95 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **96 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -91,6 +91,7 @@ import { setStrokesTool } from './set-strokes.js';
 import { setTextPropertiesTool } from './set-text-properties.js';
 import { setTextRangeTool } from './set-text-range.js';
 import { setTextTool } from './set-text.js';
+import { setVariableCodeSyntaxTool } from './set-variable-code-syntax.js';
 import { setVariableValueTool } from './set-variable-value.js';
 import { setVisibleTool } from './set-visible.js';
 import type { ToolSpec } from './spec.js';
@@ -176,6 +177,7 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   bindVariableToNodeTool,
   bindVariableToPaintTool,
   renameVariableTool,
+  setVariableCodeSyntaxTool,
   deleteVariableTool,
   deleteVariableCollectionTool,
   groupNodesTool,

--- a/packages/mcp/src/tools/set-variable-code-syntax.ts
+++ b/packages/mcp/src/tools/set-variable-code-syntax.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const SET_VARIABLE_CODE_SYNTAX_TOOL_NAME = 'set_variable_code_syntax';
+
+// A platform declaration: a non-empty name sets it, null removes it, omitted leaves it untouched —
+// the same partial-update idiom as set_text_properties.
+const platformDeclaration = z.string().min(1).nullable();
+
+export const setVariableCodeSyntaxTool: ToolSpec = {
+  name: SET_VARIABLE_CODE_SYNTAX_TOOL_NAME,
+  description:
+    "Declare a variable's code-side token name per platform (codeSyntax) — the write half of the " +
+    'codeSyntax that get_design_context / get_variable_defs surface to codegen as the ' +
+    'authoritative name (e.g. WEB: "--color-primary"). Per platform (WEB / ANDROID / iOS): a ' +
+    'non-empty string sets the declaration, null removes it, an omitted platform is untouched. ' +
+    'When authoring design-system variables from existing code tokens, declare the source token ' +
+    'name here so future codegen resolves to the exact token instead of deriving a name. Returns ' +
+    '{ ok, variableId, name, codeSyntax } with the declarations now in effect.',
+  inputShape: {
+    variableId: z.string().describe('Variable id'),
+    codeSyntax: z
+      .object({
+        WEB: platformDeclaration
+          .optional()
+          .describe('Web/CSS name, e.g. "--color-primary" or "theme.colors.primary"'),
+        ANDROID: platformDeclaration.optional().describe('Android resource name'),
+        iOS: platformDeclaration.optional().describe('iOS symbol name'),
+      })
+      .describe('Per-platform declarations: string sets, null removes, omitted is untouched'),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/test/tools/write-tools.test.ts
+++ b/packages/mcp/test/tools/write-tools.test.ts
@@ -31,6 +31,10 @@ import {
   setTextPropertiesTool,
 } from '../../src/tools/set-text-properties.js';
 import { SET_TEXT_TOOL_NAME, setTextTool } from '../../src/tools/set-text.js';
+import {
+  SET_VARIABLE_CODE_SYNTAX_TOOL_NAME,
+  setVariableCodeSyntaxTool,
+} from '../../src/tools/set-variable-code-syntax.js';
 import { SET_VISIBLE_TOOL_NAME, setVisibleTool } from '../../src/tools/set-visible.js';
 import { UNLOCK_NODES_TOOL_NAME, unlockNodesTool } from '../../src/tools/unlock-nodes.js';
 import { toToolDefinition } from '../tool-schema.js';
@@ -57,6 +61,7 @@ const setOpacityToolDefinition = toToolDefinition(setOpacityTool);
 const setStrokesToolDefinition = toToolDefinition(setStrokesTool);
 const setTextPropertiesToolDefinition = toToolDefinition(setTextPropertiesTool);
 const setTextToolDefinition = toToolDefinition(setTextTool);
+const setVariableCodeSyntaxToolDefinition = toToolDefinition(setVariableCodeSyntaxTool);
 const setVisibleToolDefinition = toToolDefinition(setVisibleTool);
 const unlockNodesToolDefinition = toToolDefinition(unlockNodesTool);
 
@@ -204,6 +209,25 @@ describe('M2 write tool definitions', () => {
         textAutoResize: { enum: ['NONE', 'HEIGHT', 'WIDTH_AND_HEIGHT', 'TRUNCATE'] },
         paragraphSpacing: { type: 'number', minimum: 0 },
         paragraphIndent: { type: 'number', minimum: 0 },
+      },
+    });
+  });
+
+  it('set_variable_code_syntax requires variableId + codeSyntax with nullable platform names', () => {
+    expect(setVariableCodeSyntaxToolDefinition.name).toBe(SET_VARIABLE_CODE_SYNTAX_TOOL_NAME);
+    expect(setVariableCodeSyntaxToolDefinition.inputSchema).toMatchObject({
+      required: ['variableId', 'codeSyntax'],
+      properties: {
+        variableId: { type: 'string' },
+        codeSyntax: {
+          type: 'object',
+          properties: {
+            // string sets (non-empty), null removes — the set_text_properties partial idiom
+            WEB: { anyOf: [{ type: 'string', minLength: 1 }, { type: 'null' }] },
+            ANDROID: { anyOf: [{ type: 'string', minLength: 1 }, { type: 'null' }] },
+            iOS: { anyOf: [{ type: 'string', minLength: 1 }, { type: 'null' }] },
+          },
+        },
       },
     });
   });

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -83,6 +83,7 @@ import { createSetStrokesHandler } from './set-strokes.js';
 import { createSetTextPropertiesHandler } from './set-text-properties.js';
 import { createSetTextRangeHandler } from './set-text-range.js';
 import { createSetTextHandler } from './set-text.js';
+import { createSetVariableCodeSyntaxHandler } from './set-variable-code-syntax.js';
 import { createSetVariableValueHandler } from './set-variable-value.js';
 import { createSetVisibleHandler } from './set-visible.js';
 import { createSwapComponentHandler } from './swap-component.js';
@@ -145,6 +146,7 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     bind_variable_to_node: createBindVariableToNodeHandler(figmaCtx),
     bind_variable_to_paint: createBindVariableToPaintHandler(figmaCtx),
     rename_variable: createRenameVariableHandler(figmaCtx),
+    set_variable_code_syntax: createSetVariableCodeSyntaxHandler(figmaCtx),
     delete_variable: createDeleteVariableHandler(figmaCtx),
     delete_variable_collection: createDeleteVariableCollectionHandler(figmaCtx),
     // Structure + bulk text

--- a/packages/plugin/src/handlers/set-variable-code-syntax.ts
+++ b/packages/plugin/src/handlers/set-variable-code-syntax.ts
@@ -1,0 +1,58 @@
+import type { VariableResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { serializeCodeSyntax } from '../serializer.js';
+
+// The exact platform literals Figma accepts (note the mixed-case 'iOS') — also the wire keys the
+// read side (get_variable_defs / resolveTokens) emits verbatim, keeping write↔read symmetric.
+const PLATFORMS = ['WEB', 'ANDROID', 'iOS'] as const;
+type Platform = (typeof PLATFORMS)[number];
+
+export const createSetVariableCodeSyntaxHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { variableId?: unknown; codeSyntax?: unknown };
+    if (typeof p.variableId !== 'string') {
+      throw new TypeError('set_variable_code_syntax: variableId must be a string');
+    }
+    if (typeof p.codeSyntax !== 'object' || p.codeSyntax === null) {
+      throw new TypeError('set_variable_code_syntax: codeSyntax must be an object');
+    }
+    const entries = Object.entries(p.codeSyntax);
+    if (entries.length === 0) {
+      throw new TypeError(
+        `set_variable_code_syntax: codeSyntax must declare at least one platform (${PLATFORMS.join(' / ')})`,
+      );
+    }
+    for (const [platform, value] of entries) {
+      if (!(PLATFORMS as readonly string[]).includes(platform)) {
+        throw new TypeError(
+          `set_variable_code_syntax: unknown platform "${platform}" — use ${PLATFORMS.join(' / ')}`,
+        );
+      }
+      // null = remove; otherwise a non-empty name (an empty string is an ambiguous half-removal —
+      // the read side would filter it, leaving a declaration that exists but never surfaces).
+      if (value !== null && (typeof value !== 'string' || value === '')) {
+        throw new TypeError(
+          `set_variable_code_syntax: ${platform} must be a non-empty string, or null to remove`,
+        );
+      }
+    }
+
+    const variable = await figmaCtx.variables.getVariableByIdAsync(p.variableId);
+    if (variable === null) {
+      throw new Error(`set_variable_code_syntax: variable ${p.variableId} not found`);
+    }
+
+    for (const [platform, value] of entries) {
+      if (value === null) variable.removeVariableCodeSyntax(platform as Platform);
+      else variable.setVariableCodeSyntax(platform as Platform, value as string);
+    }
+
+    // Echo the declarations now in effect (read back off the variable, same shape as the read side)
+    // so the caller can confirm the result without a second tool call.
+    const result: VariableResult = { ok: true, variableId: variable.id, name: variable.name };
+    const codeSyntax = serializeCodeSyntax(variable.codeSyntax);
+    if (codeSyntax !== undefined) result.codeSyntax = codeSyntax;
+    return result;
+  };

--- a/packages/plugin/src/serializer.ts
+++ b/packages/plugin/src/serializer.ts
@@ -673,6 +673,21 @@ export const serializeEffect = (effect: Effect): SerializedEffect => {
   return out;
 };
 
+/**
+ * A variable's designer-declared code-side names ({ WEB / ANDROID / iOS → string }), dropping empty
+ * strings (a cleared declaration). Returns undefined when nothing meaningful is declared, so
+ * callers only emit the field when it carries real intent. Shared by get_variable_defs and
+ * get_design_context's resolveTokens.
+ */
+export const serializeCodeSyntax = (raw: unknown): Record<string, string> | undefined => {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const out: Record<string, string> = {};
+  for (const [platform, name] of Object.entries(raw)) {
+    if (typeof name === 'string' && name !== '') out[platform] = name;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
 export const serializeLayoutGrid = (grid: LayoutGrid): SerializedLayoutGrid => {
   if (grid.pattern === 'GRID') {
     return { pattern: 'GRID', visible: grid.visible ?? true, sectionSize: grid.sectionSize };

--- a/packages/plugin/test/handlers/set-variable-code-syntax.test.ts
+++ b/packages/plugin/test/handlers/set-variable-code-syntax.test.ts
@@ -1,0 +1,87 @@
+import type { VariableResult } from '@figwright/shared';
+import { describe, expect, it } from 'vitest';
+
+import { createSetVariableCodeSyntaxHandler } from '../../src/handlers/set-variable-code-syntax.js';
+
+/** A fake Variable whose set/remove mutate the backing codeSyntax record like the real API. */
+const fakeVariable = (initial: Record<string, string> = {}): Record<string, unknown> => {
+  const codeSyntax: Record<string, string> = { ...initial };
+  return {
+    id: 'V:1',
+    name: 'color/primary',
+    codeSyntax,
+    setVariableCodeSyntax: (platform: string, value: string) => {
+      codeSyntax[platform] = value;
+    },
+    removeVariableCodeSyntax: (platform: string) => {
+      delete codeSyntax[platform];
+    },
+  };
+};
+
+const fakeFigma = (variable: unknown): typeof figma =>
+  ({
+    variables: {
+      getVariableByIdAsync: async (id: string) => (id === 'V:1' ? variable : null),
+    },
+  }) as unknown as typeof figma;
+
+describe('set_variable_code_syntax handler', () => {
+  it('sets declarations per platform and echoes the result', async () => {
+    const variable = fakeVariable();
+    const handler = createSetVariableCodeSyntaxHandler(fakeFigma(variable));
+    const result = (await handler({
+      variableId: 'V:1',
+      codeSyntax: { WEB: '--color-primary', iOS: 'ColorPrimary' },
+    })) as VariableResult;
+
+    expect(result).toEqual({
+      ok: true,
+      variableId: 'V:1',
+      name: 'color/primary',
+      codeSyntax: { WEB: '--color-primary', iOS: 'ColorPrimary' },
+    });
+  });
+
+  it('null removes a declaration, omitted platforms are untouched', async () => {
+    const variable = fakeVariable({ WEB: '--old', ANDROID: 'color_primary' });
+    const handler = createSetVariableCodeSyntaxHandler(fakeFigma(variable));
+    const result = (await handler({
+      variableId: 'V:1',
+      codeSyntax: { WEB: null },
+    })) as VariableResult;
+
+    // WEB removed, ANDROID untouched
+    expect(result.codeSyntax).toEqual({ ANDROID: 'color_primary' });
+  });
+
+  it('omits the codeSyntax echo when the last declaration is removed', async () => {
+    const variable = fakeVariable({ WEB: '--old' });
+    const handler = createSetVariableCodeSyntaxHandler(fakeFigma(variable));
+    const result = (await handler({
+      variableId: 'V:1',
+      codeSyntax: { WEB: null },
+    })) as VariableResult;
+
+    expect(result).toEqual({ ok: true, variableId: 'V:1', name: 'color/primary' });
+  });
+
+  it('throws on missing variable, unknown platform, empty object, or empty-string name', async () => {
+    const handler = createSetVariableCodeSyntaxHandler(fakeFigma(fakeVariable()));
+    await expect(handler({ variableId: 'V:9', codeSyntax: { WEB: '--x' } })).rejects.toThrow(
+      /V:9 not found/,
+    );
+    await expect(handler({ variableId: 'V:1', codeSyntax: { web: '--x' } })).rejects.toThrow(
+      /unknown platform "web"/,
+    );
+    await expect(handler({ variableId: 'V:1', codeSyntax: {} })).rejects.toThrow(
+      /at least one platform/,
+    );
+    // '' is an ambiguous half-removal (the read side filters it out) — require null to remove
+    await expect(handler({ variableId: 'V:1', codeSyntax: { WEB: '' } })).rejects.toThrow(
+      /non-empty string, or null/,
+    );
+    await expect(handler({ variableId: 'V:1' })).rejects.toThrow(/codeSyntax/);
+    await expect(handler({ codeSyntax: { WEB: '--x' } })).rejects.toThrow(/variableId/);
+  });
+});

--- a/packages/shared/src/writes.ts
+++ b/packages/shared/src/writes.ts
@@ -64,6 +64,8 @@ export const VariableResultSchema = z.object({
   ok: z.literal(true),
   variableId: z.string(),
   name: z.string(),
+  /** The per-platform declarations now in effect (set_variable_code_syntax echoes them back). */
+  codeSyntax: z.record(z.string(), z.string()).optional(),
 });
 export type VariableResult = z.infer<typeof VariableResultSchema>;
 

--- a/skills/figma-build/references/author-design-system.md
+++ b/skills/figma-build/references/author-design-system.md
@@ -19,6 +19,11 @@ Build the collection top-down — the collection hands you the mode id you need 
    type: a number for `FLOAT`, a string for `STRING`, a boolean for `BOOLEAN`, `{ r, g, b, a }`
    (0–1) for `COLOR`, or `{ type: "VARIABLE_ALIAS", id }` to alias another variable (semantic token
    → primitive token).
+4. **`set_variable_code_syntax`** (`variableId`, `codeSyntax: { WEB: "--color-primary" }`) — when
+   the variable comes **from an existing code token** (a CSS custom property, a Tailwind theme key),
+   declare that source name here. It closes the round-trip: future codegen reads it back as the
+   authoritative name (`codeSyntax` on the resolved token) instead of re-deriving one from the
+   Figma name. Skip it for tokens that have no code-side counterpart yet.
 
 Then **bind** the new variable the same way you'd bind an existing one — colour via
 `bind_variable_to_paint`, scalars via `bind_variable_to_node` (see `write-rules.md`).


### PR DESCRIPTION
## What

The write half of `codeSyntax` (read side: #39) — closing the round-trip the user asked for (「雙向都可以通」). New tool `set_variable_code_syntax` (95 → **96 tools**):

- **Per platform (`WEB` / `ANDROID` / `iOS`)**: a non-empty string sets the declaration, `null` removes it, an omitted platform is untouched — the same partial-update idiom as `set_text_properties`. Platform keys are Figma's exact literals (including mixed-case `iOS`), matching what the read side emits verbatim.
- **Empty string refused** with an actionable error: the read side filters empty declarations, so `''` would create a declaration that exists but never surfaces — an ambiguous half-removal. `null` is the explicit remove.
- **Result echoes the declarations now in effect** (read back off the variable), so the caller confirms without a second call.
- `author-design-system.md` adds it as step 4 of the variable-authoring flow: when a variable is created **from an existing code token**, declare the source name so future codegen resolves to the exact token instead of deriving one.
- Not in the batch allowlist — consistent with every other variable tool (batch is the reversible node-mutation family).

## Merge-order note

Independent of #39 (doesn't touch `ResolvedToken` / read paths), but both need the same `serializeCodeSyntax` helper — this branch carries a **byte-identical** copy at the identical location, so git merges the two cleanly **in either order** with a single copy in the result.

## Equal-or-better

Purely additive new tool; no existing tool or payload changes (`VariableResult` gains an optional echoed field only this tool sets).

## Tests

761 tests green (handler: set/remove/echo/partial + missing-variable/unknown-platform/empty-object/empty-string refusals; schema assertion; registry sync auto-verifies server↔plugin wiring); typecheck / lint / format:check / knip / build all pass.