### PR TITLE
fix(mcp): derive destructiveHint from tool specs, not a hand-kept list

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -107,20 +107,12 @@ const SPECIAL_HANDLERS: Record<string, ToolHandler> = {
   [DESIGN_DIFF_TOOL_NAME]: async args => textResult(await handleDesignDiff(dispatch, args)),
 };
 
-// Reversible writes that destroy data — surfaced via the destructiveHint annotation. Other writes
-// (creates / property sets) are non-destructive; reads/locals are read-only (derived from kind).
-const DESTRUCTIVE_TOOLS = new Set([
-  'delete_nodes',
-  'delete_page',
-  'delete_style',
-  'delete_variable',
-  'delete_component_property',
-  'ungroup_nodes',
-]);
-
+// Annotations are derived from each spec, never hand-kept here: `kind` drives readOnlyHint and the
+// spec's own `destructive` flag drives destructiveHint (a registry test asserts every delete_*
+// carries it, so a new destructive tool can't ship silently marked "non-destructive").
 const annotationsFor = (spec: ToolSpec): ToolAnnotations =>
   spec.kind === 'write'
-    ? { readOnlyHint: false, destructiveHint: DESTRUCTIVE_TOOLS.has(spec.name) }
+    ? { readOnlyHint: false, destructiveHint: spec.destructive === true }
     : { readOnlyHint: true };
 
 for (const spec of ALL_TOOL_SPECS) {

--- a/packages/mcp/src/tools/delete-component-property.ts
+++ b/packages/mcp/src/tools/delete-component-property.ts
@@ -16,4 +16,5 @@ export const deleteComponentPropertyTool: ToolSpec = {
     propertyId: z.string().describe('Property id to delete (name#id, from get_component_api)'),
   },
   kind: 'write',
+  destructive: true,
 };

--- a/packages/mcp/src/tools/delete-nodes.ts
+++ b/packages/mcp/src/tools/delete-nodes.ts
@@ -14,4 +14,5 @@ export const deleteNodesTool: ToolSpec = {
     nodeIds: z.array(z.string()).describe('Node ids to delete'),
   },
   kind: 'write',
+  destructive: true,
 };

--- a/packages/mcp/src/tools/delete-page.ts
+++ b/packages/mcp/src/tools/delete-page.ts
@@ -13,4 +13,5 @@ export const deletePageTool: ToolSpec = {
     pageId: z.string().describe('Page id to delete'),
   },
   kind: 'write',
+  destructive: true,
 };

--- a/packages/mcp/src/tools/delete-style.ts
+++ b/packages/mcp/src/tools/delete-style.ts
@@ -12,4 +12,5 @@ export const deleteStyleTool: ToolSpec = {
     styleId: z.string().describe('Style id to delete'),
   },
   kind: 'write',
+  destructive: true,
 };

--- a/packages/mcp/src/tools/delete-variable-collection.ts
+++ b/packages/mcp/src/tools/delete-variable-collection.ts
@@ -14,4 +14,5 @@ export const deleteVariableCollectionTool: ToolSpec = {
     collectionId: z.string().describe('Variable collection id to delete'),
   },
   kind: 'write',
+  destructive: true,
 };

--- a/packages/mcp/src/tools/delete-variable.ts
+++ b/packages/mcp/src/tools/delete-variable.ts
@@ -14,4 +14,5 @@ export const deleteVariableTool: ToolSpec = {
     variableId: z.string().describe('Variable id to delete'),
   },
   kind: 'write',
+  destructive: true,
 };

--- a/packages/mcp/src/tools/detach-instance.ts
+++ b/packages/mcp/src/tools/detach-instance.ts
@@ -15,4 +15,6 @@ export const detachInstanceTool: ToolSpec = {
     instanceId: z.string().describe('Instance node id to detach'),
   },
   kind: 'write',
+  // Severs the instance→component link permanently (Figma has no re-attach) — the binding is lost.
+  destructive: true,
 };

--- a/packages/mcp/src/tools/remove-reactions.ts
+++ b/packages/mcp/src/tools/remove-reactions.ts
@@ -14,4 +14,6 @@ export const removeReactionsTool: ToolSpec = {
     nodeId: z.string().describe('Node to clear reactions from'),
   },
   kind: 'write',
