### PR TITLE
fix(mcp): normalize pasted Figma URLs on every canvas-id argument

### DIFF
--- a/packages/mcp/src/node-id.ts
+++ b/packages/mcp/src/node-id.ts
@@ -42,11 +42,31 @@ export const normalizeNodeId = (raw: string): string => {
   return value;
 };
 
-const STRING_ID_FIELDS = ['nodeId', 'parentId'] as const;
+/**
+ * Every top-level tool-arg field that carries a _canvas node id_ (page / frame / layer / component
+ * / instance) — i.e. a value a user may paste as a Figma URL or dash-form id. Fields in other id
+ * namespaces (styleId, variableId, collectionId, propertyId, modeId, componentKey) are deliberately
+ * absent: their values never come from a canvas URL and must not be rewritten. Nested ids (e.g. a
+ * reaction action's destinationId, per-item ids inside `renames`) are out of scope — normalization
+ * is shallow by design. A registry test asserts every canvas-id field on an advertised tool is
+ * listed here, so a new tool can't silently miss URL normalization.
+ */
+export const STRING_ID_FIELDS = [
+  'nodeId',
+  'parentId',
+  'newParentId',
+  'pageId',
+  'root',
+  'rootId',
+  'componentId',
+  'instanceId',
+  'fromNodeId',
+] as const;
 
 /**
  * Normalize the id-bearing fields of a tool's argument object in place of the caller having to do
- * it: `nodeId` / `parentId` (strings) and `nodeIds` (string array). Non-object args pass through.
+ * it: every STRING_ID_FIELDS entry (strings) and `nodeIds` (string array). Non-object args pass
+ * through.
  */
 export const normalizeIdArgs = (args: unknown): unknown => {
   if (typeof args !== 'object' || args === null) return args;

--- a/packages/mcp/test/node-id.test.ts
+++ b/packages/mcp/test/node-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeIdArgs, normalizeNodeId } from '../src/node-id.js';
+import { normalizeIdArgs, normalizeNodeId, STRING_ID_FIELDS } from '../src/node-id.js';
+import { ALL_TOOL_SPECS } from '../src/tools/registry.js';
 
 describe('normalizeNodeId', () => {
   it('extracts and converts the node-id from a full Figma design URL', () => {
@@ -60,6 +61,40 @@ describe('normalizeIdArgs', () => {
     );
   });
 
+  it('normalizes every canvas-id field a tool exposes, not just nodeId/parentId', () => {
+    // Each of these is a real tool arg (swap_component.instanceId, create_instance.componentId,
+    // search_nodes.root, navigate_to_page.pageId, …) where a pasted URL / dash id must also work.
+    expect(
+      normalizeIdArgs({
+        instanceId: '1-2',
+        componentId: 'https://www.figma.com/design/KEY/Name?node-id=3-4',
+        root: '5-6',
+        rootId: '7-8',
+        pageId: '0-1',
+        newParentId: '9-10',
+        fromNodeId: '11-12',
+      }),
+    ).toEqual({
+      instanceId: '1:2',
+      componentId: '3:4',
+      root: '5:6',
+      rootId: '7:8',
+      pageId: '0:1',
+      newParentId: '9:10',
+      fromNodeId: '11:12',
+    });
+  });
+
+  it('never rewrites non-canvas id namespaces (style / variable / key ids)', () => {
+    const args = {
+      styleId: 'S:abc123,',
+      variableId: 'VariableID:1:23',
+      componentKey: 'a1b2c3d4',
+      propertyId: 'Show Icon#12:5',
+    };
+    expect(normalizeIdArgs(args)).toBe(args); // untouched, same reference
+  });
+
   it('returns the same reference when nothing changes (no needless clone)', () => {
     const args = { nodeId: '1:42', foo: 'bar' };
     expect(normalizeIdArgs(args)).toBe(args);
@@ -68,5 +103,30 @@ describe('normalizeIdArgs', () => {
   it('passes non-object args through', () => {
     expect(normalizeIdArgs(undefined)).toBeUndefined();
     expect(normalizeIdArgs('x')).toBe('x');
+  });
+
+  it('covers every top-level canvas-id arg any advertised tool exposes', () => {
+    // normalizeIdArgs rewrites pasted Figma URLs / dash ids only for the fields in
+    // STRING_ID_FIELDS (+ the nodeIds array). A new tool introducing e.g. `targetId` without
+    // listing it would silently skip normalization — so every *Id-shaped top-level field must be
+    // classified: either a canvas node id (listed in STRING_ID_FIELDS) or a non-canvas id
+    // namespace (allowlisted below, never URL-pasteable). Nested ids stay out of scope by design.
+    const NON_CANVAS_ID_FIELDS = new Set([
+      'styleId', // shared-style ids (S:…)
+      'variableId', // variable ids (VariableID:…)
+      'collectionId', // variable-collection ids
+      'propertyId', // component-property handles (name#id)
+      'modeId', // variable-mode ids
+    ]);
+    const covered = new Set<string>([...STRING_ID_FIELDS, 'nodeIds']);
+    const offenders: string[] = [];
+    for (const spec of ALL_TOOL_SPECS) {
+      for (const key of Object.keys(spec.inputShape)) {
+        const idShaped = /Ids?$/.test(key) || key === 'root';
+        if (!idShaped || NON_CANVAS_ID_FIELDS.has(key)) continue;
+        if (!covered.has(key)) offenders.push(`${spec.name}.${key}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`normalizeIdArgs` promises that "every tool" accepts a pasted Figma URL or dash-form node id, but it only rewrote `nodeId` / `parentId` / `nodeIds`. Tools expose seven more top-level fields that carry canvas node ids — `componentId`, `instanceId`, `root`, `rootId`, `newParentId`, `pageId`, `fromNodeId` — so e.g. a URL pasted into `swap_component.instanceId` or `search_nodes.root` failed with "not found" (or silently returned empty results).

## Fix

- `STRING_ID_FIELDS` extended to the full set, enumerated from a census of all 101 tool specs' top-level fields. Pure widening: normalization is the identity on anything that isn't a Figma URL or a dash-form id, and non-canvas id namespaces (`styleId`, `variableId`, `collectionId`, `propertyId`, `modeId`, `componentKey`) are deliberately excluded.
- New guard test classifies every `*Id`-shaped top-level tool arg as either canvas (must be in `STRING_ID_FIELDS`) or an allowlisted non-canvas namespace — a new tool introducing e.g. `targetId` fails the test until classified, so URL normalization can't silently regress.

## Verification

- Unit tests for all seven new fields (dash + URL forms) and for non-canvas namespaces staying untouched (same-reference return). Full gate suite green: typecheck / lint / format / knip / build / 810 tests.
- **Live (plugin connected)**: `scan_text_nodes.root` given `7510-1320` and a full `figma.com/design/...?node-id=7510-1320` URL both resolved to the real node (previously both returned empty).