### PR TITLE
feat(set_auto_layout): author the wrap cross-axis (counterAxisSpacing / counterAxisAlignContent)

### DIFF
--- a/packages/mcp/src/tools/set-auto-layout.ts
+++ b/packages/mcp/src/tools/set-auto-layout.ts
@@ -8,8 +8,10 @@ export const setAutoLayoutTool: ToolSpec = {
   name: SET_AUTO_LAYOUT_TOOL_NAME,
   description:
     "Configure a frame's auto layout. layoutMode NONE disables it; HORIZONTAL/VERTICAL enable flex " +
-    '(padding / itemSpacing / alignment / wrap); GRID enables CSS-Grid-style layout ' +
-    '(padding / gridRowCount / gridColumnCount / gridRowGap / gridColumnGap). Returns { ok, nodeId }.',
+    '(padding / itemSpacing / alignment / wrap, plus counterAxisSpacing / counterAxisAlignContent ' +
+    'for the wrapped cross axis — the CSS row-gap / align-content); GRID enables CSS-Grid-style ' +
+    'layout (padding / gridRowCount / gridColumnCount / gridRowGap / gridColumnGap). ' +
+    'Returns { ok, nodeId }.',
   inputShape: {
     nodeId: z.string(),
     layoutMode: z.enum(['NONE', 'HORIZONTAL', 'VERTICAL', 'GRID']),
@@ -22,6 +24,21 @@ export const setAutoLayoutTool: ToolSpec = {
     primaryAxisAlignItems: z.enum(['MIN', 'CENTER', 'MAX', 'SPACE_BETWEEN']).optional(),
     counterAxisAlignItems: z.enum(['MIN', 'CENTER', 'MAX', 'BASELINE']).optional(),
     layoutWrap: z.enum(['NO_WRAP', 'WRAP']).optional(),
+    counterAxisSpacing: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Cross-axis gap between wrapped rows (px) — the CSS row-gap when it differs from ' +
+          'itemSpacing (gap: 16px 8px). Requires layoutWrap WRAP (settable in the same call)',
+      ),
+    counterAxisAlignContent: z
+      .enum(['AUTO', 'SPACE_BETWEEN'])
+      .optional()
+      .describe(
+        'How wrapped rows distribute along the cross axis: AUTO packs them at counterAxisSpacing, ' +
+          'SPACE_BETWEEN spreads them (align-content). Requires layoutWrap WRAP',
+      ),
     // GRID
     gridRowCount: z.number().int().positive().optional(),
     gridColumnCount: z.number().int().positive().optional(),

--- a/packages/plugin/src/handlers/set-auto-layout.ts
+++ b/packages/plugin/src/handlers/set-auto-layout.ts
@@ -14,6 +14,8 @@ type AutoLayoutTarget = {
   primaryAxisAlignItems: string;
   counterAxisAlignItems: string;
   layoutWrap: string;
+  counterAxisSpacing: number | null;
+  counterAxisAlignContent: string;
   gridRowCount: number;
   gridColumnCount: number;
   gridRowGap: number;
@@ -60,6 +62,22 @@ export const createSetAutoLayoutHandler =
         if (typeof p.counterAxisAlignItems === 'string')
           target.counterAxisAlignItems = p.counterAxisAlignItems;
         if (typeof p.layoutWrap === 'string') target.layoutWrap = p.layoutWrap;
+        // Wrap cross-axis: the row gap and the row distribution (→ CSS row-gap / align-content).
+        // Only meaningful under WRAP, so applied after layoutWrap (enabling wrap and setting its
+        // row gap works in one call) and rejected loudly otherwise — Figma would otherwise ignore
+        // the value, and a silent no-op is the worst failure mode for an authoring tool.
+        const wantsCrossAxis =
+          p.counterAxisSpacing !== undefined || p.counterAxisAlignContent !== undefined;
+        if (wantsCrossAxis && target.layoutWrap !== 'WRAP') {
+          throw new Error(
+            'set_auto_layout: counterAxisSpacing / counterAxisAlignContent apply only to a ' +
+              'wrapping flex — pass layoutWrap: "WRAP" (in this call or before)',
+          );
+        }
+        if (typeof p.counterAxisSpacing === 'number')
+          target.counterAxisSpacing = p.counterAxisSpacing;
+        if (typeof p.counterAxisAlignContent === 'string')
+          target.counterAxisAlignContent = p.counterAxisAlignContent;
       }
     }
 

--- a/packages/plugin/src/handlers/set-auto-layout.ts
+++ b/packages/plugin/src/handlers/set-auto-layout.ts
@@ -38,6 +38,24 @@ export const createSetAutoLayoutHandler =
       throw new Error(`set_auto_layout: node ${p.nodeId} not found or has no auto layout`);
     }
     const target = node as unknown as AutoLayoutTarget;
