### PR TITLE
feat(save_image_fills): extract original image-fill bytes to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **101 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **102 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
@@ -182,9 +182,9 @@ npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-cod
 
 ## Tools
 
-Figwright exposes **101 MCP tools** in three groups:
+Figwright exposes **102 MCP tools** in three groups:
 
-- **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, and PDF export.
+- **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, original image-fill assets, and PDF export.
 - **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components (including authoring their boolean/text/instance-swap properties), pages, and reactions; plus a `batch` tool to apply many edits at once.
 - **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have; plus `design_diff`, which reports what changed in a design against a saved baseline so you update only the affected code.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **101 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **102 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,6 +20,7 @@ import { GET_SCREENSHOT_TOOL_NAME, screenshotContent } from './tools/get-screens
 import { handleIconMap, ICON_MAP_TOOL_NAME } from './tools/icon-map.js';
 import { formatPingResult, handlePing, pingTool } from './tools/ping.js';
 import { ALL_TOOL_SPECS } from './tools/registry.js';
+import { handleSaveImageFills, SAVE_IMAGE_FILLS_TOOL_NAME } from './tools/save-image-fills.js';
 import { handleSaveScreenshots, SAVE_SCREENSHOTS_TOOL_NAME } from './tools/save-screenshots.js';
 import { handleScanComponents, SCAN_COMPONENTS_TOOL_NAME } from './tools/scan-components.js';
 import type { ToolSpec } from './tools/spec.js';
@@ -92,6 +93,8 @@ const SPECIAL_HANDLERS: Record<string, ToolHandler> = {
   }),
   [SAVE_SCREENSHOTS_TOOL_NAME]: async args =>
     textResult(await handleSaveScreenshots(dispatch, args)),
