### PR TITLE
feat(design_diff): report per-node design changes against a saved baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **96 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **97 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
@@ -182,11 +182,11 @@ npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-cod
 
 ## Tools
 
-Figwright exposes **93 MCP tools** in three groups:
+Figwright exposes **97 MCP tools** in three groups:
 
 - **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, and PDF export.
 - **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components, pages, and reactions; plus a `batch` tool to apply many edits at once.
-- **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have.
+- **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have; plus `design_diff`, which reports what changed in a design against a saved baseline so you update only the affected code.
 
 > [!TIP]
 > Your MCP client lists every tool at connect time — that's always the authoritative, up-to-date catalog.

--- a/packages/mcp/src/diff/design-diff.ts
+++ b/packages/mcp/src/diff/design-diff.ts
@@ -1,0 +1,225 @@
+import type { GetDesignContextResult, DesignContextNode } from '@figwright/shared';
+
+// The design-diff core: compare two get_design_context snapshots of the same node and report what
+// changed, per node, per property. Pure over its inputs (no filesystem, no plugin) so it's fully
+// unit-testable; design-diff the tool wraps it with the snapshot store + the get_design_context call.
+//
+// Two normalizations make the output actionable rather than opaque:
+//   1. globalVars refs (fill / stroke / effect / textStyle point into result.globalVars.styles by a
+//      content-hash id) are inlined to their actual value, so a changed fill reads as a paint delta,
+//      not "fill_AB12 → fill_9F3K".
+//   2. token ids (styleIds slots + boundVariables bindings point into result.styles / result.variables)
+//      are resolved to their human names, so a rebind reads as "Primary/500 → Primary/600".
+// Both are applied symmetrically to baseline and current, so the diff compares like with like. The
+// stored snapshot keeps the RAW result (faithful, re-diffable if this logic improves) — resolution
+// lives here, at compare time.
+
+export interface FieldChange {
+  /** The node field that changed (a DesignContextNode key, or synthetic `parent` / `order`). */
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+export type NodeChangeKind = 'added' | 'removed' | 'changed';
+
+export interface NodeChange {
+  id: string;
+  name: string;
+  type: string;
+  /** Readable location: the chain of ancestor names, e.g. "PriceCard / Header / Title". */
+  path: string;
+  kind: NodeChangeKind;
+  /** Present only for `changed`: the per-field deltas (resolved values). */
+  fields?: FieldChange[];
+}
+
+export interface DesignDiffChanges {
+  added: NodeChange[];
+  removed: NodeChange[];
+  changed: NodeChange[];
+}
+
+/** A node flattened for comparison: own fields (resolved, children stripped) + structural context. */
+interface FlatNode {
+  own: Record<string, unknown>;
+  name: string;
+  type: string;
+  path: string;
+  parentId: string | null;
+  index: number;
+}
+
+/** Structural walk keys that must never be treated as a comparable value field. */
+const STRUCTURAL_KEYS = new Set(['children']);
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * Deep structural equality over the JSON-ish values get_design_context emits
+ * (primitives/arrays/objects).
+ */
+export const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    const bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    return ak.every(k => Object.hasOwn(b, k) && deepEqual(a[k], b[k]));
+  }
+  return false;
+};
+
+/**
+ * Resolve one node's own fields into diff-ready values: inline globalVars style refs and map token
+ * ids to names, using the result-level tables. Non-own-value keys (children) are dropped; every
+ * other key is copied through so a schema field added later is diffed automatically (no allowlist
+ * to go stale — matching the repo's "don't drop a dimension" bar).
+ */
+const resolveOwnFields = (
+  node: DesignContextNode,
+  globalVars: Readonly<Record<string, unknown>>,
+  tokenName: (id: string) => string,
+): Record<string, unknown> => {
+  const own: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (STRUCTURAL_KEYS.has(key)) continue;
+    if (
+      (key === 'fill' || key === 'stroke' || key === 'effect' || key === 'textStyle') &&
+      typeof value === 'string'
+    ) {
+      // A globalVars ref → its actual bundle, so the delta is the paint/typography, not the hash.
+      own[key] = Object.hasOwn(globalVars, value) ? globalVars[value] : value;
+      continue;
+    }
+    if (key === 'styleIds' && isPlainObject(value)) {
+      // { fill: "S:1", text: "S:2" } → { fill: "Primary/500", text: "Body/Bold" }
+      const out: Record<string, unknown> = {};
+      for (const [slot, id] of Object.entries(value)) {
+        out[slot] = typeof id === 'string' ? tokenName(id) : id;
+      }
+      own[key] = out;
+      continue;
+    }
+    if (key === 'boundVariables' && isPlainObject(value)) {
+      // { fills: ["V:1"], … } → { fills: ["Primary/500"], … }
+      const out: Record<string, unknown> = {};
+      for (const [prop, ids] of Object.entries(value)) {
+        out[prop] = Array.isArray(ids)
+          ? ids.map(id => (typeof id === 'string' ? tokenName(id) : id))
+          : ids;
+      }
+      own[key] = out;
+      continue;
+    }
+    own[key] = value;
+  }
+  return own;
+};
+
+/**
+ * Flatten a snapshot into id → FlatNode, resolving refs/tokens and recording each node's path,
+ * parent, and sibling index. Duplicate ids (shouldn't happen in one Figma tree) keep the first
+ * seen.
+ */
+const flattenResolved = (ctx: GetDesignContextResult): Map<string, FlatNode> => {
+  const globalVars = ctx.globalVars?.styles ?? {};
+  const tokenName = (id: string): string =>
+    ctx.variables?.[id]?.name ?? ctx.styles?.[id]?.name ?? id;
+
+  const out = new Map<string, FlatNode>();
+  const visit = (
+    node: DesignContextNode,
+    parentId: string | null,
+    index: number,
+    ancestry: readonly string[],
+  ): void => {
+    const path = [...ancestry, node.name].join(' / ');
+    if (!out.has(node.id)) {
+      out.set(node.id, {
+        own: resolveOwnFields(node, globalVars, tokenName),
+        name: node.name,
+        type: node.type,
+        path,
+        parentId,
+        index,
+      });
+    }
+    const kids = node.children ?? [];
+    for (let i = 0; i < kids.length; i += 1)
+      visit(kids[i] as DesignContextNode, node.id, i, [...ancestry, node.name]);
+  };
+  for (let i = 0; i < ctx.nodes.length; i += 1)
+    visit(ctx.nodes[i] as DesignContextNode, null, i, []);
+  return out;
+};
+
+/** The per-field deltas between two flattened nodes: own-field changes plus structural moves. */
+const fieldChanges = (before: FlatNode, after: FlatNode): FieldChange[] => {
+  const changes: FieldChange[] = [];
+  const keys = new Set([...Object.keys(before.own), ...Object.keys(after.own)]);
+  for (const key of [...keys].toSorted()) {
+    const b = before.own[key];
+    const a = after.own[key];
+    if (!deepEqual(b, a)) changes.push({ field: key, before: b, after: a });
+  }
+  // Structure: a reparent (parent changed) subsumes any index shift; a pure reorder (same parent,
+  // new index) is reported on its own. Both are real design edits worth surfacing.
+  if (before.parentId !== after.parentId) {
+    changes.push({ field: 'parent', before: before.parentId, after: after.parentId });
+  } else if (before.index !== after.index) {
+    changes.push({ field: 'order', before: before.index, after: after.index });
+  }
+  return changes;
+};
+
+const asChange = (
+  flat: FlatNode,
+  id: string,
+  kind: NodeChangeKind,
+  fields?: FieldChange[],
+): NodeChange => ({
+  id,
+  name: flat.name,
+  type: flat.type,
+  path: flat.path,
+  kind,
+  ...(fields === undefined ? {} : { fields }),
+});
+
+/**
+ * Diff two get_design_context snapshots of the same root. Nodes are matched by Figma id (stable
+ * across property edits within a file); a node only in the baseline is `removed`, only in the
+ * current is `added`, in both with any field/structure delta is `changed`. Pure.
+ */
+export const diffDesignContext = (
+  baseline: GetDesignContextResult,
+  current: GetDesignContextResult,
+): DesignDiffChanges => {
+  const before = flattenResolved(baseline);
+  const after = flattenResolved(current);
+
+  const removed: NodeChange[] = [];
+  const changed: NodeChange[] = [];
+  for (const [id, flat] of before) {
+    const now = after.get(id);
+    if (now === undefined) {
+      removed.push(asChange(flat, id, 'removed'));
+      continue;
+    }
+    const fields = fieldChanges(flat, now);
+    if (fields.length > 0) changed.push(asChange(now, id, 'changed', fields));
+  }
+
+  const added: NodeChange[] = [];
+  for (const [id, flat] of after) {
+    if (!before.has(id)) added.push(asChange(flat, id, 'added'));
+  }
+
+  return { added, removed, changed };
+};

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,7 @@ import { normalizeIdArgs } from './node-id.js';
 import { PROMPTS } from './prompts/registry.js';
 import { ANALYZE_PROJECT_TOOL_NAME, handleAnalyzeProject } from './tools/analyze-project.js';
 import { COMPONENT_MAP_TOOL_NAME, handleComponentMap } from './tools/component-map.js';
