### PR TITLE
feat(component-property): author boolean/text/instance-swap component properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **97 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **101 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
@@ -182,10 +182,10 @@ npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-cod
 
 ## Tools
 
-Figwright exposes **97 MCP tools** in three groups:
+Figwright exposes **101 MCP tools** in three groups:
 
 - **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, and PDF export.
-- **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components, pages, and reactions; plus a `batch` tool to apply many edits at once.
+- **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components (including authoring their boolean/text/instance-swap properties), pages, and reactions; plus a `batch` tool to apply many edits at once.
 - **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have; plus `design_diff`, which reports what changed in a design against a saved baseline so you update only the affected code.
 
 > [!TIP]

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -114,6 +114,7 @@ const DESTRUCTIVE_TOOLS = new Set([
   'delete_page',
   'delete_style',
   'delete_variable',
+  'delete_component_property',
   'ungroup_nodes',
 ]);
 

--- a/packages/mcp/src/tools/add-component-property.ts
+++ b/packages/mcp/src/tools/add-component-property.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const ADD_COMPONENT_PROPERTY_TOOL_NAME = 'add_component_property';
+
+export const addComponentPropertyTool: ToolSpec = {
+  name: ADD_COMPONENT_PROPERTY_TOOL_NAME,
+  description:
+    'Declare a component property on a component (or its variant set): BOOLEAN (show/hide a layer), ' +
+    'TEXT (editable text), or INSTANCE_SWAP (swappable nested instance). The property starts inert — ' +
+    'attach it to a layer with bind_component_property (BOOLEAN→visible, TEXT→characters, ' +
+    'INSTANCE_SWAP→mainComponent) for it to do anything. defaultValue must match the type (boolean / ' +
+    'string / a component key string); preferredValues (INSTANCE_SWAP only) pre-populates the swap ' +
+    'menu. VARIANT properties come from combine_as_variants, not here. Returns { ok, componentId, ' +
+    'propertyId, name } — pass propertyId to bind / edit / delete / set_instance_properties.',
+  inputShape: {
+    componentId: z
+      .string()
+      .describe('Component or component-set id (a variant resolves to its set)'),
+    name: z.string().describe('Property name, e.g. "Show Icon"'),
+    type: z.enum(['BOOLEAN', 'TEXT', 'INSTANCE_SWAP']).describe('Property type'),
+    defaultValue: z
+      .union([z.boolean(), z.string()])
+      .describe('Default: boolean (BOOLEAN), string (TEXT), or a component key (INSTANCE_SWAP)'),
+    preferredValues: z
+      .array(z.object({ type: z.enum(['COMPONENT', 'COMPONENT_SET']), key: z.string() }))
+      .describe('INSTANCE_SWAP only: components/sets offered in the swap menu')
+      .optional(),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/bind-component-property.ts
+++ b/packages/mcp/src/tools/bind-component-property.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const BIND_COMPONENT_PROPERTY_TOOL_NAME = 'bind_component_property';
+
+export const bindComponentPropertyTool: ToolSpec = {
+  name: BIND_COMPONENT_PROPERTY_TOOL_NAME,
+  description:
+    'Attach a declared component property (from add_component_property) to a sublayer field so it ' +
+    'drives that layer: field "visible" for a BOOLEAN, "characters" for a TEXT (the node must be a ' +
+    'TEXT node), "mainComponent" for an INSTANCE_SWAP (the node must be an INSTANCE). The same ' +
+    'property can be bound to several layers (call once per layer). Pass propertyId: null to remove ' +
+    "the binding on that field. The property's type must match the field and it must exist on the " +
+    'containing component. Returns { ok, nodeId }.',
+  inputShape: {
+    nodeId: z.string().describe('Sublayer inside the component to bind on'),
+    field: z
+      .enum(['visible', 'characters', 'mainComponent'])
+      .describe('Which layer field the property drives'),
+    propertyId: z
+      .string()
+      .nullable()
+      .describe('Property id (name#id) to bind, or null to unbind this field'),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/delete-component-property.ts
+++ b/packages/mcp/src/tools/delete-component-property.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const DELETE_COMPONENT_PROPERTY_TOOL_NAME = 'delete_component_property';
+
+export const deleteComponentPropertyTool: ToolSpec = {
+  name: DELETE_COMPONENT_PROPERTY_TOOL_NAME,
+  description:
+    'Remove a BOOLEAN / TEXT / INSTANCE_SWAP property from a component and every sublayer reference ' +
+    'to it. VARIANT properties are the variant-set structure — delete their variants instead; this ' +
+    'refuses a VARIANT. Get current property ids from get_component_api. Returns { ok, componentId, ' +
+    'propertyId, name }.',
+  inputShape: {
+    componentId: z.string().describe('Component or component-set id that owns the property'),
+    propertyId: z.string().describe('Property id to delete (name#id, from get_component_api)'),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/edit-component-property.ts
+++ b/packages/mcp/src/tools/edit-component-property.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const EDIT_COMPONENT_PROPERTY_TOOL_NAME = 'edit_component_property';
+
+export const editComponentPropertyTool: ToolSpec = {
+  name: EDIT_COMPONENT_PROPERTY_TOOL_NAME,
+  description:
+    'Change an existing component property: rename it, change its defaultValue, or (INSTANCE_SWAP ' +
+    'only) change its preferredValues. Supply at least one. Renaming returns a new propertyId (the ' +
+    '#id suffix is kept but the name part changes), so use the returned propertyId for later calls; ' +
+    'existing bindings keep working. Get current property ids from get_component_api. Returns ' +
+    '{ ok, componentId, propertyId, name }.',
+  inputShape: {
+    componentId: z.string().describe('Component or component-set id that owns the property'),
+    propertyId: z.string().describe('Property id to edit (name#id, from get_component_api / add)'),
+    name: z.string().describe('New property name').optional(),
+    defaultValue: z
+      .union([z.boolean(), z.string()])
+      .describe('New default (boolean / string / component key, matching the property type)')
+      .optional(),
+    preferredValues: z
+      .array(z.object({ type: z.enum(['COMPONENT', 'COMPONENT_SET']), key: z.string() }))
+      .describe('INSTANCE_SWAP only: replacement swap-menu components/sets')
+      .optional(),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -3,12 +3,14 @@
 // inputShape); the write set is derived from `kind`, not maintained by hand. A registry test asserts
 // these stay in sync with the plugin's handler map so a new tool can't be half-wired.
 
+import { addComponentPropertyTool } from './add-component-property.js';
 import { addPageTool } from './add-page.js';
 import { addVariableModeTool } from './add-variable-mode.js';
 import { analyzeProjectTool } from './analyze-project.js';
 import { applyStyleToNodeTool } from './apply-style-to-node.js';
 import { batchRenameNodesTool } from './batch-rename-nodes.js';
 import { batchTool } from './batch.js';
+import { bindComponentPropertyTool } from './bind-component-property.js';
 import { bindVariableToNodeTool } from './bind-variable-to-node.js';
 import { bindVariableToPaintTool } from './bind-variable-to-paint.js';
 import { cloneNodeTool } from './clone-node.js';
@@ -27,6 +29,7 @@ import { createTextStyleTool } from './create-text-style.js';
 import { createTextTool } from './create-text.js';
 import { createVariableCollectionTool } from './create-variable-collection.js';
 import { createVariableTool } from './create-variable.js';
+import { deleteComponentPropertyTool } from './delete-component-property.js';
 import { deleteNodesTool } from './delete-nodes.js';
 import { deletePageTool } from './delete-page.js';
 import { deleteStyleTool } from './delete-style.js';
@@ -34,6 +37,7 @@ import { deleteVariableCollectionTool } from './delete-variable-collection.js';
 import { deleteVariableTool } from './delete-variable.js';
 import { designDiffTool } from './design-diff.js';
 import { detachInstanceTool } from './detach-instance.js';
+import { editComponentPropertyTool } from './edit-component-property.js';
 import { exportPdfTool } from './export-pdf.js';
 import { findReplaceTextTool } from './find-replace-text.js';
 import { getAnnotationsTool } from './get-annotations.js';
@@ -196,6 +200,10 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   removeReactionsTool,
   swapComponentTool,
   setInstancePropertiesTool,
+  addComponentPropertyTool,
+  bindComponentPropertyTool,
+  editComponentPropertyTool,
+  deleteComponentPropertyTool,
   detachInstanceTool,
   importImageTool,
   importSvgTool,

--- a/packages/plugin/src/handlers/add-component-property.ts
+++ b/packages/plugin/src/handlers/add-component-property.ts
@@ -1,0 +1,81 @@
+import type { ComponentPropertyResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import {
+  type AuthorablePropertyType,
+  PROPERTY_TYPES,
+  resolveComponentOwner,
+} from './component-property.js';
+
+/**
+ * Declare a BOOLEAN / TEXT / INSTANCE_SWAP property on a component (or its set). The property is
+ * inert until bound to a sublayer field with bind_component_property; this handler only creates the
+ * declaration and returns its Figma-assigned id ("name#id"), the handle every later
+ * bind/edit/delete needs.
+ */
+export const createAddComponentPropertyHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as {
+      componentId?: unknown;
+      name?: unknown;
+      type?: unknown;
+      defaultValue?: unknown;
+      preferredValues?: unknown;
+    };
+    if (typeof p.componentId !== 'string') {
+      throw new TypeError('add_component_property: componentId must be a string');
+    }
+    if (typeof p.name !== 'string' || p.name.length === 0) {
+      throw new TypeError('add_component_property: name must be a non-empty string');
+    }
+    if (!PROPERTY_TYPES.includes(p.type as AuthorablePropertyType)) {
+      throw new TypeError(
+        `add_component_property: type must be one of ${PROPERTY_TYPES.join(' / ')} ` +
+          '(VARIANT properties come from combine_as_variants)',
+      );
+    }
+    const type = p.type as AuthorablePropertyType;
+
+    // defaultValue must match the type: BOOLEAN → boolean, TEXT → string, INSTANCE_SWAP → a
+    // component key string. A mismatch is the easy caller error, so reject it with a precise message.
+    if (type === 'BOOLEAN' && typeof p.defaultValue !== 'boolean') {
+      throw new TypeError(
+        'add_component_property: a BOOLEAN property needs a boolean defaultValue',
+      );
+    }
+    if ((type === 'TEXT' || type === 'INSTANCE_SWAP') && typeof p.defaultValue !== 'string') {
+      throw new TypeError(
+        `add_component_property: a ${type} property needs a string defaultValue` +
+          (type === 'INSTANCE_SWAP' ? ' (a component key)' : ''),
+      );
+    }
+    if (p.preferredValues !== undefined && type !== 'INSTANCE_SWAP') {
+      throw new TypeError(
+        'add_component_property: preferredValues is only valid for an INSTANCE_SWAP property',
+      );
+    }
+
+    const node = await figmaCtx.getNodeByIdAsync(p.componentId);
+    if (node === null) throw new Error(`add_component_property: node ${p.componentId} not found`);
+    const owner = resolveComponentOwner('add_component_property', node);
+
+    const options =
+      type === 'INSTANCE_SWAP' && Array.isArray(p.preferredValues)
+        ? { preferredValues: p.preferredValues as InstanceSwapPreferredValue[] }
+        : undefined;
+    const propertyId = owner.addComponentProperty(
+      p.name,
+      type,
+      p.defaultValue as string | boolean,
+      options,
+    );
+
+    const result: ComponentPropertyResult = {
+      ok: true,
+      componentId: owner.id,
+      propertyId,
+      name: p.name,
+    };
+    return result;
+  };

--- a/packages/plugin/src/handlers/bind-component-property.ts
+++ b/packages/plugin/src/handlers/bind-component-property.ts
@@ -1,0 +1,99 @@
+import type { MutateResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import {
+  type AuthorablePropertyType,
+  FIELD_FOR_TYPE,
+  owningComponents,
+  PROPERTY_TYPES,
+} from './component-property.js';
+
+const REF_FIELDS = ['visible', 'characters', 'mainComponent'] as const;
+type RefField = (typeof REF_FIELDS)[number];
+
+type Referencing = SceneNode & {
+  componentPropertyReferences: Partial<Record<RefField, string>> | null;
+};
+
+/**
+ * Bind a declared component property to a sublayer field so it actually drives the layer — a
+ * BOOLEAN to `visible`, a TEXT to `characters`, an INSTANCE_SWAP to `mainComponent`. Repeatable:
+ * the same property can drive several layers. Pass propertyId: null to remove the binding on that
+ * field. Validates that the field fits the node, that the property exists on the containing
+ * component, and that its type matches the field — a mis-bind otherwise fails silently or points a
+ * layer at nothing.
+ */
+export const createBindComponentPropertyHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; propertyId?: unknown; field?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('bind_component_property: nodeId must be a string');
+    }
+    if (p.propertyId !== null && typeof p.propertyId !== 'string') {
+      throw new TypeError('bind_component_property: propertyId must be a string or null');
+    }
+    if (typeof p.field !== 'string' || !REF_FIELDS.includes(p.field as RefField)) {
+      throw new TypeError(
+        `bind_component_property: field must be one of ${REF_FIELDS.join(' / ')}`,
+      );
+    }
+    const field = p.field as RefField;
+
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null) throw new Error(`bind_component_property: node ${p.nodeId} not found`);
+    // A field must fit the node it drives: characters only on TEXT, mainComponent only on an
+    // INSTANCE; visible works on any layer.
+    if (field === 'characters' && node.type !== 'TEXT') {
+      throw new Error(
+        `bind_component_property: field "characters" requires a TEXT node, got ${node.type}`,
+      );
+    }
+    if (field === 'mainComponent' && node.type !== 'INSTANCE') {
+      throw new Error(
+        `bind_component_property: field "mainComponent" requires an INSTANCE node, got ${node.type}`,
+      );
+    }
+
+    const target = node as Referencing;
+    const refs: Partial<Record<RefField, string>> = { ...target.componentPropertyReferences };
+
+    if (p.propertyId === null) {
+      delete refs[field];
+    } else {
+      // The property must exist on the containing component (or its set) and its type must match the
+      // field — otherwise the reference dangles or drives the wrong thing.
+      const owners = owningComponents(node);
+      if (owners.length === 0) {
+        throw new Error(
+          `bind_component_property: ${p.nodeId} is not inside a component — nothing to bind a property to`,
+        );
+      }
+      const def = owners
+        .map(o => o.componentPropertyDefinitions[p.propertyId as string])
+        .find(d => d !== undefined);
+      if (def === undefined) {
+        throw new Error(
+          `bind_component_property: property ${p.propertyId} not found on the containing component ` +
+            '(add it with add_component_property first)',
+        );
+      }
+      if (!PROPERTY_TYPES.includes(def.type as AuthorablePropertyType)) {
+        throw new Error(
+          `bind_component_property: property ${p.propertyId} is a ${def.type} property, which isn't bound this way`,
+        );
+      }
+      const expected = FIELD_FOR_TYPE[def.type as AuthorablePropertyType];
+      if (expected !== field) {
+        throw new Error(
+          `bind_component_property: a ${def.type} property binds to "${expected}", not "${field}"`,
+        );
+      }
+      refs[field] = p.propertyId;
+    }
+
+    target.componentPropertyReferences = refs;
+
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/src/handlers/component-property.ts
+++ b/packages/plugin/src/handlers/component-property.ts
@@ -1,0 +1,67 @@
+// Shared helpers for the component-property authoring writes (add / bind / edit / delete). Kept in
+// one place so owner resolution and the type↔field mapping can't drift between the four handlers.
+
+/**
+ * The property types these tools author. VARIANT properties come from the variant-set structure
+ * (combine_as_variants), and SLOT is out of scope — so authoring is BOOLEAN / TEXT / INSTANCE_SWAP,
+ * the three that a plain component gains via addComponentProperty and that drive a sublayer field.
+ */
+export const PROPERTY_TYPES = ['BOOLEAN', 'TEXT', 'INSTANCE_SWAP'] as const;
+export type AuthorablePropertyType = (typeof PROPERTY_TYPES)[number];
+
+/** The node field (componentPropertyReferences key) each property type drives. */
+export const FIELD_FOR_TYPE: Readonly<
+  Record<AuthorablePropertyType, 'visible' | 'characters' | 'mainComponent'>
+> = {
+  BOOLEAN: 'visible',
+  TEXT: 'characters',
+  INSTANCE_SWAP: 'mainComponent',
+};
+
+/**
+ * Resolve the node that owns component properties: a COMPONENT_SET as-is, a variant COMPONENT's
+ * parent set (Figma keeps a variant's BOOLEAN/TEXT/SWAP props on the set so every variant shares
+ * them), or a plain COMPONENT. Throws for an INSTANCE (author on the main component, not a copy) or
+ * anything else. `tool` prefixes the error to match the calling tool.
+ */
+export const resolveComponentOwner = (
+  tool: string,
+  node: BaseNode,
+): ComponentNode | ComponentSetNode => {
+  if (node.type === 'COMPONENT_SET') return node;
+  if (node.type === 'COMPONENT') {
+    return node.parent !== null && node.parent.type === 'COMPONENT_SET' ? node.parent : node;
+  }
+  if (node.type === 'INSTANCE') {
+    throw new Error(
+      `${tool}: ${node.id} is an INSTANCE — author properties on its main component, not an instance`,
+    );
+  }
+  throw new Error(`${tool}: ${node.id} (${node.type}) is not a component or component set`);
+};
+
+/**
+ * The components that could define a property referenced by `node` (a sublayer): the nearest
+ * COMPONENT / COMPONENT_SET ancestor, plus that component's own COMPONENT_SET parent when it's a
+ * variant — because a shared BOOLEAN/TEXT/SWAP prop lives on the set, not the variant. Empty when
+ * the node isn't inside a component at all.
+ */
+export const owningComponents = (node: BaseNode): (ComponentNode | ComponentSetNode)[] => {
+  let cur: BaseNode | null = node;
+  while (cur !== null) {
+    if (cur.type === 'COMPONENT' || cur.type === 'COMPONENT_SET') break;
+    cur = cur.parent;
+  }
+  if (cur === null) return [];
+  const owners: (ComponentNode | ComponentSetNode)[] = [cur];
+  if (cur.type === 'COMPONENT' && cur.parent !== null && cur.parent.type === 'COMPONENT_SET') {
+    owners.push(cur.parent);
+  }
+  return owners;
+};
+
+/** Strip Figma's unique "#id" suffix off a property id to recover its display name. */
+export const propertyDisplayName = (propertyId: string): string => {
+  const hash = propertyId.lastIndexOf('#');
+  return hash === -1 ? propertyId : propertyId.slice(0, hash);
+};

--- a/packages/plugin/src/handlers/delete-component-property.ts
+++ b/packages/plugin/src/handlers/delete-component-property.ts
@@ -1,0 +1,49 @@
+import type { ComponentPropertyResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { propertyDisplayName, resolveComponentOwner } from './component-property.js';
+
+/**
+ * Remove a BOOLEAN / TEXT / INSTANCE_SWAP property from a component (and with it every sublayer
+ * reference to it). VARIANT properties come from the variant-set structure, not
+ * addComponentProperty, and deleteComponentProperty rejects them — so this refuses a VARIANT with
+ * guidance rather than surfacing Figma's raw error.
+ */
+export const createDeleteComponentPropertyHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { componentId?: unknown; propertyId?: unknown };
+    if (typeof p.componentId !== 'string') {
+      throw new TypeError('delete_component_property: componentId must be a string');
+    }
+    if (typeof p.propertyId !== 'string') {
+      throw new TypeError('delete_component_property: propertyId must be a string');
+    }
+
+    const node = await figmaCtx.getNodeByIdAsync(p.componentId);
+    if (node === null)
+      throw new Error(`delete_component_property: node ${p.componentId} not found`);
+    const owner = resolveComponentOwner('delete_component_property', node);
+    const def = owner.componentPropertyDefinitions[p.propertyId];
+    if (def === undefined) {
+      throw new Error(
+        `delete_component_property: property ${p.propertyId} not found on ${owner.id}`,
+      );
+    }
+    if (def.type === 'VARIANT') {
+      throw new Error(
+        `delete_component_property: ${p.propertyId} is a VARIANT property — remove its variants instead of deleting the property`,
+      );
+    }
+
+    const name = propertyDisplayName(p.propertyId);
+    owner.deleteComponentProperty(p.propertyId);
+
+    const result: ComponentPropertyResult = {
+      ok: true,
+      componentId: owner.id,
+      propertyId: p.propertyId,
+      name,
+    };
+    return result;
+  };

--- a/packages/plugin/src/handlers/edit-component-property.ts
+++ b/packages/plugin/src/handlers/edit-component-property.ts
@@ -1,0 +1,70 @@
+import type { ComponentPropertyResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { propertyDisplayName, resolveComponentOwner } from './component-property.js';
+
+/**
+ * Rename a component property, change its default value, or (INSTANCE_SWAP only) its preferred
+ * values. editComponentProperty returns a fresh id when the name changes, so the new id is echoed
+ * back for subsequent bind/delete calls. At least one change must be supplied.
+ */
+export const createEditComponentPropertyHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as {
+      componentId?: unknown;
+      propertyId?: unknown;
+      name?: unknown;
+      defaultValue?: unknown;
+      preferredValues?: unknown;
+    };
+    if (typeof p.componentId !== 'string') {
+      throw new TypeError('edit_component_property: componentId must be a string');
+    }
+    if (typeof p.propertyId !== 'string') {
+      throw new TypeError('edit_component_property: propertyId must be a string');
+    }
+    const renaming = typeof p.name === 'string';
+    const redefaulting = p.defaultValue !== undefined;
+    const repreferring = p.preferredValues !== undefined;
+    if (!renaming && !redefaulting && !repreferring) {
+      throw new TypeError(
+        'edit_component_property: supply at least one of name / defaultValue / preferredValues',
+      );
+    }
+
+    const node = await figmaCtx.getNodeByIdAsync(p.componentId);
+    if (node === null) throw new Error(`edit_component_property: node ${p.componentId} not found`);
+    const owner = resolveComponentOwner('edit_component_property', node);
+    const def = owner.componentPropertyDefinitions[p.propertyId];
+    if (def === undefined) {
+      throw new Error(
+        `edit_component_property: property ${p.propertyId} not found on ${owner.id} ` +
+          '(get_component_api lists the current ids)',
+      );
+    }
+    if (repreferring && def.type !== 'INSTANCE_SWAP') {
+      throw new TypeError(
+        'edit_component_property: preferredValues can only be edited on an INSTANCE_SWAP property',
+      );
+    }
+
+    const newValue: {
+      name?: string;
+      defaultValue?: string | boolean;
+      preferredValues?: InstanceSwapPreferredValue[];
+    } = {};
+    if (renaming) newValue.name = p.name as string;
+    if (redefaulting) newValue.defaultValue = p.defaultValue as string | boolean;
+    if (repreferring) newValue.preferredValues = p.preferredValues as InstanceSwapPreferredValue[];
+
+    const propertyId = owner.editComponentProperty(p.propertyId, newValue);
+
+    const result: ComponentPropertyResult = {
+      ok: true,
+      componentId: owner.id,
+      propertyId,
+      name: propertyDisplayName(propertyId),
+    };
+    return result;
+  };

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -1,10 +1,12 @@
 import type { SandboxHandlers } from '../dispatcher.js';
 import { createIdempotencyCache, idempotent } from '../idempotency.js';
+import { createAddComponentPropertyHandler } from './add-component-property.js';
 import { createAddPageHandler } from './add-page.js';
 import { createAddVariableModeHandler } from './add-variable-mode.js';
 import { createApplyStyleToNodeHandler } from './apply-style-to-node.js';
 import { createBatchRenameNodesHandler } from './batch-rename-nodes.js';
 import { createBatchHandler } from './batch.js';
+import { createBindComponentPropertyHandler } from './bind-component-property.js';
 import { createBindVariableToNodeHandler } from './bind-variable-to-node.js';
 import { createBindVariableToPaintHandler } from './bind-variable-to-paint.js';
 import { createCloneNodeHandler } from './clone-node.js';
@@ -22,12 +24,14 @@ import { createCreateTextStyleHandler } from './create-text-style.js';
 import { createCreateTextHandler } from './create-text.js';
 import { createCreateVariableCollectionHandler } from './create-variable-collection.js';
 import { createCreateVariableHandler } from './create-variable.js';
+import { createDeleteComponentPropertyHandler } from './delete-component-property.js';
 import { createDeleteNodesHandler } from './delete-nodes.js';
 import { createDeletePageHandler } from './delete-page.js';
 import { createDeleteStyleHandler } from './delete-style.js';
 import { createDeleteVariableCollectionHandler } from './delete-variable-collection.js';
 import { createDeleteVariableHandler } from './delete-variable.js';
 import { createDetachInstanceHandler } from './detach-instance.js';
+import { createEditComponentPropertyHandler } from './edit-component-property.js';
 import { createExportPdfHandler } from './export-pdf.js';
 import { createFindReplaceTextHandler } from './find-replace-text.js';
 import { createGetAnnotationsHandler } from './get-annotations.js';
@@ -166,6 +170,10 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     remove_reactions: createRemoveReactionsHandler(figmaCtx),
     swap_component: createSwapComponentHandler(figmaCtx),
     set_instance_properties: createSetInstancePropertiesHandler(figmaCtx),
+    add_component_property: createAddComponentPropertyHandler(figmaCtx),
+    bind_component_property: createBindComponentPropertyHandler(figmaCtx),
+    edit_component_property: createEditComponentPropertyHandler(figmaCtx),
+    delete_component_property: createDeleteComponentPropertyHandler(figmaCtx),
     detach_instance: createDetachInstanceHandler(figmaCtx),
     import_image: createImportImageHandler(figmaCtx),
     import_svg: createImportSvgHandler(figmaCtx),

--- a/packages/plugin/test/handlers/component-property.test.ts
+++ b/packages/plugin/test/handlers/component-property.test.ts
@@ -1,0 +1,270 @@
+import type { ComponentPropertyResult, MutateResult } from '@figwright/shared';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAddComponentPropertyHandler } from '../../src/handlers/add-component-property.js';
+import { createBindComponentPropertyHandler } from '../../src/handlers/bind-component-property.js';
+import { createDeleteComponentPropertyHandler } from '../../src/handlers/delete-component-property.js';
+import { createEditComponentPropertyHandler } from '../../src/handlers/edit-component-property.js';
+
+/** A figma stub whose getNodeByIdAsync resolves from a fixed id → node map. */
+const fakeFigma = (nodes: Record<string, unknown>): typeof figma =>
+  ({ getNodeByIdAsync: async (id: string) => nodes[id] ?? null }) as unknown as typeof figma;
+
+describe('add_component_property handler', () => {
+  it('declares a BOOLEAN property and returns its assigned id', async () => {
+    const addComponentProperty = vi.fn<(n: string, t: string, d: unknown) => string>(
+      name => `${name}#4:2`,
+    );
+    const comp = { id: 'C:1', type: 'COMPONENT', parent: null, addComponentProperty };
+    const handler = createAddComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    const r = (await handler({
+      componentId: 'C:1',
+      name: 'Show Icon',
+      type: 'BOOLEAN',
+      defaultValue: true,
+    })) as ComponentPropertyResult;
+
+    expect(addComponentProperty).toHaveBeenCalledWith('Show Icon', 'BOOLEAN', true, undefined);
+    expect(r).toEqual({
+      ok: true,
+      componentId: 'C:1',
+      propertyId: 'Show Icon#4:2',
+      name: 'Show Icon',
+    });
+  });
+
+  it('passes preferredValues through for an INSTANCE_SWAP property', async () => {
+    const addComponentProperty = vi.fn<(n: string, t: string, d: unknown, o: unknown) => string>(
+      name => `${name}#4:3`,
+    );
+    const comp = { id: 'C:1', type: 'COMPONENT', parent: null, addComponentProperty };
+    const handler = createAddComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    await handler({
+      componentId: 'C:1',
+      name: 'Icon',
+      type: 'INSTANCE_SWAP',
+      defaultValue: 'abc123',
+      preferredValues: [{ type: 'COMPONENT', key: 'k1' }],
+    });
+    expect(addComponentProperty).toHaveBeenCalledWith('Icon', 'INSTANCE_SWAP', 'abc123', {
+      preferredValues: [{ type: 'COMPONENT', key: 'k1' }],
+    });
+  });
+
+  it('rejects a defaultValue that does not match the type, and preferredValues off INSTANCE_SWAP', async () => {
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      addComponentProperty: vi.fn<() => string>(),
+    };
+    const handler = createAddComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    await expect(
+      handler({ componentId: 'C:1', name: 'X', type: 'BOOLEAN', defaultValue: 'nope' }),
+    ).rejects.toThrow(/BOOLEAN property needs a boolean/);
+    await expect(
+      handler({
+        componentId: 'C:1',
+        name: 'X',
+        type: 'TEXT',
+        defaultValue: 'hi',
+        preferredValues: [{ type: 'COMPONENT', key: 'k' }],
+      }),
+    ).rejects.toThrow(/preferredValues is only valid for an INSTANCE_SWAP/);
+  });
+
+  it('resolves a variant component to its set, and refuses an instance', async () => {
+    const set = {
+      id: 'S:1',
+      type: 'COMPONENT_SET',
+      addComponentProperty: vi.fn<() => string>(() => 'P#1'),
+    };
+    const variant = { id: 'C:1', type: 'COMPONENT', parent: set };
+    const instance = { id: 'I:1', type: 'INSTANCE' };
+    const handler = createAddComponentPropertyHandler(
+      fakeFigma({ 'C:1': variant, 'I:1': instance }),
+    );
+    const r = (await handler({
+      componentId: 'C:1',
+      name: 'P',
+      type: 'BOOLEAN',
+      defaultValue: false,
+    })) as ComponentPropertyResult;
+    expect(r.componentId).toBe('S:1'); // authored on the set, not the variant
+    expect(set.addComponentProperty).toHaveBeenCalled();
+    await expect(
+      handler({ componentId: 'I:1', name: 'P', type: 'BOOLEAN', defaultValue: false }),
+    ).rejects.toThrow(/is an INSTANCE — author properties on its main component/);
+  });
+});
+
+describe('bind_component_property handler', () => {
+  const boolDef = { 'Show Icon#4:2': { type: 'BOOLEAN', defaultValue: true } };
+
+  it('binds a BOOLEAN property to a layer visible reference', async () => {
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: boolDef,
+    };
+    const layer = { id: 'L:1', type: 'FRAME', parent: comp, componentPropertyReferences: null };
+    const handler = createBindComponentPropertyHandler(fakeFigma({ 'L:1': layer }));
+    const r = (await handler({
+      nodeId: 'L:1',
+      field: 'visible',
+      propertyId: 'Show Icon#4:2',
+    })) as MutateResult;
+    expect(r).toEqual({ ok: true, nodeId: 'L:1' });
+    expect(layer.componentPropertyReferences).toEqual({ visible: 'Show Icon#4:2' });
+  });
+
+  it('finds a property defined on the variant set above the layer', async () => {
+    const set = { id: 'S:1', type: 'COMPONENT_SET', componentPropertyDefinitions: boolDef };
+    const variant = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: set,
+      componentPropertyDefinitions: {},
+    };
+    const layer = { id: 'L:1', type: 'FRAME', parent: variant, componentPropertyReferences: null };
+    const handler = createBindComponentPropertyHandler(fakeFigma({ 'L:1': layer }));
+    await handler({ nodeId: 'L:1', field: 'visible', propertyId: 'Show Icon#4:2' });
+    expect(layer.componentPropertyReferences).toEqual({ visible: 'Show Icon#4:2' });
+  });
+
+  it('rejects a field that does not fit the node type', async () => {
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: boolDef,
+    };
+    const layer = { id: 'L:1', type: 'FRAME', parent: comp, componentPropertyReferences: null };
+    const handler = createBindComponentPropertyHandler(fakeFigma({ 'L:1': layer }));
+    await expect(
+      handler({ nodeId: 'L:1', field: 'characters', propertyId: 'Show Icon#4:2' }),
+    ).rejects.toThrow(/field "characters" requires a TEXT node/);
+  });
+
+  it('rejects a property whose type does not match the field', async () => {
+    const swapDef = { 'Icon#4:5': { type: 'INSTANCE_SWAP', defaultValue: 'k' } };
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: swapDef,
+    };
+    const layer = { id: 'L:1', type: 'FRAME', parent: comp, componentPropertyReferences: null };
+    const handler = createBindComponentPropertyHandler(fakeFigma({ 'L:1': layer }));
+    // INSTANCE_SWAP binds to mainComponent, so binding it to visible must fail.
+    await expect(
+      handler({ nodeId: 'L:1', field: 'visible', propertyId: 'Icon#4:5' }),
+    ).rejects.toThrow(/binds to "mainComponent", not "visible"/);
+  });
+
+  it('rejects a property id not present on the containing component', async () => {
+    const comp = { id: 'C:1', type: 'COMPONENT', parent: null, componentPropertyDefinitions: {} };
+    const layer = { id: 'L:1', type: 'FRAME', parent: comp, componentPropertyReferences: null };
+    const handler = createBindComponentPropertyHandler(fakeFigma({ 'L:1': layer }));
+    await expect(
+      handler({ nodeId: 'L:1', field: 'visible', propertyId: 'Ghost#9:9' }),
+    ).rejects.toThrow(/not found on the containing component/);
+  });
+
+  it('unbinds a field when propertyId is null', async () => {
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: boolDef,
+    };
+    const layer = {
+      id: 'L:1',
+      type: 'FRAME',
+      parent: comp,
+      componentPropertyReferences: { visible: 'Show Icon#4:2' },
+    };
+    const handler = createBindComponentPropertyHandler(fakeFigma({ 'L:1': layer }));
+    await handler({ nodeId: 'L:1', field: 'visible', propertyId: null });
+    expect(layer.componentPropertyReferences).toEqual({});
+  });
+});
+
+describe('edit_component_property handler', () => {
+  it('renames a property and returns the new id + parsed name', async () => {
+    const editComponentProperty = vi.fn<(id: string, v: { name?: string }) => string>(
+      (_id, v) => `${v.name}#4:2`,
+    );
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: { 'Show Icon#4:2': { type: 'BOOLEAN', defaultValue: true } },
+      editComponentProperty,
+    };
+    const handler = createEditComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    const r = (await handler({
+      componentId: 'C:1',
+      propertyId: 'Show Icon#4:2',
+      name: 'Show Badge',
+    })) as ComponentPropertyResult;
+    expect(editComponentProperty).toHaveBeenCalledWith('Show Icon#4:2', { name: 'Show Badge' });
+    expect(r).toMatchObject({ propertyId: 'Show Badge#4:2', name: 'Show Badge' });
+  });
+
+  it('requires at least one change and a real property id', async () => {
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: { 'P#1:1': { type: 'BOOLEAN', defaultValue: true } },
+      editComponentProperty: vi.fn<() => string>(),
+    };
+    const handler = createEditComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    await expect(handler({ componentId: 'C:1', propertyId: 'P#1:1' })).rejects.toThrow(
+      /at least one of name/,
+    );
+    await expect(
+      handler({ componentId: 'C:1', propertyId: 'Ghost#9:9', name: 'x' }),
+    ).rejects.toThrow(/not found on/);
+  });
+});
+
+describe('delete_component_property handler', () => {
+  it('deletes a property and returns its parsed name', async () => {
+    const deleteComponentProperty = vi.fn<(id: string) => void>();
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT',
+      parent: null,
+      componentPropertyDefinitions: { 'Show Icon#4:2': { type: 'BOOLEAN', defaultValue: true } },
+      deleteComponentProperty,
+    };
+    const handler = createDeleteComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    const r = (await handler({
+      componentId: 'C:1',
+      propertyId: 'Show Icon#4:2',
+    })) as ComponentPropertyResult;
+    expect(deleteComponentProperty).toHaveBeenCalledWith('Show Icon#4:2');
+    expect(r).toEqual({
+      ok: true,
+      componentId: 'C:1',
+      propertyId: 'Show Icon#4:2',
+      name: 'Show Icon',
+    });
+  });
+
+  it('refuses to delete a VARIANT property', async () => {
+    const comp = {
+      id: 'C:1',
+      type: 'COMPONENT_SET',
+      componentPropertyDefinitions: { Size: { type: 'VARIANT', defaultValue: 'M' } },
+      deleteComponentProperty: vi.fn<() => void>(),
+    };
+    const handler = createDeleteComponentPropertyHandler(fakeFigma({ 'C:1': comp }));
+    await expect(handler({ componentId: 'C:1', propertyId: 'Size' })).rejects.toThrow(
+      /is a VARIANT property/,
+    );
+  });
+});