+  [SAVE_IMAGE_FILLS_TOOL_NAME]: async args =>
+    textResult(await handleSaveImageFills(dispatch, args)),
   [EXPORT_PDF_TOOL_NAME]: async args => textResult(await handleExportPdf(dispatch, args)),
   [GET_SCREENSHOT_TOOL_NAME]: async args => ({
     content: screenshotContent(

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -73,6 +73,7 @@ import { reorderNodesTool } from './reorder-nodes.js';
 import { reparentNodesTool } from './reparent-nodes.js';
 import { resizeNodesTool } from './resize-nodes.js';
 import { rotateNodesTool } from './rotate-nodes.js';
+import { saveImageFillsTool } from './save-image-fills.js';
 import { saveScreenshotsTool } from './save-screenshots.js';
 import { scanComponentsTool } from './scan-components.js';
 import { scanNodesByTypesTool } from './scan-nodes-by-types.js';
@@ -131,6 +132,7 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   getDesignContextTool,
   getScreenshotTool,
   saveScreenshotsTool,
+  saveImageFillsTool,
   exportPdfTool,
   // Server-local (filesystem; no plugin handler — like save_screenshots). analyze_project is an
   // optional standalone probe; scan_components / component_map also run detection internally.

--- a/packages/mcp/src/tools/save-image-fills.ts
+++ b/packages/mcp/src/tools/save-image-fills.ts
@@ -1,0 +1,134 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+import type {
+  ImageFillsResult,
+  NodeImageFills,
+  SaveImageFillsResult,
+  SavedImageFill,
+  SavedNodeImageFills,
+} from '@figwright/shared';
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const SAVE_IMAGE_FILLS_TOOL_NAME = 'save_image_fills';
+
+const inputShape = {
+  nodeIds: z.array(z.string()).describe('Figma node ids whose IMAGE fills to extract'),
+  outDir: z
+    .string()
+    .describe('Directory to write the original image files into (created if missing)'),
+};
+
+export const saveImageFillsTool: ToolSpec = {
+  name: SAVE_IMAGE_FILLS_TOOL_NAME,
+  description:
+    "Extract the ORIGINAL image bytes behind each node's IMAGE fills and write them to disk under " +
+    'outDir — the source asset exactly as uploaded (no mask, clip, crop, scale, or effects applied), ' +
+    'unlike save_screenshots / get_screenshot which re-render the composited node. Returns ' +
+    '{ nodes: [{ nodeId, images: [{ index, imageHash, format, path, width?, height?, scaleMode? }], ' +
+    'mixed? }] }. index is the fill position in node.fills; width/height are the image intrinsic size; ' +
+    'scaleMode is how the fill is displayed (FILL / FIT / CROP / TILE); format is sniffed from the ' +
+    'bytes (PNG / JPG / GIF / WEBP, or BIN if unrecognized). Identical images (same imageHash reused ' +
+    'across nodes) are fetched once and share one file named by hash. path is null when the fill image ' +
+    "can't be resolved; images:[] means the node has no image fill; mixed:true means the node's fills " +
+    'are per-text-range and were not enumerated. For a rendered/composited raster use save_screenshots; ' +
+    'for a vector node use export_pdf.',
+  inputShape,
+  kind: 'local',
+};
+
+/**
+ * Sniff the container from the leading magic bytes so the file lands with the right extension. Only
+ * the formats Figma stores as image fills are recognized; anything else is written verbatim as
+ * `.bin` (lossless — the bytes are preserved, only the label is generic).
+ */
+export const detectImageFormat = (bytes: Buffer): { format: string; ext: string } => {
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  )
+    return { format: 'PNG', ext: 'png' };
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff)
+    return { format: 'JPG', ext: 'jpg' };
+  if (bytes.length >= 3 && bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46)
+    return { format: 'GIF', ext: 'gif' };
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  )
+    return { format: 'WEBP', ext: 'webp' };
+  return { format: 'BIN', ext: 'bin' };
+};
+
+/** Map a Figma image hash to a filesystem-safe basename, blocking path traversal. */
+const sanitize = (hash: string): string => hash.replace(/[^\w.-]/g, '-');
+
+/** Carry the identifying/display fields through from the plugin result to the write result. */
+const carry = (img: NodeImageFills['images'][number]): Omit<SavedImageFill, 'format' | 'path'> => ({
+  index: img.index,
+  imageHash: img.imageHash,
+  ...(img.width !== undefined ? { width: img.width } : {}),
+  ...(img.height !== undefined ? { height: img.height } : {}),
+  ...(img.scaleMode !== undefined ? { scaleMode: img.scaleMode } : {}),
+});
+
+/**
+ * Decode the base64 image bytes into files under outDir (created if missing). Files are named by
+ * imageHash so an asset reused across many nodes is written exactly once; every usage still gets
+ * its own result entry pointing at the shared path. Pure-fs and dispatch-free so it can be
+ * unit-tested against a temp directory.
+ */
+export const writeImageFills = async (
+  outDir: string,
+  nodes: readonly NodeImageFills[],
+): Promise<SaveImageFillsResult> => {
+  const dir = resolve(outDir);
+  await mkdir(dir, { recursive: true });
+
+  // Dedup writes by path: a hash reused across nodes maps to one file written once. Build the whole
+  // result (and the unique write set) first, then flush the files in parallel — no await in a loop.
+  const toWrite = new Map<string, Buffer>();
+  const outNodes: SavedNodeImageFills[] = nodes.map(node => {
+    const images: SavedImageFill[] = node.images.map(img => {
+      if (img.base64 === null || img.imageHash === null) return { ...carry(img), path: null };
+      const buf = Buffer.from(img.base64, 'base64');
+      const { format, ext } = detectImageFormat(buf);
+      const path = join(dir, `${sanitize(img.imageHash)}.${ext}`);
+      if (!toWrite.has(path)) toWrite.set(path, buf);
+      return { ...carry(img), format, path };
+    });
+    return { nodeId: node.nodeId, images, ...(node.mixed === true ? { mixed: true } : {}) };
+  });
+
+  await Promise.all([...toWrite].map(([path, buf]) => writeFile(path, buf)));
+  return { nodes: outNodes };
+};
+
+export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
+
+/**
+ * Reuses the plugin-side save_image_fills handler to fetch the original fill bytes, then lands them
+ * on the server filesystem.
+ */
+export const handleSaveImageFills = async (
+  dispatch: ToolDispatcher,
+  rawArgs: unknown,
+): Promise<SaveImageFillsResult> => {
+  const args = z.object(inputShape).parse(rawArgs);
+  const { nodes } = (await dispatch(SAVE_IMAGE_FILLS_TOOL_NAME, {
+    nodeIds: args.nodeIds,
+  })) as ImageFillsResult;
+  return writeImageFills(args.outDir, nodes);
+};