+import { DESIGN_DIFF_TOOL_NAME, handleDesignDiff } from './tools/design-diff.js';
 import { EXPORT_PDF_TOOL_NAME, handleExportPdf } from './tools/export-pdf.js';
 import { GET_SCREENSHOT_TOOL_NAME, screenshotContent } from './tools/get-screenshot.js';
 import { handleIconMap, ICON_MAP_TOOL_NAME } from './tools/icon-map.js';
@@ -103,6 +104,7 @@ const SPECIAL_HANDLERS: Record<string, ToolHandler> = {
     textResult(await handleComponentMap(await routedDispatch(), args)),
   [TOKEN_MAP_TOOL_NAME]: async args => textResult(await handleTokenMap(dispatch, args)),
   [ICON_MAP_TOOL_NAME]: async args => textResult(await handleIconMap(await routedDispatch(), args)),
+  [DESIGN_DIFF_TOOL_NAME]: async args => textResult(await handleDesignDiff(dispatch, args)),
 };
 
 // Reversible writes that destroy data — surfaced via the destructiveHint annotation. Other writes

--- a/packages/mcp/src/tools/design-diff.ts
+++ b/packages/mcp/src/tools/design-diff.ts
@@ -1,0 +1,209 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import type { GetDesignContextResult } from '@figwright/shared';
+import { z } from 'zod';
+
+import { type DesignDiffChanges, diffDesignContext } from '../diff/design-diff.js';
+import { GET_DESIGN_CONTEXT_TOOL_NAME } from './get-design-context.js';
+import type { ToolSpec } from './spec.js';
+
+export const DESIGN_DIFF_TOOL_NAME = 'design_diff';
+
+// design_diff turns the one-shot Figma→code flow into an incremental one: snapshot a node's
+// get_design_context now, and on a later run report exactly what changed in the design (per node,
+// per property) so an agent edits the affected code instead of regenerating the screen. The baseline
+// is written to a file under the project (.figwright/snapshots/) — the tool never mutates Figma and
+// never touches an existing code path; it's a local consumer of get_design_context, like token_map.
+
+/**
+ * Bumped only when the on-disk snapshot shape changes; an older file is re-baselined, never
+ * mis-diffed.
+ */
+const SNAPSHOT_FORMAT_VERSION = 1;
+const SNAPSHOT_SUBDIR = join('.figwright', 'snapshots');
+
+const inputShape = {
+  nodeId: z
+    .string()
+    .describe('Node to snapshot / diff (a pasted Figma URL also works); omit to use the selection')
+    .optional(),
+  rootDir: z.string().describe('Project root; defaults to the server cwd').optional(),
+  update: z
+    .boolean()
+    .describe('After diffing, overwrite the baseline with the current design (accept the changes)')
+    .optional(),
+};
+
+export const designDiffTool: ToolSpec = {
+  name: DESIGN_DIFF_TOOL_NAME,
+  description:
+    'Diff a Figma node against a saved baseline of itself, so after a design changes you edit only ' +
+    'the affected code instead of regenerating. First call on a node saves a baseline (its ' +
+    'get_design_context, full detail) under .figwright/snapshots/ and returns status ' +
+    "'baseline-created'; a later call returns status 'diff' with the per-node, per-property changes " +
+    '(added / removed / changed nodes; fills, layout/padding, text, token bindings — resolved to ' +
+    "readable values, not opaque ids) or 'no-changes'. Pass update:true to accept the current design " +
+    'as the new baseline (re-snapshot). nodeId defaults to the selection; rootDir defaults to the ' +
+    'server cwd. The baseline is a plain file the tool writes under the project — committing it (so ' +
+    'teammates share the baseline) or gitignoring it is your call; the tool never changes git. It ' +
+    'never mutates Figma. Scope by a component / section nodeId, the same unit codegen works on.',
+  inputShape,
+  kind: 'local',
+};
+
+export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
+
+/**
+ * The on-disk snapshot: a format tag + provenance + the raw get_design_context result
+ * (re-diffable).
+ */
+interface SnapshotFile {
+  figwrightSnapshot: number;
+  nodeId: string;
+  capturedAt: string;
+  context: GetDesignContextResult;
+}
+
+export interface DesignDiffResult {
+  status: 'baseline-created' | 'diff' | 'no-changes';
+  /** The node id the baseline is keyed by (the requested nodeId, or the resolved root). */
+  nodeId: string;
+  /** Repo-relative path of the baseline file. */
+  snapshotPath: string;
+  /** When the compared-against baseline was captured (absent on baseline-created). */
+  baselineCapturedAt?: string;
+  summary?: { added: number; removed: number; changed: number };
+  changes?: DesignDiffChanges;
+  /** True when update:true rewrote the baseline to the current design. */
+  baselineUpdated?: boolean;
+  note?: string;
+}
+
+const sanitize = (id: string): string => id.replace(/[^a-zA-Z0-9._-]/g, '-');
+
+/**
+ * Root-identity sanity check: warn (don't refuse) when the baseline root looks like a different
+ * node.
+ */
+const identityNote = (
+  baseline: GetDesignContextResult,
+  current: GetDesignContextResult,
+): string | undefined => {
+  const b = baseline.nodes[0];
+  const c = current.nodes[0];
+  if (b === undefined || c === undefined) return undefined;
+  if (b.name === c.name && b.type === c.type) return undefined;
+  return (
+    `baseline root was "${b.name}" [${b.type}] but the current root is "${c.name}" [${c.type}] — ` +
+    'a different node or a renamed root. If this is intentional, re-baseline with update:true.'
+  );
+};
+
+const writeSnapshot = async (
+  absPath: string,
+  nodeId: string,
+  context: GetDesignContextResult,
+): Promise<SnapshotFile> => {
+  await mkdir(dirname(absPath), { recursive: true });
+  const snap: SnapshotFile = {
+    figwrightSnapshot: SNAPSHOT_FORMAT_VERSION,
+    nodeId,
+    capturedAt: new Date().toISOString(),
+    context,
+  };
+  await writeFile(absPath, JSON.stringify(snap, null, 2), 'utf8');
+  return snap;
+};
+
+/** Read + validate a baseline; returns null when absent, unreadable, unparseable, or a stale format. */
+const readSnapshot = async (absPath: string): Promise<SnapshotFile | null> => {
+  let raw: string;
+  try {
+    raw = await readFile(absPath, 'utf8');
+  } catch {
+    return null; // ENOENT (no baseline) or unreadable — treat as "no baseline".
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<SnapshotFile>;
+    if (
+      parsed.figwrightSnapshot !== SNAPSHOT_FORMAT_VERSION ||
+      typeof parsed.context !== 'object' ||
+      parsed.context === null
+    ) {
+      return null; // Stale format or corrupt → re-baseline rather than mis-diff.
+    }
+    return parsed as SnapshotFile;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Snapshot-or-diff a node's design. Fetches the current get_design_context once (the only plugin
+ * round-trip — reading the baseline and computing the diff are local + synchronous), then either
+ * writes the first baseline or diffs against the saved one. Pure diff logic lives in
+ * diff/design-diff.
+ */
+export const handleDesignDiff = async (
+  dispatch: ToolDispatcher,
+  rawArgs: unknown,
+): Promise<DesignDiffResult> => {
+  const args = z.object(inputShape).parse(rawArgs);
+  const rootDir = args.rootDir ?? process.cwd();
+
+  const current = (await dispatch(GET_DESIGN_CONTEXT_TOOL_NAME, {
+    ...(args.nodeId === undefined ? {} : { nodeId: args.nodeId }),
+    detail: 'full',
+    dedupeComponents: true,
+  })) as GetDesignContextResult;
+
+  // Key the baseline by the requested nodeId, or the resolved root when the selection was used.
+  const key = args.nodeId ?? current.nodes[0]?.id;
+  if (key === undefined) {
+    throw new Error('design_diff: no node to diff (empty selection and no nodeId)');
+  }
+  const relPath = join(SNAPSHOT_SUBDIR, `${sanitize(key)}.json`);
+  const absPath = join(rootDir, relPath);
+  const multiRootNote =
+    args.nodeId === undefined && current.nodes.length > 1
+      ? `selection has ${current.nodes.length} root nodes; the baseline is keyed by the first ("${current.nodes[0]?.name}"). Pass an explicit nodeId for a stable per-node baseline.`
+      : undefined;
+
+  const existing = await readSnapshot(absPath);
+
+  if (existing === null) {
+    await writeSnapshot(absPath, key, current);
+    return {
+      status: 'baseline-created',
+      nodeId: key,
+      snapshotPath: relPath,
+      ...(multiRootNote === undefined ? {} : { note: multiRootNote }),
+    };
+  }
+
+  const changes = diffDesignContext(existing.context, current);
+  const summary = {
+    added: changes.added.length,
+    removed: changes.removed.length,
+    changed: changes.changed.length,
+  };
+  const hasChanges = summary.added + summary.removed + summary.changed > 0;
+
+  if (args.update === true) await writeSnapshot(absPath, key, current);
+
+  const notes = [identityNote(existing.context, current), multiRootNote].filter(
+    (n): n is string => n !== undefined,
+  );
+
+  return {
+    status: hasChanges ? 'diff' : 'no-changes',
+    nodeId: key,
+    snapshotPath: relPath,
+    baselineCapturedAt: existing.capturedAt,
+    summary,
+    changes,
+    ...(args.update === true ? { baselineUpdated: true } : {}),
+    ...(notes.length > 0 ? { note: notes.join(' ') } : {}),
+  };
+};

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -32,6 +32,7 @@ import { deletePageTool } from './delete-page.js';
 import { deleteStyleTool } from './delete-style.js';
 import { deleteVariableCollectionTool } from './delete-variable-collection.js';
 import { deleteVariableTool } from './delete-variable.js';
+import { designDiffTool } from './design-diff.js';
 import { detachInstanceTool } from './detach-instance.js';
 import { exportPdfTool } from './export-pdf.js';
 import { findReplaceTextTool } from './find-replace-text.js';
@@ -134,6 +135,7 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   componentMapTool,
   tokenMapTool,
   iconMapTool,
+  designDiffTool,
   // Writes
   setFillsTool,
   setTextTool,

--- a/packages/mcp/test/diff/design-diff.test.ts
+++ b/packages/mcp/test/diff/design-diff.test.ts
@@ -1,0 +1,164 @@
+import type { GetDesignContextResult } from '@figwright/shared';
+import { describe, expect, it } from 'vitest';
+
+import { deepEqual, diffDesignContext } from '../../src/diff/design-diff.js';
+
+// A minimal but realistic get_design_context result: one root frame with two children, styles
+// deduped into globalVars, one bound variable. Overrides let each test mutate a slice.
+const ctx = (over: Partial<GetDesignContextResult> = {}): GetDesignContextResult => ({
+  nodes: [
+    {
+      id: '1:1',
+      name: 'Card',
+      type: 'FRAME',
+      layout: { mode: 'VERTICAL', paddingTop: 16, paddingBottom: 16, itemSpacing: 8 } as never,
+      children: [
+        { id: '1:2', name: 'Title', type: 'TEXT', characters: 'Hello', fill: 'fill_A' },
+        {
+          id: '1:3',
+          name: 'Body',
+          type: 'TEXT',
+          characters: 'World',
+          boundVariables: { fills: ['V:1'] },
+        },
+      ],
+    },
+  ],
+  globalVars: {
+    styles: {
+      fill_A: [{ type: 'SOLID', color: '#111111' }],
+      fill_B: [{ type: 'SOLID', color: '#EE0000' }],
+    },
+  },
+  variables: { 'V:1': { name: 'Primary/500', type: 'COLOR' } },
+  ...over,
+});
+
+describe('diffDesignContext', () => {
+  it('reports no changes for identical snapshots', () => {
+    const d = diffDesignContext(ctx(), ctx());
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([]);
+    expect(d.changed).toEqual([]);
+  });
+
+  it('resolves a globalVars fill ref so a fill change reads as the paint value, not the hash', () => {
+    const after = ctx();
+    // Title now points at fill_B (red) instead of fill_A.
+    (after.nodes[0]!.children![0] as { fill?: string }).fill = 'fill_B';
+    const d = diffDesignContext(ctx(), after);
+    expect(d.changed).toHaveLength(1);
+    const change = d.changed[0]!;
+    expect(change.id).toBe('1:2');
+    expect(change.path).toBe('Card / Title');
+    const fill = change.fields!.find(f => f.field === 'fill')!;
+    // Resolved: before = the #111111 bundle, after = the #EE0000 bundle (not "fill_A" → "fill_B").
+    expect(fill.before).toEqual([{ type: 'SOLID', color: '#111111' }]);
+    expect(fill.after).toEqual([{ type: 'SOLID', color: '#EE0000' }]);
+  });
+
+  it('reports a layout (padding) delta at field granularity', () => {
+    const after = ctx();
+    (after.nodes[0]!.layout as { paddingTop: number }).paddingTop = 24;
+    const d = diffDesignContext(ctx(), after);
+    expect(d.changed).toHaveLength(1);
+    const layout = d.changed[0]!.fields!.find(f => f.field === 'layout')!;
+    expect((layout.before as { paddingTop: number }).paddingTop).toBe(16);
+    expect((layout.after as { paddingTop: number }).paddingTop).toBe(24);
+  });
+
+  it('reports a text content change', () => {
+    const after = ctx();
+    (after.nodes[0]!.children![0] as { characters: string }).characters = 'Hi there';
+    const d = diffDesignContext(ctx(), after);
+    const chars = d.changed[0]!.fields!.find(f => f.field === 'characters')!;
+    expect(chars.before).toBe('Hello');
+    expect(chars.after).toBe('Hi there');
+  });
+
+  it('resolves a bound-variable rebind to token names', () => {
+    const after = ctx({
+      variables: {
+        'V:1': { name: 'Primary/500', type: 'COLOR' },
+        'V:2': { name: 'Primary/600', type: 'COLOR' },
+      },
+    });
+    (after.nodes[0]!.children![1] as { boundVariables?: unknown }).boundVariables = {
+      fills: ['V:2'],
+    };
+    const d = diffDesignContext(ctx(), after);
+    const bound = d.changed[0]!.fields!.find(f => f.field === 'boundVariables')!;
+    expect(bound.before).toEqual({ fills: ['Primary/500'] });
+    expect(bound.after).toEqual({ fills: ['Primary/600'] });
+  });
+
+  it('classifies an added node', () => {
+    const after = ctx();
+    after.nodes[0]!.children = [
+      ...after.nodes[0]!.children!,
+      { id: '1:4', name: 'Badge', type: 'INSTANCE' },
+    ];
+    const d = diffDesignContext(ctx(), after);
+    expect(d.added).toHaveLength(1);
+    expect(d.added[0]).toMatchObject({
+      id: '1:4',
+      name: 'Badge',
+      kind: 'added',
+      path: 'Card / Badge',
+    });
+    expect(d.added[0]!.fields).toBeUndefined();
+  });
+
+  it('classifies a removed node', () => {
+    const after = ctx();
+    after.nodes[0]!.children = [after.nodes[0]!.children![0]!]; // drop Body
+    const d = diffDesignContext(ctx(), after);
+    expect(d.removed).toHaveLength(1);
+    expect(d.removed[0]).toMatchObject({ id: '1:3', name: 'Body', kind: 'removed' });
+  });
+
+  it('reports a reparent as a `parent` field change (not add+remove)', () => {
+    const before = ctx();
+    // Move Body (1:3) out to the root as a sibling of Card.
+    const after = ctx();
+    after.nodes[0]!.children = [after.nodes[0]!.children![0]!];
+    after.nodes = [
+      ...after.nodes,
+      {
+        id: '1:3',
+        name: 'Body',
+        type: 'TEXT',
+        characters: 'World',
+        boundVariables: { fills: ['V:1'] },
+      },
+    ];
+    const d = diffDesignContext(before, after);
+    expect(d.added).toEqual([]);
+    expect(d.removed).toEqual([]);
+    const parent = d.changed.find(c => c.id === '1:3')!.fields!.find(f => f.field === 'parent')!;
+    expect(parent.before).toBe('1:1');
+    expect(parent.after).toBe(null);
+  });
+
+  it('reports a pure sibling reorder as an `order` change', () => {
+    const after = ctx();
+    after.nodes[0]!.children = [after.nodes[0]!.children![1]!, after.nodes[0]!.children![0]!]; // swap
+    const d = diffDesignContext(ctx(), after);
+    const title = d.changed.find(c => c.id === '1:2')!;
+    const order = title.fields!.find(f => f.field === 'order')!;
+    expect(order.before).toBe(0);
+    expect(order.after).toBe(1);
+    // A reorder must not also emit a `parent` change (same parent).
+    expect(title.fields!.some(f => f.field === 'parent')).toBe(false);
+  });
+});
+
+describe('deepEqual', () => {
+  it('compares primitives, arrays, and nested objects structurally', () => {
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] })).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+});