+  // Deletes the node's prototype reactions outright — data that can't be recovered afterwards.
+  destructive: true,
 };

--- a/packages/mcp/src/tools/spec.ts
+++ b/packages/mcp/src/tools/spec.ts
@@ -12,4 +12,11 @@ export interface ToolSpec {
   /** Zod raw shape (e.g. `{ nodeId: z.string() }`); `{}` for a no-argument tool. */
   inputShape: ZodRawShape;
   kind: ToolKind;
+  /**
+   * Marks a write that irreversibly destroys user data (a delete, ungrouping, clearing reactions,
+   * severing an instance from its component) — drives the MCP `destructiveHint` annotation. Lives
+   * on the spec so the flag can't drift from the tool it describes; a registry test asserts every
+   * `delete_*` tool carries it. Omitted = non-destructive (creates / property sets).
+   */
+  destructive?: true;
 }

--- a/packages/mcp/src/tools/ungroup-nodes.ts
+++ b/packages/mcp/src/tools/ungroup-nodes.ts
@@ -13,4 +13,6 @@ export const ungroupNodesTool: ToolSpec = {
     nodeIds: z.array(z.string()).describe('Group node ids to ungroup'),
   },
   kind: 'write',
+  // Dissolves the GROUP node itself — the grouping (and the node id) is destroyed, not recoverable.
+  destructive: true,
 };

--- a/test/tool-registry.test.ts
+++ b/test/tool-registry.test.ts
@@ -79,6 +79,23 @@ describe('tool registry', () => {
     expect(writes.filter(n => !handlerKeys.includes(n))).toEqual([]);
   });
 
+  it('every delete_* tool declares destructive, and destructive only appears on writes', () => {
+    // destructiveHint is derived from the spec's own flag (index.ts annotationsFor) — an unflagged
+    // delete would actively advertise destructiveHint:false, so lock the naming convention to the
+    // flag. Non-delete destructive tools (ungroup_nodes, remove_reactions, detach_instance) are
+    // judgment calls made at the spec; only the mechanical rule is asserted here.
+    const unflaggedDeletes = ALL_TOOL_SPECS.filter(
+      s => s.name.startsWith('delete_') && s.destructive !== true,
+    ).map(s => s.name);
+    const nonWriteDestructive = ALL_TOOL_SPECS.filter(
+      s => s.destructive === true && s.kind !== 'write',
+    ).map(s => s.name);
+    expect({ unflaggedDeletes, nonWriteDestructive }).toEqual({
+      unflaggedDeletes: [],
+      nonWriteDestructive: [],
+    });
+  });
+
   it('every input schema property declares a type (no untyped polymorphic params)', () => {
     const offenders: string[] = [];
     for (const spec of ALL_TOOL_SPECS) {


### PR DESCRIPTION
## Problem

`delete_variable_collection` was missing from index.ts's hand-kept `DESTRUCTIVE_TOOLS` set — and because `annotationsFor` marks every unlisted write `destructiveHint: false`, deleting an entire collection (with every variable and mode in it) was **actively advertised as non-destructive** to MCP clients. Root cause is the hand-kept list itself: `WRITE_TOOL_NAMES` is already derived from each spec's `kind`, but the destructive set wasn't derived from anything.

## Fix

- `ToolSpec` gains `destructive?: true`; each destructive tool declares it at its own definition, and index.ts derives the annotation (`destructiveHint: spec.destructive === true`). The hand-kept set is gone.
- Flagged: the six `delete_*` tools, `ungroup_nodes` (parity with before), plus two under the same "irreversibly destroys user data" criterion — `remove_reactions` (deletes prototype reactions outright) and `detach_instance` (permanently severs the instance→component link; Figma has no re-attach).
- New registry test: every `delete_*` tool must carry the flag, and the flag may only appear on writes — a future delete can't ship silently marked non-destructive again.

## Verification

Full gate suite green: typecheck / lint / format / knip / build / 810 tests (annotation-level change; behavior covered by the registry guard).