### PR TITLE
fix(batch): snapshot every field a write mutates so rollback is all-or-nothing

### DIFF
--- a/packages/plugin/src/handlers/batch.ts
+++ b/packages/plugin/src/handlers/batch.ts
@@ -124,6 +124,67 @@ const createComponentInverse: BatchInverse = {
   undo: componentCreateInverse.undo,
 };
 
+// Every field the set_text_properties handler can write. The snapshot must cover all of them —
+// an inverse that captures a subset would "roll back" while silently leaving the rest changed,
+// breaking the all-or-nothing contract. Restore order matters at the tail: maxLines only takes
+// effect once textTruncation is ENDING, so truncation is restored before maxLines (mirrors the
+// handler's apply order).
+const TEXT_PROPERTY_KEYS = [
+  'fontName',
+  'fontSize',
+  'lineHeight',
+  'letterSpacing',
+  'textCase',
+  'textDecoration',
+  'paragraphSpacing',
+  'paragraphIndent',
+  'textAutoResize',
+  'textTruncation',
+  'maxLines',
+] as const;
+
+/**
+ * Set_text_properties mutates typography, which Figma only allows with the node's fonts loaded — so
+ * the undo must reload the captured fonts before restoring, exactly like setTextInverse. A per-run
+ * `mixed` value (symbol) can't be restored node-level and is skipped; every other field
+ * round-trips.
+ */
+const setTextPropertiesInverse: BatchInverse = {
+  async capture(figmaCtx, params) {
+    const id = (params as { nodeId?: unknown } | null)?.nodeId;
+    if (typeof id !== 'string') {
+      throw new TypeError('batch/set_text_properties: nodeId must be a string');
+    }
+    const node = await figmaCtx.getNodeByIdAsync(id);
+    if (node === null || node.type !== 'TEXT') {
+      throw new Error(`batch/set_text_properties: node ${id} is not a TEXT node`);
+    }
+    const text = node as TextNode;
+    const fonts =
+      text.fontName === figmaCtx.mixed && text.characters.length > 0
+        ? text.getRangeAllFontNames(0, text.characters.length)
+        : [text.fontName as FontName];
+    const bag = text as unknown as Record<string, unknown>;
+    const snapshot: Record<string, unknown> = {};
+    for (const k of TEXT_PROPERTY_KEYS) if (k in text) snapshot[k] = bag[k];
+    return { id, snapshot, fonts };
+  },
+  async undo(figmaCtx, _params, captured) {
+    const { id, snapshot, fonts } = captured as {
+      id: string;
+      snapshot: Record<string, unknown>;
+      fonts: FontName[];
+    };
+    const node = await figmaCtx.getNodeByIdAsync(id);
+    if (node === null || node.type !== 'TEXT') return;
+    await Promise.all(fonts.map(font => figmaCtx.loadFontAsync(font)));
+    const bag = node as unknown as Record<string, unknown>;
+    for (const k of TEXT_PROPERTY_KEYS) {
+      if (k in snapshot && k in node && restorable(snapshot[k])) bag[k] = snapshot[k];
+    }
+  },
+};
+
 /** Set_text needs every font loaded before `characters` can be restored. */
 const setTextInverse: BatchInverse = {
   async capture(figmaCtx, params) {
@@ -157,21 +218,41 @@ const setTextInverse: BatchInverse = {
 const INVERSES: Readonly<Record<string, BatchInverse>> = {
   // Single-node property mutations.
   set_fills: nodeProps('set_fills', ['fills']),
-  set_strokes: nodeProps('set_strokes', ['strokes', 'strokeWeight']),
+  // Snapshot every field the handler can write, not just the headline one: a subset snapshot would
+  // "roll back" while silently leaving the rest changed. The per-side weights are also what rescue
+  // a node whose uniform strokeWeight reads figma.mixed (a symbol, skipped by `restorable`) — they
+  // are plain numbers, so mixed-stroke nodes still restore fully. Order matters: the uniform weight
+  // is restored before the per-side values so the sides override it (mirrors the handler).
+  set_strokes: nodeProps('set_strokes', [
+    'strokes',
+    'strokeWeight',
+    'strokeAlign',
+    'dashPattern',
+    'strokeTopWeight',
+    'strokeRightWeight',
+    'strokeBottomWeight',
+    'strokeLeftWeight',
+  ]),
   set_opacity: nodeProps('set_opacity', ['opacity']),
   set_visible: nodeProps('set_visible', ['visible']),
-  set_corner_radius: nodeProps('set_corner_radius', ['cornerRadius']),
+  // Same full-coverage rule as set_strokes: per-corner radii are plain numbers, so a node whose
+  // uniform cornerRadius reads figma.mixed (skipped by `restorable`) still restores through them
+  // (a plain-cornerRadius node like an ellipse has no per-corner props — the `in node` guard skips
+  // them and the uniform value alone round-trips). Uniform first, corners after (handler order).
+  set_corner_radius: nodeProps('set_corner_radius', [
+    'cornerRadius',
+    'topLeftRadius',
+    'topRightRadius',
+    'bottomRightRadius',
+    'bottomLeftRadius',
+  ]),
   set_arc: nodeProps('set_arc', ['arcData']),
   set_blend_mode: nodeProps('set_blend_mode', ['blendMode']),
   set_effects: nodeProps('set_effects', ['effects']),
   set_constraints: nodeProps('set_constraints', ['constraints']),
   rename_node: nodeProps('rename_node', ['name']),
   set_text: setTextInverse,
-  set_text_properties: nodeProps('set_text_properties', [
-    'textAutoResize',
-    'textTruncation',
-    'maxLines',
-  ]),
+  set_text_properties: setTextPropertiesInverse,
   // Multi-node mutations.
   move_nodes: nodesSnapshot(
     'move_nodes',

--- a/packages/plugin/test/handlers/batch.test.ts
+++ b/packages/plugin/test/handlers/batch.test.ts
@@ -8,8 +8,11 @@ import { createCreateFrameHandler } from '../../src/handlers/create-frame.js';
 import { createDeleteNodesHandler } from '../../src/handlers/delete-nodes.js';
 import { createMoveNodesHandler } from '../../src/handlers/move-nodes.js';
 import { createRenameNodeHandler } from '../../src/handlers/rename-node.js';
+import { createSetCornerRadiusHandler } from '../../src/handlers/set-corner-radius.js';
 import { createSetFillsHandler } from '../../src/handlers/set-fills.js';
 import { createSetOpacityHandler } from '../../src/handlers/set-opacity.js';
+import { createSetStrokesHandler } from '../../src/handlers/set-strokes.js';
+import { createSetTextPropertiesHandler } from '../../src/handlers/set-text-properties.js';
 import { createIdempotencyCache, idempotent } from '../../src/idempotency.js';
 
 /** A mutable node store backing a fake figma whose getNodeByIdAsync / createFrame share one map. */
@@ -17,9 +20,11 @@ const makeFigma = (initial: Record<string, Record<string, unknown>>) => {
   const store = new Map<string, Record<string, unknown>>(Object.entries(initial));
   let seq = 100;
   const currentPage = { appendChild: vi.fn<(n: unknown) => void>() };
+  const loadFontAsync = vi.fn<(font: unknown) => Promise<void>>(async () => {});
   const figmaCtx = {
     mixed: Symbol('mixed'),
     currentPage,
+    loadFontAsync,
     getNodeByIdAsync: async (id: string) => store.get(id) ?? null,
     createFrame: () => {
       const id = `9:${(seq += 1)}`;
@@ -38,13 +43,16 @@ const makeFigma = (initial: Record<string, Record<string, unknown>>) => {
       return node;
     },
   } as unknown as typeof figma;
-  return { figmaCtx, store };
+  return { figmaCtx, store, loadFontAsync };
 };
 
 const realWrites = (figmaCtx: typeof figma): SandboxHandlers => ({
   rename_node: createRenameNodeHandler(figmaCtx),
   set_opacity: createSetOpacityHandler(figmaCtx),
   set_fills: createSetFillsHandler(figmaCtx),
+  set_strokes: createSetStrokesHandler(figmaCtx),
+  set_corner_radius: createSetCornerRadiusHandler(figmaCtx),
+  set_text_properties: createSetTextPropertiesHandler(figmaCtx),
   move_nodes: createMoveNodesHandler(figmaCtx),
   create_frame: createCreateFrameHandler(figmaCtx),
   create_component: createCreateComponentHandler(figmaCtx),
@@ -208,6 +216,137 @@ describe('batch handler', () => {
         ],
       }),
     ).rejects.toThrow(/undo\(s\) FAILED.*cannot remove.*partially changed/);
+  });
+
+  it('restores per-corner radii on rollback when cornerRadius reads mixed', async () => {
+    // Corners differ → the uniform cornerRadius getter is figma.mixed (a symbol the undo must
+    // skip); the per-corner snapshot is what actually restores the node.
+    const { figmaCtx, store } = makeFigma({
+      '1:1': {
+        id: '1:1',
+        cornerRadius: Symbol('mixed'),
+        topLeftRadius: 8,
+        topRightRadius: 0,
+        bottomRightRadius: 4,
+        bottomLeftRadius: 0,
+      },
+      '1:2': { id: '1:2', fills: [] },
+    });
+    const handler = createBatchHandler(figmaCtx, realWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          { tool: 'set_corner_radius', params: { nodeId: '1:1', radius: 12 } },
+          { tool: 'set_fills', params: { nodeId: '1:2', fills: [{ type: 'GRADIENT_LINEAR' }] } },
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(store.get('1:1')).toMatchObject({
+      topLeftRadius: 8,
+      topRightRadius: 0,
+      bottomRightRadius: 4,
+      bottomLeftRadius: 0,
+    });
+  });
+
+  it('restores strokeAlign / dashPattern / per-side weights on rollback', async () => {
+    const { figmaCtx, store } = makeFigma({
+      '1:1': {
+        id: '1:1',
+        strokes: [SOLID(0.2)],
+        strokeWeight: Symbol('mixed'), // per-side weights differ
+        strokeAlign: 'INSIDE',
+        dashPattern: [4, 2],
+        strokeTopWeight: 1,
+        strokeRightWeight: 0,
+        strokeBottomWeight: 2,
+        strokeLeftWeight: 0,
+      },
+      '1:2': { id: '1:2', fills: [] },
+    });
+    const handler = createBatchHandler(figmaCtx, realWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          {
+            tool: 'set_strokes',
+            params: {
+              nodeId: '1:1',
+              strokes: [SOLID(0.9)],
+              strokeWeight: 3,
+              strokeAlign: 'CENTER',
+              dashPattern: [],
+            },
+          },
+          { tool: 'set_fills', params: { nodeId: '1:2', fills: [{ type: 'GRADIENT_LINEAR' }] } },
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(store.get('1:1')).toMatchObject({
+      strokes: [SOLID(0.2)],
+      strokeAlign: 'INSIDE',
+      dashPattern: [4, 2],
+      strokeTopWeight: 1,
+      strokeRightWeight: 0,
+      strokeBottomWeight: 2,
+      strokeLeftWeight: 0,
+    });
+  });
+
+  it('restores typography on set_text_properties rollback, reloading fonts first', async () => {
+    const { figmaCtx, store, loadFontAsync } = makeFigma({
+      '1:1': {
+        id: '1:1',
+        type: 'TEXT',
+        characters: 'Hi',
+        fontName: { family: 'Inter', style: 'Regular' },
+        fontSize: 12,
+        lineHeight: { unit: 'AUTO' },
+        letterSpacing: { value: 0, unit: 'PIXELS' },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+        paragraphSpacing: 0,
+        paragraphIndent: 0,
+        textAutoResize: 'WIDTH_AND_HEIGHT',
+        textTruncation: 'DISABLED',
+        maxLines: null,
+      },
+      '1:2': { id: '1:2', fills: [] },
+    });
+    const handler = createBatchHandler(figmaCtx, realWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          {
+            tool: 'set_text_properties',
+            params: {
+              nodeId: '1:1',
+              fontName: { family: 'Arial', style: 'Bold' },
+              fontSize: 24,
+              textCase: 'UPPER',
+              paragraphSpacing: 8,
+              textAutoResize: 'HEIGHT',
+            },
+          },
+          { tool: 'set_fills', params: { nodeId: '1:2', fills: [{ type: 'GRADIENT_LINEAR' }] } },
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(store.get('1:1')).toMatchObject({
+      fontName: { family: 'Inter', style: 'Regular' },
+      fontSize: 12,
+      textCase: 'ORIGINAL',
+      paragraphSpacing: 0,
+      textAutoResize: 'WIDTH_AND_HEIGHT',
+    });
+    // The undo reloads the captured (pre-op) font before restoring — it's the final font load.
+    expect(loadFontAsync.mock.calls.at(-1)).toEqual([{ family: 'Inter', style: 'Regular' }]);
   });
 
   it('replays as a unit under idempotency: same requestId applies its ops once', async () => {


### PR DESCRIPTION
## Problem

`batch` advertises all-or-nothing with rollback, but three inverses snapshotted only a subset of what their handlers write — a mid-batch failure reported "rolled back N applied op(s)" while silently leaving the rest changed:

- **`set_corner_radius`** snapshotted only the uniform `cornerRadius`, which reads `figma.mixed` (a symbol, skipped by `restorable`) exactly when corners differ — so mixed-corner nodes restored **nothing**, and the four per-corner fields the handler writes were never captured.
- **`set_strokes`** missed `strokeAlign`, `dashPattern` and the four per-side weights (mixed `strokeWeight` hit the same symbol skip).
- **`set_text_properties`** captured 3 layout fields but none of the 8 typography fields the handler mutates.

## Fix

- Extend the `set_corner_radius` / `set_strokes` snapshots to every field the handler writes. Per-corner / per-side values are plain numbers (never mixed), so they also rescue the mixed-symbol case; restore order mirrors the handlers (uniform first, individual overrides after).
- `set_text_properties` gets a dedicated inverse (mirroring `setTextInverse`): captures all 11 writable fields + the node's fonts, reloads fonts before restoring, and restores `maxLines` after `textTruncation` (the handler's effective order). Per-run `mixed` values remain node-level unrestorable and are skipped — strictly better than before (nothing restored).

## Verification

- 3 new regression tests (mixed-corner rollback, full stroke-field rollback, typography rollback asserting the undo's font reload). Full gate suite green: typecheck / lint / format / knip / build / 810 tests.
- **Live round-trip (plugin connected)**: baseline per-corner radii 8/0/4/0 → batch sets uniform 12 then fails mid-batch → read-back shows exact 8/0/4/0 + `mixed` restored. Typography batch (fontSize 24 / UPPER / paragraphSpacing 8) fails mid-batch → all restored to 12 / ORIGINAL / 0 with fonts reloaded.