--- a/packages/mcp/test/tools/design-diff.test.ts
+++ b/packages/mcp/test/tools/design-diff.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { GetDesignContextResult } from '@figwright/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { handleDesignDiff, type ToolDispatcher } from '../../src/tools/design-diff.js';
+import { GET_DESIGN_CONTEXT_TOOL_NAME } from '../../src/tools/get-design-context.js';
+
+const SNAP_REL = join('.figwright', 'snapshots', '1-1.json');
+
+const ctx = (over: Partial<GetDesignContextResult> = {}): GetDesignContextResult => ({
+  nodes: [
+    {
+      id: '1:1',
+      name: 'Card',
+      type: 'FRAME',
+      children: [{ id: '1:2', name: 'Title', type: 'TEXT', characters: 'Hello' }],
+    },
+  ],
+  metrics: {
+    nodeCount: 2,
+    maxDepth: 1,
+    styleCount: 0,
+    tokenCount: 0,
+    inlineSizeKb: 1,
+    dedupedSizeKb: 1,
+  },
+  ...over,
+});
+
+describe('handleDesignDiff', () => {
+  let dir: string;
+  let currentCtx: GetDesignContextResult;
+
+  // dispatch stub: design_diff's only round-trip is get_design_context; return the mutable currentCtx.
+  const dispatch: ToolDispatcher = async (tool, args) => {
+    if (tool !== GET_DESIGN_CONTEXT_TOOL_NAME) throw new Error(`unexpected dispatch: ${tool}`);
+    // The tool must always ask for full detail + dedupe (the codegen-equivalent baseline view).
+    expect(args).toMatchObject({ detail: 'full', dedupeComponents: true });
+    return currentCtx;
+  };
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'designdiff-'));
+    currentCtx = ctx();
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes a baseline on the first call and reports baseline-created', async () => {
+    const r = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(r.status).toBe('baseline-created');
+    expect(r.nodeId).toBe('1:1');
+    expect(r.snapshotPath).toBe(SNAP_REL);
+    expect(r.summary).toBeUndefined();
+
+    // The file exists, is format-tagged, and stores the raw context.
+    const saved = JSON.parse(await readFile(join(dir, SNAP_REL), 'utf8'));
+    expect(saved.figwrightSnapshot).toBe(1);
+    expect(saved.nodeId).toBe('1:1');
+    expect(saved.context.nodes[0].id).toBe('1:1');
+  });
+
+  it('reports no-changes when the design is unchanged since the baseline', async () => {
+    await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    const r = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(r.status).toBe('no-changes');
+    expect(r.summary).toEqual({ added: 0, removed: 0, changed: 0 });
+    expect(r.baselineCapturedAt).toBeDefined();
+  });
+
+  it('reports a real per-property change against the baseline', async () => {
+    await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    // The title text changes.
+    currentCtx = ctx();
+    (currentCtx.nodes[0]!.children![0] as { characters: string }).characters = 'Updated';
+    const r = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(r.status).toBe('diff');
+    expect(r.summary).toEqual({ added: 0, removed: 0, changed: 1 });
+    const chars = r.changes!.changed[0]!.fields!.find(f => f.field === 'characters')!;
+    expect(chars.before).toBe('Hello');
+    expect(chars.after).toBe('Updated');
+  });
+
+  it('does not rewrite the baseline on a plain diff, but does with update:true', async () => {
+    await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    currentCtx = ctx();
+    (currentCtx.nodes[0]!.children![0] as { characters: string }).characters = 'Updated';
+
+    // Plain diff: baseline untouched, so a second plain diff still reports the same change.
+    const plain = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(plain.baselineUpdated).toBeUndefined();
+    expect(plain.summary!.changed).toBe(1);
+
+    // update:true accepts the current design as the new baseline...
+    const accepted = await handleDesignDiff(dispatch, {
+      nodeId: '1:1',
+      rootDir: dir,
+      update: true,
+    });
+    expect(accepted.baselineUpdated).toBe(true);
+    // ...so the next diff (still the "Updated" design) is clean.
+    const after = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(after.status).toBe('no-changes');
+  });
+
+  it('re-baselines (never mis-diffs) when the on-disk format version is stale', async () => {
+    await mkdir(join(dir, '.figwright', 'snapshots'), { recursive: true });
+    await writeFile(
+      join(dir, SNAP_REL),
+      JSON.stringify({ figwrightSnapshot: 999, nodeId: '1:1', capturedAt: 'x', context: ctx() }),
+    );
+    const r = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(r.status).toBe('baseline-created');
+    const saved = JSON.parse(await readFile(join(dir, SNAP_REL), 'utf8'));
+    expect(saved.figwrightSnapshot).toBe(1); // rewritten to the current format
+  });
+
+  it('warns (but still diffs) when the baseline root looks like a different node', async () => {
+    await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    // Same id, but the root was renamed/replaced (different name + type).
+    currentCtx = ctx({
+      nodes: [{ id: '1:1', name: 'Sidebar', type: 'COMPONENT', children: [] }],
+    });
+    const r = await handleDesignDiff(dispatch, { nodeId: '1:1', rootDir: dir });
+    expect(r.status).toBe('diff');
+    expect(r.note).toMatch(/different node or a renamed root/i);
+  });
+
+  it('keys the baseline by the resolved root when nodeId is omitted (selection)', async () => {
+    const r = await handleDesignDiff(dispatch, { rootDir: dir });
+    expect(r.nodeId).toBe('1:1');
+    expect(r.snapshotPath).toBe(SNAP_REL);
+  });
+});