--- a/packages/mcp/test/tools/save-image-fills.test.ts
+++ b/packages/mcp/test/tools/save-image-fills.test.ts
@@ -1,0 +1,201 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ImageFillsResult, NodeImageFills, SaveImageFillsResult } from '@figwright/shared';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  detectImageFormat,
+  handleSaveImageFills,
+  SAVE_IMAGE_FILLS_TOOL_NAME,
+  saveImageFillsTool,
+  type ToolDispatcher,
+  writeImageFills,
+} from '../../src/tools/save-image-fills.js';
+import { toToolDefinition } from '../tool-schema.js';
+
+const saveImageFillsToolDefinition = toToolDefinition(saveImageFillsTool);
+
+// Minimal magic-byte payloads, base64-encoded the way the plugin ships them over the wire.
+const b64 = (bytes: number[]): string => Buffer.from(bytes).toString('base64');
+const PNG_B64 = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPG_B64 = b64([0xff, 0xd8, 0xff, 0xe0, 0x00]);
+
+const emptyDispatch: ToolDispatcher = async () => ({ nodes: [] }) satisfies ImageFillsResult;
+
+const dirs: string[] = [];
+const makeDir = async (): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), 'save-image-fills-'));
+  dirs.push(dir);
+  return dir;
+};
+
+afterEach(async () => {
+  await Promise.all(dirs.map(d => rm(d, { recursive: true, force: true })));
+  dirs.length = 0;
+});
+
+describe('save_image_fills — definition', () => {
+  it('requires nodeIds + outDir and is read-only (kind local)', () => {
+    expect(saveImageFillsToolDefinition.name).toBe(SAVE_IMAGE_FILLS_TOOL_NAME);
+    expect(saveImageFillsTool.kind).toBe('local');
+    expect(saveImageFillsToolDefinition.inputSchema).toMatchObject({
+      type: 'object',
+      required: ['nodeIds', 'outDir'],
+      properties: {
+        nodeIds: { type: 'array', items: { type: 'string' } },
+        outDir: { type: 'string' },
+      },
+    });
+  });
+});
+
+describe('detectImageFormat', () => {
+  it('recognizes PNG / JPG / GIF / WEBP by magic bytes', () => {
+    expect(detectImageFormat(Buffer.from([0x89, 0x50, 0x4e, 0x47]))).toEqual({
+      format: 'PNG',
+      ext: 'png',
+    });
+    expect(detectImageFormat(Buffer.from([0xff, 0xd8, 0xff]))).toEqual({
+      format: 'JPG',
+      ext: 'jpg',
+    });
+    expect(detectImageFormat(Buffer.from([0x47, 0x49, 0x46, 0x38]))).toEqual({
+      format: 'GIF',
+      ext: 'gif',
+    });
+    const webp = Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]);
+    expect(detectImageFormat(webp)).toEqual({ format: 'WEBP', ext: 'webp' });
+  });
+
+  it('falls back to BIN for an unrecognized container (bytes still preserved)', () => {
+    expect(detectImageFormat(Buffer.from([0x00, 0x01, 0x02, 0x03]))).toEqual({
+      format: 'BIN',
+      ext: 'bin',
+    });
+  });
+});
+
+describe('writeImageFills', () => {
+  it('writes each fill to a hash-named file with the sniffed extension', async () => {
+    const base = await makeDir();
+    const dir = join(base, 'nested', 'assets');
+    const nodes: NodeImageFills[] = [
+      {
+        nodeId: '1:1',
+        images: [
+          {
+            index: 0,
+            imageHash: 'abcHASH',
+            base64: PNG_B64,
+            width: 200,
+            height: 100,
+            scaleMode: 'FILL',
+          },
+          { index: 2, imageHash: 'jpgHASH', base64: JPG_B64, scaleMode: 'CROP' },
+        ],
+      },
+    ];
+    const result = await writeImageFills(dir, nodes);
+
+    expect(result).toEqual({
+      nodes: [
+        {
+          nodeId: '1:1',
+          images: [
+            {
+              index: 0,
+              imageHash: 'abcHASH',
+              format: 'PNG',
+              path: join(dir, 'abcHASH.png'),
+              width: 200,
+              height: 100,
+              scaleMode: 'FILL',
+            },
+            {
+              index: 2,
+              imageHash: 'jpgHASH',
+              format: 'JPG',
+              path: join(dir, 'jpgHASH.jpg'),
+              scaleMode: 'CROP',
+            },
+          ],
+        },
+      ],
+    } satisfies SaveImageFillsResult);
+    expect((await readFile(join(dir, 'abcHASH.png'))).toString('base64')).toBe(PNG_B64);
+    expect((await readFile(join(dir, 'jpgHASH.jpg'))).toString('base64')).toBe(JPG_B64);
+  });
+
+  it('dedupes a shared imageHash to one file while every usage still maps to it', async () => {
+    const dir = await makeDir();
+    const nodes: NodeImageFills[] = [
+      {
+        nodeId: '1:1',
+        images: [{ index: 0, imageHash: 'logo', base64: PNG_B64, scaleMode: 'FILL' }],
+      },
+      {
+        nodeId: '2:2',
+        images: [{ index: 0, imageHash: 'logo', base64: PNG_B64, scaleMode: 'FIT' }],
+      },
+    ];
+    const result = await writeImageFills(dir, nodes);
+    const shared = join(dir, 'logo.png');
+    expect(result.nodes[0]?.images[0]?.path).toBe(shared);
+    expect(result.nodes[1]?.images[0]?.path).toBe(shared);
+    expect((await readFile(shared)).toString('base64')).toBe(PNG_B64);
+  });
+
+  it('returns path null (no write) for an unresolved image and passes mixed through', async () => {
+    const dir = await makeDir();
+    const nodes: NodeImageFills[] = [
+      { nodeId: '1:1', images: [{ index: 0, imageHash: 'gone', base64: null, scaleMode: 'FILL' }] },
+      { nodeId: '2:2', images: [{ index: 1, imageHash: null, base64: null }] },
+      { nodeId: '3:3', images: [], mixed: true },
+    ];
+    const result = await writeImageFills(dir, nodes);
+    expect(result.nodes[0]?.images[0]).toEqual({
+      index: 0,
+      imageHash: 'gone',
+      path: null,
+      scaleMode: 'FILL',
+    });
+    expect(result.nodes[1]?.images[0]).toEqual({ index: 1, imageHash: null, path: null });
+    expect(result.nodes[2]).toEqual({ nodeId: '3:3', images: [], mixed: true });
+    await expect(readFile(join(dir, 'gone.png'))).rejects.toThrow(/ENOENT/);
+  });
+});
+
+describe('handleSaveImageFills', () => {
+  it('dispatches save_image_fills with nodeIds and lands the bytes on disk', async () => {
+    const dir = await makeDir();
+    let dispatched: { tool: string; args: unknown } | null = null;
+    const dispatch: ToolDispatcher = async (tool, args) => {
+      dispatched = { tool, args };
+      return {
+        nodes: [{ nodeId: '1:1', images: [{ index: 0, imageHash: 'h', base64: PNG_B64 }] }],
+      } satisfies ImageFillsResult;
+    };
+
+    const result = (await handleSaveImageFills(dispatch, {
+      nodeIds: ['1:1'],
+      outDir: dir,
+    })) as SaveImageFillsResult;
+
+    expect(dispatched).toEqual({ tool: 'save_image_fills', args: { nodeIds: ['1:1'] } });
+    expect(result.nodes[0]?.images[0]).toEqual({
+      index: 0,
+      imageHash: 'h',
+      format: 'PNG',
+      path: join(dir, 'h.png'),
+    });
+    expect((await readFile(join(dir, 'h.png'))).toString('base64')).toBe(PNG_B64);
+  });
+
+  it('rejects input missing outDir', async () => {
+    await expect(handleSaveImageFills(emptyDispatch, { nodeIds: ['1:1'] })).rejects.toThrow(
+      /outDir/,
+    );
+  });
+});

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -66,6 +66,7 @@ import { createReorderNodesHandler } from './reorder-nodes.js';
 import { createReparentNodesHandler } from './reparent-nodes.js';
 import { createResizeNodesHandler } from './resize-nodes.js';
 import { createRotateNodesHandler } from './rotate-nodes.js';