--- a/packages/shared/src/writes.ts
+++ b/packages/shared/src/writes.ts
@@ -69,6 +69,19 @@ export const VariableResultSchema = z.object({
 });
 export type VariableResult = z.infer<typeof VariableResultSchema>;
 
+/**
+ * Result of a component-property authoring write (add / edit / delete_component_property). The
+ * propertyId is the name-with-unique-suffix ("Show Icon#12:5") Figma assigns — the handle every
+ * later bind / edit / delete and set_instance_properties call must use, so it's echoed back.
+ */
+export const ComponentPropertyResultSchema = z.object({
+  ok: z.literal(true),
+  componentId: z.string(),
+  propertyId: z.string(),
+  name: z.string(),
+});
+export type ComponentPropertyResult = z.infer<typeof ComponentPropertyResultSchema>;
+
 /** One step in an atomic batch: a write tool name + the params it would normally receive. */
 export const BatchOpSchema = z.object({
   tool: z.string(),

--- a/skills/figma-build/references/author-design-system.md
+++ b/skills/figma-build/references/author-design-system.md
@@ -71,5 +71,20 @@ look (a shadow, a type ramp step).
    back (`get_node`) to confirm the property was derived (each child keeps its `Prop=Value` name under
    the set).
 
+**Non-variant properties** (a real DS component usually needs these too — an optional icon, editable
+label text, a swappable nested icon) are authored separately from variants, and each is a **declare +
+bind** pair:
+
+1. **`add_component_property`** (`componentId`, `name`, `type`, `defaultValue`) → declares a `BOOLEAN`
+   (show/hide), `TEXT` (editable string), or `INSTANCE_SWAP` (swappable instance) property. Returns a
+   `propertyId` (`Show Icon#4:2`). The property is **inert on its own** — declaring is only half.
+2. **`bind_component_property`** (`nodeId`, `field`, `propertyId`) attaches it to the sublayer it
+   drives: `visible` for a BOOLEAN, `characters` for a TEXT node, `mainComponent` for an INSTANCE.
+   Bind the same property to several layers by calling once per layer (one BOOLEAN hiding a whole
+   group). **A declared-but-unbound property controls nothing** — always bind, then `get_component_api`
+   to confirm the property and its default read back.
+3. **`edit_component_property`** renames / re-defaults (returns a new `propertyId` on rename);
+   **`delete_component_property`** removes it. VARIANT properties stay the domain of `combine_as_variants`.
+
 Once authored, switch back to the reuse path: `create_instance` the new component, bind the new
 tokens, and assemble (see `assemble-screens.md`).


### PR DESCRIPTION
## What

Closes a read/write asymmetry: `get_component_api` reads a component's full property contract (VARIANT/BOOLEAN/TEXT/INSTANCE_SWAP), but there was no way to **write** one — so `figma-build` could never author a real design-system component (an optional icon, an editable label, a swappable nested instance). Four fine-grained tools, mirroring the variable tools' `create` / `bind` / `rename` / `delete` decomposition:

- **`add_component_property`** — declare a `BOOLEAN` / `TEXT` / `INSTANCE_SWAP` property on a component (a variant COMPONENT resolves to its set, where shared props live). Returns the Figma-assigned `"name#id"`.
- **`bind_component_property`** — attach a declared property to a sublayer field (`BOOLEAN`→`visible`, `TEXT`→`characters`, `INSTANCE_SWAP`→`mainComponent`) so it actually drives the layer. Repeatable across layers (one BOOLEAN hiding a group); `propertyId: null` unbinds. **A declared-but-unbound property is inert**, so binding is the necessary other half — declaring alone would ship a footgun.
- **`edit_component_property`** — rename / re-default / re-`preferredValues` (returns a new id on rename; existing bindings keep working).
- **`delete_component_property`** — remove it and its references (refuses `VARIANT` — that's `combine_as_variants`' domain).

Validation is upfront and precise: `type`↔`defaultValue`, `preferredValues` only on INSTANCE_SWAP, `field`↔node-type, and the property must exist on the containing component before a bind.

## Zero impact on existing functionality

Purely additive — new plugin handlers + server specs + a shared helper (`component-property.ts`) + a `ComponentPropertyResult` schema, wired through both registries. No existing tool, serializer, plugin handler, or relay path is modified. `delete_component_property` is marked destructive; batch leaves it non-batchable (not in the inverse allowlist), which is correct.

## Verified

- **Live, plugin connected**: built a throwaway scratch component, then `add` BOOLEAN + `bind` to a layer's `visible`, `add` TEXT + `bind` to `characters` — the layer's text took the property default (`"Hello"`), proving the binding genuinely drives the layer, not just declares. `get_component_api` read both back with correct types/defaults; `edit` renamed to a new id (`Show Label#… → Show Icon#…`); `delete` removed one. Then the scratch component was deleted (`search_nodes` confirms it's gone). **Zero impact on any existing design.**
- **14 unit tests** across the four handlers (declare + type/default validation, owner resolution incl. variant→set and instance-refusal, bind field/type validation + unbind, rename returns new id, delete refuses VARIANT).
- Full gate: typecheck, lint, format:check, knip, build, **803 tests** — all green.

## Docs

`figma-build`'s author-design-system reference now documents the declare + bind workflow (a real DS component needs both). README tool count **97 → 101**, and the Write group notes component-property authoring.