--- a/skills/figma-codegen/SKILL.md
+++ b/skills/figma-codegen/SKILL.md
@@ -71,6 +71,23 @@ Then emit code in the detected stack (the profile comes back on `component_map` 
 not call `analyze_project` yourself): compose the reused components, wrap unmapped pieces, and apply
 token references for colour/spacing/radius/typography.
 
+## Keep code in sync as the design changes
+
+Codegen is rarely one-shot — the design keeps moving. To make the second pass an incremental edit
+instead of a regeneration:
+
+- **After you generate**, `design_diff` on the section/component `nodeId` saves a baseline (its
+  `get_design_context`) under `.figwright/snapshots/`. Committing that file lets teammates share the
+  baseline; the tool never touches git.
+- **When asked to re-sync** ("the design changed, update the component"), `design_diff` the same
+  `nodeId` again: it returns the per-node, per-property delta — `added` / `removed` / `changed` nodes
+  with resolved values (a fill, a padding, a text string, a token rebind), each with a readable `path`
+  (`Card / Header / Title`). Edit only the code those nodes map to; don't regenerate the screen.
+  Ground each changed value the usual way (it's a `get_design_context` slice), then `design_diff` with
+  `update: true` to accept the new design as the baseline.
+- Scope it by the same `nodeId` unit you coded from. `no-changes` means the design is untouched since
+  the baseline — nothing to do.
+
 ## Responsive & verify
 
 - **Responsive by default** — root is `w-full`, never the artboard's fixed width; ground breakpoints

--- a/test/tool-registry.test.ts
+++ b/test/tool-registry.test.ts
@@ -23,6 +23,7 @@ const SERVER_ONLY_TOOLS = new Set([
   'component_map',
   'token_map',
   'icon_map',
+  'design_diff',
 ]);
 
 const serverNames = ALL_TOOL_SPECS.map(s => s.name);


### PR DESCRIPTION
## What

Codegen from Figma is rarely one-shot — the design keeps changing, and today the only options are "regenerate the whole screen" or "eyeball two screenshots." `design_diff` makes the second pass **incremental**: it tells you exactly what changed in the design, per node, per property, so an agent edits only the affected code.

- **First call on a node** saves a baseline (its `get_design_context`, full detail + `dedupeComponents`) under `.figwright/snapshots/` → `status: baseline-created`.
- **A later call** returns `status: diff` with `added` / `removed` / `changed` nodes. Each `changed` node lists per-field deltas with **resolved, readable values** — a fill shows the paint, a token binding shows `Primary/500 → Primary/600`, not an opaque `fill_AB12 → fill_9F3K` — plus a readable `path` (`Card / Header / Title`). `no-changes` when the design is untouched.
- `update: true` accepts the current design as the new baseline (re-snapshot).

## Design

- **`diff/design-diff.ts`** — pure, fully unit-tested. Flattens both snapshots by **stable Figma node id**, inlines `globalVars` `fill`/`stroke`/`effect`/`textStyle` refs and resolves `styleIds`/`boundVariables` ids to token names (symmetric on both sides, so the diff compares like-with-like), then classifies add/remove/change with per-field deltas. Reparent surfaces as a `parent` change, a pure sibling reorder as `order`. Field comparison is generic over the node's keys (no allowlist to go stale — a schema field added later is diffed automatically).
- **`tools/design-diff.ts`** — a `local` tool like `token_map`: exactly **one plugin round-trip** (the current `get_design_context`); reading the baseline and computing the diff are local + synchronous, so it adds **no new timeout surface**. Snapshots are format-versioned and re-baselined (never mis-diffed) on a stale/corrupt file; a root name/type identity guard warns without refusing.

## Zero impact on existing functionality

Purely additive: **a new local tool + a new pure module + a one-line registry append**. No existing tool, serializer, plugin handler, or relay path is modified. The tool writes only a file under the project and **never changes git** — committing the baseline (shared across teammates, the "design lockfile" story) or gitignoring it is the user's call.

## Verified

- **Live, plugin connected, against a real Nuxt UI section** (`Header`, 180px): `baseline-created` → `no-changes` on unchanged real data (proving the ref/token normalization is deterministic — a real full-detail tree diffed against itself yields zero spurious changes), then a tampered-baseline diff caught **exactly** the injected text (`Colours → Colors`) and padding (`12 → 4`) changes, with readable paths and no noise elsewhere. Zero mutation to the Figma file.
- **18 new unit tests** (10 pure diff, 8 tool orchestration incl. baseline-created / no-changes / real diff / update-rewrites / stale-format re-baseline / identity-mismatch warn).
- Full gate: typecheck, lint, format:check, knip, build, **789 tests** — all green.

## Usage

Scope by the same component/section `nodeId` you code from. The `figma-codegen` skill now documents the sync workflow (snapshot after generating, diff to re-sync, `update:true` to accept).