+import { createSaveImageFillsHandler } from './save-image-fills.js';
 import { createScanNodesByTypesHandler } from './scan-nodes-by-types.js';
 import { createScanTextNodesHandler } from './scan-text-nodes.js';
 import { createSearchNodesHandler } from './search-nodes.js';
@@ -206,6 +207,7 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     list_files: createListFilesHandler(figmaCtx),
     get_design_context: createGetDesignContextHandler(figmaCtx),
     get_screenshot: createGetScreenshotHandler(figmaCtx),
+    save_image_fills: createSaveImageFillsHandler(figmaCtx),
     export_pdf: createExportPdfHandler(figmaCtx),
   };
 

--- a/packages/plugin/src/handlers/save-image-fills.ts
+++ b/packages/plugin/src/handlers/save-image-fills.ts
@@ -1,0 +1,86 @@
+import type { ImageFillBytes, ImageFillsResult, NodeImageFills } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+
+/** Bytes + intrinsic size for one resolved image hash. */
+interface ResolvedImage {
+  base64: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * Extract the ORIGINAL bytes behind each node's IMAGE fills via getImageByHash().getBytesAsync() —
+ * the asset as uploaded, with no mask / clip / crop / scale / effects applied (that is what
+ * get_screenshot's exportAsync bakes in). Read-only: reading image bytes never mutates the
+ * document.
+ *
+ * The same imageHash (a logo reused across many nodes) is fetched exactly once per call — the byte
+ * fetch + size lookup is memoized by hash, so a design that repeats one asset doesn't re-download
+ * it N times.
+ */
+export const createSaveImageFillsHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeIds?: unknown };
+    if (
+      !Array.isArray(p.nodeIds) ||
+      p.nodeIds.length === 0 ||
+      p.nodeIds.some(id => typeof id !== 'string')
+    ) {
+      throw new TypeError('save_image_fills: nodeIds must be a non-empty string[]');
+    }
+
+    const cache = new Map<string, Promise<ResolvedImage | null>>();
+    const fetchImage = (hash: string): Promise<ResolvedImage | null> => {
+      let pending = cache.get(hash);
+      if (pending === undefined) {
+        pending = (async (): Promise<ResolvedImage | null> => {
+          const image = figmaCtx.getImageByHash(hash);
+          if (image === null) return null;
+          const [bytes, size] = await Promise.all([image.getBytesAsync(), image.getSizeAsync()]);
+          return { base64: figmaCtx.base64Encode(bytes), width: size.width, height: size.height };
+        })();
+        cache.set(hash, pending);
+      }
+      return pending;
+    };
+
+    const ids = p.nodeIds as readonly string[];
+    const nodes: NodeImageFills[] = await Promise.all(
+      ids.map(async (nodeId): Promise<NodeImageFills> => {
+        const node = await figmaCtx.getNodeByIdAsync(nodeId);
+        if (node === null || !('fills' in node)) return { nodeId, images: [] };
+
+        const fills = (node as unknown as { fills: readonly Paint[] | typeof figma.mixed }).fills;
+        // Mixed fills (per-text-range) can't be indexed as an array — flag rather than crash.
+        if (fills === figmaCtx.mixed) return { nodeId, images: [], mixed: true };
+
+        // Fetch every fill's bytes in parallel (shared hashes still resolve once via the memoized
+        // cache), then drop the non-image paints — keeps fill order without an await in a loop.
+        const entries = await Promise.all(
+          fills.map(async (paint, index): Promise<ImageFillBytes | null> => {
+            if (paint.type !== 'IMAGE') return null;
+            const { scaleMode } = paint;
+            const imageHash = paint.imageHash ?? null;
+            if (imageHash === null) return { index, imageHash: null, base64: null, scaleMode };
+            const data = await fetchImage(imageHash);
+            if (data === null) return { index, imageHash, base64: null, scaleMode };
+            return {
+              index,
+              imageHash,
+              base64: data.base64,
+              width: data.width,
+              height: data.height,
+              scaleMode,
+            };
+          }),
+        );
+        const images = entries.filter((e): e is ImageFillBytes => e !== null);
+        return { nodeId, images };
+      }),
+    );
+
+    const result: ImageFillsResult = { nodes };
+    return result;
+  };