+
+    // Wrap cross-axis (counterAxisSpacing / counterAxisAlignContent → CSS row-gap /
+    // align-content) is only meaningful on a wrapping flex. Validate BEFORE any mutation —
+    // this is a contradiction in the inputs, and rejecting it after layoutWrap was already
+    // applied would leave a partial change behind (caught live). Rejected loudly rather than
+    // deferred to Figma, whose silent ignore is the worst failure mode for an authoring tool.
+    const wantsCrossAxis =
+      p.counterAxisSpacing !== undefined || p.counterAxisAlignContent !== undefined;
+    if (wantsCrossAxis && (p.layoutMode === 'HORIZONTAL' || p.layoutMode === 'VERTICAL')) {
+      const effectiveWrap = typeof p.layoutWrap === 'string' ? p.layoutWrap : target.layoutWrap;
+      if (effectiveWrap !== 'WRAP') {
+        throw new Error(
+          'set_auto_layout: counterAxisSpacing / counterAxisAlignContent apply only to a ' +
+            'wrapping flex — pass layoutWrap: "WRAP" (in this call or before)',
+        );
+      }
+    }
+
     // Set the mode first: grid counts / gaps only become writable once layoutMode is GRID.
     target.layoutMode = p.layoutMode;
 
@@ -62,18 +80,8 @@ export const createSetAutoLayoutHandler =
         if (typeof p.counterAxisAlignItems === 'string')
           target.counterAxisAlignItems = p.counterAxisAlignItems;
         if (typeof p.layoutWrap === 'string') target.layoutWrap = p.layoutWrap;
-        // Wrap cross-axis: the row gap and the row distribution (→ CSS row-gap / align-content).
-        // Only meaningful under WRAP, so applied after layoutWrap (enabling wrap and setting its
-        // row gap works in one call) and rejected loudly otherwise — Figma would otherwise ignore
-        // the value, and a silent no-op is the worst failure mode for an authoring tool.
-        const wantsCrossAxis =
-          p.counterAxisSpacing !== undefined || p.counterAxisAlignContent !== undefined;
-        if (wantsCrossAxis && target.layoutWrap !== 'WRAP') {
-          throw new Error(
-            'set_auto_layout: counterAxisSpacing / counterAxisAlignContent apply only to a ' +
-              'wrapping flex — pass layoutWrap: "WRAP" (in this call or before)',
-          );
-        }
+        // Wrap cross-axis, validated up front; applied after layoutWrap so enabling wrap and
+        // setting its row gap works in one call.
         if (typeof p.counterAxisSpacing === 'number')
           target.counterAxisSpacing = p.counterAxisSpacing;
         if (typeof p.counterAxisAlignContent === 'string')

