### PR TITLE
docs: sync npm README tool count with the registry and fix stale manifest reasoning

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **96 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **101 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/plugin/manifest.json
+++ b/packages/plugin/manifest.json
@@ -8,6 +8,6 @@
   "documentAccess": "dynamic-page",
   "networkAccess": {
     "allowedDomains": ["*"],
-    "reasoning": "Connects only to a local Figwright WebSocket on 127.0.0.1; the listen port falls back across a range, so all origins are allowed for simplicity (the plugin never reaches the public network)."
+    "reasoning": "The core connection is a local WebSocket relay on 127.0.0.1:3055 (the Figwright MCP server on this machine). Open domains are required because the import_image tool can additionally fetch an image from a user-supplied URL."
   }
 }

--- a/test/docs-sync.test.ts
+++ b/test/docs-sync.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { ALL_TOOL_SPECS } from '../packages/mcp/src/tools/registry.js';
+
+// Docs-sync guard: the tool count is prose in two user-facing READMEs (the GitHub front page and
+// the npm package page) while the authority is ALL_TOOL_SPECS.length — and the npm one has already
+// drifted once (advertised 96 while the server shipped 101). Lock every bolded "**N tools**" /
+// "**N MCP tools**" claim to the registry. Requiring at least one match per file keeps the guard
+// itself honest: a reworded README that no longer matches the pattern fails loudly instead of
+// silently un-guarding the number.
+
+const README_PATHS = ['README.md', 'packages/mcp/README.md'];
+const TOOL_COUNT_CLAIM = /\*\*(\d+)(?: MCP)? tools\*\*/g;
+
+describe('README tool counts', () => {
+  it.each(README_PATHS)('%s advertises exactly ALL_TOOL_SPECS.length tools', path => {
+    const body = readFileSync(join(import.meta.dirname, '..', path), 'utf8');
+    const claims = [...body.matchAll(TOOL_COUNT_CLAIM)].map(m => Number(m[1]));
+    expect(
+      claims.length,
+      `${path}: no "**N tools**" claim found — update TOOL_COUNT_CLAIM`,
+    ).toBeGreaterThan(0);
+    expect(claims).toEqual(claims.map(() => ALL_TOOL_SPECS.length));
+  });
+});


### PR DESCRIPTION
## Problem

Two user-facing docs drifted from reality:

1. **`packages/mcp/README.md`** (the npm package page) advertised **96 tools** while the server ships **101** (`ALL_TOOL_SPECS.length`). The count is prose with no guard, so it re-drifts every time tools land.
2. **`packages/plugin/manifest.json`** `networkAccess.reasoning` — the text Figma Community review reads — was stale on two counts: it cited a port-range fallback removed in #28 (the relay always binds 3055), and claimed "the plugin never reaches the public network", untrue since `import_image` fetches user-supplied URLs on request.

## Fix

- README count 96 → 101, plus a `test/docs-sync.test.ts` guard locking every bolded `**N tools**` / `**N MCP tools**` claim in both READMEs to `ALL_TOOL_SPECS.length`. The guard requires ≥1 match per file, so a reworded README fails loudly instead of silently un-guarding the number.
- Manifest reasoning replaced with the honest rationale (local relay on 127.0.0.1:3055 + import_image URL fetch). **`allowedDomains` deliberately unchanged** — narrowing it would break import_image's URL mode (equal-or-better bar).

## Verification

Full gate suite green on the branch: typecheck / lint / format / knip / build / 812 tests.