--- a/packages/plugin/test/handlers/save-image-fills.test.ts
+++ b/packages/plugin/test/handlers/save-image-fills.test.ts
@@ -1,0 +1,126 @@
+import type { ImageFillsResult } from '@figwright/shared';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSaveImageFillsHandler } from '../../src/handlers/save-image-fills.js';
+
+const MIXED = Symbol('figma.mixed');
+
+interface FakeImage {
+  getBytesAsync: () => Promise<Uint8Array>;
+  getSizeAsync: () => Promise<{ width: number; height: number }>;
+}
+
+const makeFigma = (
+  nodes: Record<string, unknown>,
+  images: Record<string, FakeImage | null>,
+  getBytes = vi.fn<(h: string) => Promise<Uint8Array>>(),
+): typeof figma =>
+  ({
+    mixed: MIXED,
+    base64Encode: (bytes: Uint8Array) => `b64(${bytes.length})`,
+    getNodeByIdAsync: async (id: string) => (nodes[id] ?? null) as BaseNode | null,
+    getImageByHash: (hash: string) => {
+      const img = images[hash];
+      if (img === null || img === undefined) return null;
+      // Route byte reads through the shared spy so tests can count fetches (dedup).
+      return { ...img, getBytesAsync: () => getBytes(hash) };
+    },
+    __getBytes: getBytes,
+  }) as unknown as typeof figma;
+
+const imagePaint = (imageHash: string | null, scaleMode = 'FILL'): unknown => ({
+  type: 'IMAGE',
+  imageHash,
+  scaleMode,
+});
+
+describe('save_image_fills handler', () => {
+  it('extracts original bytes + intrinsic size + scaleMode per IMAGE fill, skipping non-image paints', async () => {
+    const getBytes = vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([1, 2, 3]));
+    const f = makeFigma(
+      {
+        '1:1': {
+          fills: [{ type: 'SOLID' }, imagePaint('h1', 'CROP'), imagePaint('h2', 'FIT')],
+        },
+      },
+      {
+        h1: { getBytesAsync: getBytes, getSizeAsync: async () => ({ width: 200, height: 100 }) },
+        h2: { getBytesAsync: getBytes, getSizeAsync: async () => ({ width: 64, height: 64 }) },
+      },
+      getBytes,
+    );
+
+    const result = (await createSaveImageFillsHandler(f)({ nodeIds: ['1:1'] })) as ImageFillsResult;
+    expect(result.nodes).toEqual([
+      {
+        nodeId: '1:1',
+        images: [
+          {
+            index: 1,
+            imageHash: 'h1',
+            base64: 'b64(3)',
+            width: 200,
+            height: 100,
+            scaleMode: 'CROP',
+          },
+          { index: 2, imageHash: 'h2', base64: 'b64(3)', width: 64, height: 64, scaleMode: 'FIT' },
+        ],
+      },
+    ]);
+  });
+
+  it('fetches a shared imageHash exactly once across nodes/fills', async () => {
+    const getBytes = vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([9]));
+    const f = makeFigma(
+      {
+        '1:1': { fills: [imagePaint('logo')] },
+        '2:2': { fills: [imagePaint('logo'), imagePaint('logo')] },
+      },
+      { logo: { getBytesAsync: getBytes, getSizeAsync: async () => ({ width: 10, height: 10 }) } },
+      getBytes,
+    );
+
+    const result = (await createSaveImageFillsHandler(f)({
+      nodeIds: ['1:1', '2:2'],
+    })) as ImageFillsResult;
+    expect(result.nodes[0]?.images).toHaveLength(1);
+    expect(result.nodes[1]?.images).toHaveLength(2);
+    // Three usages of one asset → a single getBytesAsync call.
+    expect(getBytes).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports base64 null for an unresolvable hash and a null imageHash, without dropping scaleMode', async () => {
+    const f = makeFigma(
+      { '1:1': { fills: [imagePaint('gone'), imagePaint(null, 'TILE')] } },
+      { gone: null },
+    );
+    const result = (await createSaveImageFillsHandler(f)({ nodeIds: ['1:1'] })) as ImageFillsResult;
+    expect(result.nodes[0]?.images).toEqual([
+      { index: 0, imageHash: 'gone', base64: null, scaleMode: 'FILL' },
+      { index: 1, imageHash: null, base64: null, scaleMode: 'TILE' },
+    ]);
+  });
+
+  it('returns empty images for a missing node or one with no fills property', async () => {
+    const f = makeFigma({ '2:2': { type: 'GROUP' } }, {});
+    const result = (await createSaveImageFillsHandler(f)({
+      nodeIds: ['9:9', '2:2'],
+    })) as ImageFillsResult;
+    expect(result.nodes).toEqual([
+      { nodeId: '9:9', images: [] },
+      { nodeId: '2:2', images: [] },
+    ]);
+  });
+
+  it('flags mixed fills instead of crashing on the symbol', async () => {
+    const f = makeFigma({ '1:1': { fills: MIXED } }, {});
+    const result = (await createSaveImageFillsHandler(f)({ nodeIds: ['1:1'] })) as ImageFillsResult;
+    expect(result.nodes).toEqual([{ nodeId: '1:1', images: [], mixed: true }]);
+  });
+
+  it('throws on empty or non-string nodeIds', async () => {
+    const f = makeFigma({}, {});
+    await expect(createSaveImageFillsHandler(f)({ nodeIds: [] })).rejects.toThrow(/nodeIds/);
+    await expect(createSaveImageFillsHandler(f)({ nodeIds: [1] })).rejects.toThrow(/nodeIds/);
+  });
+});