--- a/packages/plugin/test/handlers/set-auto-layout.test.ts
+++ b/packages/plugin/test/handlers/set-auto-layout.test.ts
@@ -17,6 +17,8 @@ const makeFrame = () => ({
   primaryAxisAlignItems: 'MIN',
   counterAxisAlignItems: 'MIN',
   layoutWrap: 'NO_WRAP',
+  counterAxisSpacing: null as number | null,
+  counterAxisAlignContent: 'AUTO',
   gridRowCount: 0,
   gridColumnCount: 0,
   gridRowGap: 0,
@@ -73,6 +75,40 @@ describe('set_auto_layout handler', () => {
     expect(node.gridColumnGap).toBe(12);
     expect(node.itemSpacing).toBe(0); // unchanged — itemSpacing is flex-only
     expect(result).toEqual({ ok: true, nodeId: '1:1' });
+  });
+
+  it('sets the wrap cross-axis (row gap + align-content) when enabling WRAP in the same call', async () => {
+    const node = makeFrame();
+    const handler = createSetAutoLayoutHandler(fakeFigma({ '1:1': node }));
+    await handler({
+      nodeId: '1:1',
+      layoutMode: 'HORIZONTAL',
+      itemSpacing: 8,
+      layoutWrap: 'WRAP',
+      counterAxisSpacing: 16,
+      counterAxisAlignContent: 'SPACE_BETWEEN',
+    });
+    expect(node.layoutWrap).toBe('WRAP');
+    expect(node.counterAxisSpacing).toBe(16);
+    expect(node.counterAxisAlignContent).toBe('SPACE_BETWEEN');
+  });
+
+  it('sets the row gap on an already-wrapping frame without re-passing layoutWrap', async () => {
+    const node = makeFrame();
+    node.layoutWrap = 'WRAP';
+    const handler = createSetAutoLayoutHandler(fakeFigma({ '1:1': node }));
+    await handler({ nodeId: '1:1', layoutMode: 'HORIZONTAL', counterAxisSpacing: 24 });
+    expect(node.counterAxisSpacing).toBe(24);
+  });
+
+  it('rejects cross-axis fields on a non-wrapping flex instead of a silent no-op', async () => {
+    const handler = createSetAutoLayoutHandler(fakeFigma({ '1:1': makeFrame() }));
+    await expect(
+      handler({ nodeId: '1:1', layoutMode: 'HORIZONTAL', counterAxisSpacing: 16 }),
+    ).rejects.toThrow(/apply only to a wrapping flex/);
+    await expect(
+      handler({ nodeId: '1:1', layoutMode: 'VERTICAL', counterAxisAlignContent: 'SPACE_BETWEEN' }),
+    ).rejects.toThrow(/layoutWrap/);
   });
 
   it('throws on bad layoutMode or a node without auto layout', async () => {

--- a/packages/plugin/test/handlers/set-auto-layout.test.ts
+++ b/packages/plugin/test/handlers/set-auto-layout.test.ts
@@ -111,6 +111,27 @@ describe('set_auto_layout handler', () => {
     ).rejects.toThrow(/layoutWrap/);
   });
 
+  it('rejects the contradiction before mutating anything (no partial change left behind)', async () => {
+    // NO_WRAP + counterAxisSpacing is contradictory input. Caught live: the first cut applied
+    // layoutWrap (and layoutMode/itemSpacing) before throwing, leaving a partial change.
+    const node = makeFrame();
+    node.layoutMode = 'HORIZONTAL';
+    node.layoutWrap = 'WRAP';
+    node.itemSpacing = 8;
+    const handler = createSetAutoLayoutHandler(fakeFigma({ '1:1': node }));
+    await expect(
+      handler({
+        nodeId: '1:1',
+        layoutMode: 'HORIZONTAL',
+        itemSpacing: 99,
+        layoutWrap: 'NO_WRAP',
+        counterAxisSpacing: 20,
+      }),
+    ).rejects.toThrow(/apply only to a wrapping flex/);
+    // Every field untouched — the reject happened before the first mutation.
+    expect(node).toMatchObject({ layoutMode: 'HORIZONTAL', layoutWrap: 'WRAP', itemSpacing: 8 });
+  });
+
   it('throws on bad layoutMode or a node without auto layout', async () => {
     const handler = createSetAutoLayoutHandler(fakeFigma({ '1:1': makeFrame() }));
     await expect(handler({ nodeId: '1:1', layoutMode: 'DIAGONAL' })).rejects.toThrow(/layoutMode/);


### PR DESCRIPTION
## Problem

The serializer has long read a wrapping flex's cross-axis — the row gap (`counterAxisSpacing`) and row distribution (`counterAxisAlignContent`) — but `set_auto_layout` couldn't write either. figma-build could enable WRAP yet never author CSS's `gap: <row> <col>` or `align-content`: tag lists and wrapped card rows came out with the wrong row rhythm.

## Change

Both fields land on `set_auto_layout` (the tool that owns wrap):

- Applied after `layoutWrap`, so enabling wrap and setting its row gap works in **one call**.
- Contradictory input (cross-axis fields on a non-wrapping flex) is **validated before any mutation** and rejected with an actionable error — Figma's own behavior is a silent ignore, the worst failure mode for an authoring tool.

## Verification

- Unit tests: same-call wrap+gap, already-wrapping frame, non-wrap reject, and a no-partial-change regression test.
- **Live round-trip caught a real bug in the first cut**: the reject fired *after* `layoutMode`/`itemSpacing`/`layoutWrap` were applied, leaving a partial change. Fixed by validating up front against the effective wrap (incoming value, else the node's current one); re-verified live — a rejected call now leaves every field untouched (`WRAP`/`itemSpacing: 8`/`counterAxisSpacing: 16` intact after the error).
- Happy path live: one call set WRAP + row-gap 16 + SPACE_BETWEEN; read-back exact. Full gates green: 820 tests.