--- a/packages/shared/src/queries.ts
+++ b/packages/shared/src/queries.ts
@@ -93,6 +93,66 @@ export const ExportPdfResultSchema = z.object({
 });
 export type ExportPdfResult = z.infer<typeof ExportPdfResultSchema>;
 
+// ── save_image_fills ─────────────────────────────────────────────────────────
+/**
+ * One IMAGE fill's ORIGINAL bytes, as uploaded — no mask, clip, crop, scale, or effects applied
+ * (unlike get_screenshot / save_screenshots, which re-render the composited node). `index` is the
+ * paint's position in node.fills; `imageHash` identifies the shared asset (the same hash reused
+ * across nodes points at one file). `base64` is null when the hash can't be resolved to an image.
+ * `width`/`height` are the image's intrinsic pixel size; `scaleMode` is how the fill is displayed.
+ */
+export const ImageFillBytesSchema = z.object({
+  index: z.number(),
+  imageHash: z.string().nullable(),
+  base64: z.string().nullable(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  scaleMode: z.string().optional(),
+});
+export type ImageFillBytes = z.infer<typeof ImageFillBytesSchema>;
+
+/**
+ * A node's extractable image fills. `images` is empty when the node is missing, has no `fills`
+ * property, or carries no IMAGE paint; `mixed:true` marks a node whose `fills` are mixed
+ * (per-text-range) and so weren't enumerable.
+ */
+export const NodeImageFillsSchema = z.object({
+  nodeId: z.string(),
+  images: z.array(ImageFillBytesSchema),
+  mixed: z.boolean().optional(),
+});
+export type NodeImageFills = z.infer<typeof NodeImageFillsSchema>;
+
+/** Plugin-side result: raw image-fill bytes per node, before the server lands them on disk. */
+export const ImageFillsResultSchema = z.object({ nodes: z.array(NodeImageFillsSchema) });
+export type ImageFillsResult = z.infer<typeof ImageFillsResultSchema>;
+
+/**
+ * Per-fill write result. `path` is the written file (named by imageHash so identical images share
+ * one file) or null when the fill's image couldn't be resolved. `format` is sniffed from the bytes
+ * (PNG / JPG / GIF / WEBP, or BIN for an unrecognized container) and absent when path is null.
+ */
+export const SavedImageFillSchema = z.object({
+  index: z.number(),
+  imageHash: z.string().nullable(),
+  format: z.string().optional(),
+  path: z.string().nullable(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  scaleMode: z.string().optional(),
+});
+export type SavedImageFill = z.infer<typeof SavedImageFillSchema>;
+
+export const SavedNodeImageFillsSchema = z.object({
+  nodeId: z.string(),
+  images: z.array(SavedImageFillSchema),
+  mixed: z.boolean().optional(),
+});
+export type SavedNodeImageFills = z.infer<typeof SavedNodeImageFillsSchema>;
+
+export const SaveImageFillsResultSchema = z.object({ nodes: z.array(SavedNodeImageFillsSchema) });
+export type SaveImageFillsResult = z.infer<typeof SaveImageFillsResultSchema>;
+
 // ── get_viewport ───────────────────────────────────────────────────────────
 export const GetViewportResultSchema = z.object({
   center: z.object({ x: z.number(), y: z.number() }),

--- a/packages/shared/src/tool-budgets.ts
+++ b/packages/shared/src/tool-budgets.ts
@@ -27,6 +27,7 @@ export const BUDGET_LAYER_MARGIN_MS = 5_000;
 const HEAVY_TOOLS: ReadonlySet<string> = new Set([
   'get_screenshot',
   'save_screenshots',
+  'save_image_fills',
   'export_pdf',
   'get_document',
   'get_design_context',

--- a/skills/figma-codegen/SKILL.md
+++ b/skills/figma-codegen/SKILL.md
@@ -63,7 +63,9 @@ Run the grounded tools against the selection, then generate — **trust them ove
      groups (`Color/Light/*` + `Color/Dark/*`, a plan-limited workaround) — get the same treatment.
 
 4. **Export the assets grounding can't carry** — logos, photos, icons have no pixels and otherwise
-   render as grey blocks. `get_screenshot` (and `icon_map` first for icons, to reuse curated `.svg`s).
+   render as grey blocks. `save_image_fills` for `IMAGE`-fill nodes (the original asset, not a
+   clipped re-render), `icon_map` first for icons (reuse curated `.svg`s), `get_screenshot` only for
+   the composited look.
    → **Full asset/icon/svg/colour-contract workflow:
    [`references/assets-and-icons.md`](./references/assets-and-icons.md).**
 

--- a/skills/figma-codegen/references/assets-and-icons.md
+++ b/skills/figma-codegen/references/assets-and-icons.md
@@ -8,13 +8,24 @@ pixel asset grounding can't encode.
 
 ## What to export, and how
 
-- A node with an **`IMAGE` fill** (a photo / product-shot rectangle) → `get_screenshot` `PNG` (scale 2).
+- A node with an **`IMAGE` fill** (a photo / product-shot rectangle) → **`save_image_fills`**. It
+  writes the **original** uploaded asset (no clip, crop, scale, gradient, or mask baked in) and reports
+  each fill's `scaleMode` + intrinsic size, so you reproduce the display in CSS (`FILL`→`object-fit:
+cover`, `FIT`→`contain`) instead of shipping a pre-scaled, pre-clipped render. It dedupes a reused
+  asset to one file (named by hash) and handles a node carrying several image fills. Reach for
+  `save_screenshots` / `get_screenshot` `PNG` **only** when you specifically need the **composited**
+  look — a `CROP` region, mask, or gradient overlay you can't reproduce in CSS.
 - A **`VECTOR`** / boolean-op, or an **icon instance** (e.g. `mainComponent.name` under `Icons/…`, a
   small square instance) → **`icon_map` first, `get_screenshot` `SVG` only as the fallback** (below).
 - **Logos / brand marks are always exported**, never typed by hand.
+- Because `save_image_fills` reads the source bytes, a **clipped / off-canvas** node still yields its
+  full asset — the empty/recovered dance below only applies to the screenshot fallback. A **`path:
+null`** (or `images: []`) means the fill's image couldn't be resolved / the node has no image fill;
+  don't invent a file, fall back to a screenshot or skip.
 - An **`empty: true` export rendered nothing** (node hidden / fully clipped / off-canvas — e.g. a
-  marquee's off-screen edge logos). Don't ship the blank file: if grounding shows the instance has
-  art, re-export its `mainComponent`; if it's genuinely empty, skip it.
+  marquee's off-screen edge logos) — a **screenshot-fallback** concern only. Don't ship the blank
+  file: if grounding shows the instance has art, re-export its `mainComponent`; if it's genuinely
+  empty, skip it.
 
 ## Icons: reuse before re-export (`icon_map`)
 


### PR DESCRIPTION
## Why

`save_screenshots` / `get_screenshot` go through `exportAsync`, which renders a node **as composited on the canvas** — clip, crop, `scaleMode`, mask, gradient overlays, and effects are all baked in, and the raster is scaled to the node's bounds. There was no way to recover the **source asset** an `IMAGE` fill was uploaded from. For codegen that means a photo/logo comes out as a clipped, pre-scaled re-render instead of the real file you'd commit.

## What

Adds **`save_image_fills`** (tool #102). For each requested node it reads every `IMAGE` paint's original bytes via `getImageByHash().getBytesAsync()` and writes them to disk under `outDir` — the file **exactly as uploaded**, no compositing.

- Reports each fill's `index`, `imageHash`, intrinsic `width`/`height`, and `scaleMode`.
- Sniffs the container from magic bytes (`PNG`/`JPG`/`GIF`/`WEBP`, else `BIN`) for the extension.
- **Dedupes** a hash reused across nodes to a single hash-named file (fetched once on the plugin side too).
- Clipped / off-canvas nodes still yield their **full** asset — the `empty`/`recovered` dance only applies to the screenshot fallback.

Wired as a `local` tool exactly like `export_pdf`: a read-only plugin handler returns the bytes, the server lands them on the filesystem. Added to the `HEAVY_TOOLS` budget since payloads can be large.

## Codegen skill

`figma-codegen` step 4 now reaches for `save_image_fills` on `IMAGE`-fill nodes (original asset; reproduce display via CSS `object-fit` — `FILL`→cover, `FIT`→contain) and falls back to a screenshot only for a composited `CROP`/mask/overlay it can't redo in CSS.

## Verification

- Full gate green: typecheck, lint, format:check, knip, build, **839 tests** (new unit tests for the format sniffer, disk-write + dedup, plugin extraction + memoization, mixed/missing guards; cross-package registry & docs-sync guards updated).
- **Live round-trip** against a connected file: a `1440×688` frame with `clipsContent` + two `IMAGE` fills + gradient overlays yielded two clean **`4096×2048`** / **`4096×1855`** source PNGs — the originals a screenshot could never return.