### PR TITLE
refactor(repo-walk): replace experimental node:fs glob with fdir

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,6 +21,7 @@
     "currentpagechange",
     "selectionchange",
     "vueuse",
-    "changelogen"
+    "changelogen",
+    "fdir"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Figwright exposes **102 MCP tools** in three groups:
 ## Requirements
 
 - An **MCP client** (Claude Code, Cursor, …).
-- **Node.js 24 LTS or newer** — the server runs via `npx`.
+- **Node.js 20.19+ or 22.12+** — the server runs via `npx`, as its own process, so this is independent of the Node version your project builds with. (This is the modern-Node baseline; Node 18/21 and 22.0–22.11 aren't supported.)
 - **Figma** — the free tier is enough; the desktop app is needed to import the plugin in development.
 
 ## FAQ

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -23,7 +23,7 @@ The server talks to the Figwright Figma plugin running in your Figma app. See th
 
 ## Requirements
 
-- Node.js 24 LTS or newer
+- Node.js 20.19+ or 22.12+ (the server runs via `npx` as its own process, independent of your project's Node version)
 
 ## Links
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@msgpack/msgpack": "^3.1.3",
+    "fdir": "^6.5.0",
     "ignore": "^7.0.5",
     "oxc-parser": "^0.139.0",
     "ws": "^8.21.0",
@@ -59,5 +60,8 @@
     "@types/ws": "^8.18.1",
     "publint": "^0.3.21",
     "tsdown": "^0.22.4"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/packages/mcp/src/ignored-dirs.ts
+++ b/packages/mcp/src/ignored-dirs.ts
@@ -4,9 +4,11 @@
 //
 // `vendor` is the one that bites hardest: a PHP (Composer) / Ruby (Bundler) vendor dir holds tens of
 // thousands of files. It contains no .tsx/.vue/.css we'd match, so a post-filter wouldn't drop
-// anything — but node:fs glob still *descends* into it to find that out, and that traversal is linear
-// in the vendor's size (measured ~90ms for 24k files, and real vendors are far bigger). The fix isn't
-// the list, it's pruning at the glob level (globExclude) so the walk never enters these dirs at all.
+// anything — but the crawler would still *descend* into it to find that out, and that traversal is
+// linear in the vendor's size (and real vendors are far bigger). The fix isn't the list, it's pruning
+// at the directory level (fdir's `exclude`, keyed on the dir basename) so the walk never enters these
+// dirs at all. Dot-directories are pruned separately by the walker, so the entries below only need to
+// cover the *non-dot* build/vendor dirs — the dot ones are kept as explicit, self-documenting intent.
 export const IGNORED_DIRS = new Set([
   'node_modules',
   'vendor', // PHP Composer / Ruby Bundler — huge, and invisible to a post-filter
@@ -22,18 +24,3 @@ export const IGNORED_DIRS = new Set([
   '.git',
   'coverage',
 ]);
-
-/** True when any path segment is an ignored (vendor/build) directory. */
-export const isIgnoredPath = (relPath: string): boolean =>
-  relPath.split('/').some(seg => IGNORED_DIRS.has(seg));
-
-/**
- * Pruning callback for node:fs `glob({ exclude })`. Unlike a post-filter, this stops the walk from
- * descending into an ignored directory, so traversal cost is independent of how large node_modules
- * / vendor are. node passes either a Dirent (has `.name`) or a path string depending on version, so
- * accept both and key on the basename — matching IGNORED_DIRS' per-segment semantics.
- */
-export const globExclude = (entry: { name: string } | string): boolean => {
-  const name = typeof entry === 'string' ? (entry.split('/').pop() ?? entry) : (entry.name ?? '');
-  return IGNORED_DIRS.has(name);
-};

--- a/packages/mcp/src/repo-walk.ts
+++ b/packages/mcp/src/repo-walk.ts
@@ -1,9 +1,10 @@
-import { glob, readFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { fdir } from 'fdir';
 import ignore, { type Ignore } from 'ignore';
 
-import { globExclude, isIgnoredPath } from './ignored-dirs.js';
+import { IGNORED_DIRS } from './ignored-dirs.js';
 
 // The one repo file walk shared by every server-side scan (components, the Tailwind CSS probe, the
 // token aggregator). "What to skip" is layered defense-in-depth so it's correct with OR without a
@@ -11,19 +12,24 @@ import { globExclude, isIgnoredPath } from './ignored-dirs.js';
 //
 //   1. .gitignore (+ .git/info/exclude) — the target project's own, authoritative declaration of what
 //      isn't hand-written source. Read when present; honored via the `ignore` package (gitignore-spec
-//      matcher: anchoring, globs, negation, directory rules). This is the strongest, most general
-//      signal — it auto-covers a project's vendor/build/generated dirs without us hardcoding them.
-//   2. IGNORED_DIRS baseline — pruned at the glob level (globExclude), so node_modules / vendor are
-//      never descended into (traversal cost independent of their size). This is the *fallback*: when a
-//      project has no .gitignore, this is the only directory defense, so it must stay.
-//   3. cap — a terminal yield limit, the last line against a pathological repo with a huge custom dir
-//      that's neither in the baseline nor gitignored.
+//      matcher: anchoring, globs, negation, directory rules). Applied per *file* so negations survive
+//      (`!Special.tsx` under `*.tsx` re-includes) — a directory-level prune couldn't put a negated
+//      child back. This is the strongest, most general signal — it auto-covers a project's
+//      vendor/build/generated dirs without us hardcoding them.
+//   2. IGNORED_DIRS baseline (+ dotfiles/dot-dirs) — pruned at the traversal level (fdir `exclude`), so
+//      node_modules / vendor are never descended into (cost independent of their size). This is the
+//      *fallback*: when a project has no .gitignore, this is the only directory defense, so it must
+//      stay. Dot-directories and dotfiles are skipped too, matching the prior node:fs glob semantics
+//      (its `*`/`**` never crossed a leading dot).
+//   3. cap — a terminal limit (fdir `withMaxFiles`, which counts kept files and early-stops the walk),
+//      the last line against a pathological repo with a huge custom dir that's neither baseline nor
+//      gitignored.
 //
 // The .gitignore layer is a *union* on top of the baseline, never a replacement — so "no .gitignore"
 // degrades exactly to the baseline-only behavior (no regression), and "has .gitignore" only adds
 // precision (skips gitignored source-like files the baseline would miss). The matcher needs full
-// repo-relative paths (rules can be anchored / path-specific), which is why it post-filters the glob
-// results rather than riding the basename-only `exclude` callback.
+// repo-relative posix paths (rules can be anchored / path-specific), which is why the walk forces a
+// `/` separator on every platform.
 
 const DEFAULT_CAP = 5000;
 
@@ -63,20 +69,23 @@ export async function* walkRepoFiles(
 ): AsyncGenerator<string> {
   const cap = opts.cap ?? DEFAULT_CAP;
   const exts = opts.extensions?.map(e => (e.startsWith('.') ? e : `.${e}`));
-  // One glob per extension, not a `{a,b}` brace group: node's fs glob won't expand a single-element
-  // brace (`**/*{.vue}` finds nothing), which silently sank every single-extension profile.
-  const patterns = exts === undefined ? ['**/*'] : exts.map(e => `**/*${e}`);
-
   const matcher = await buildIgnoreMatcher(rootDir);
-  let count = 0;
 
-  for await (const entry of glob(patterns, { cwd: rootDir, exclude: globExclude })) {
-    const rel = typeof entry === 'string' ? entry : String(entry);
-    const posix = rel.split(/[\\/]/).join('/'); // gitignore matcher wants posix-relative paths
-    if (isIgnoredPath(posix)) continue; // defense-in-depth (exclude already pruned these dirs)
-    if (matcher.ignores(posix)) continue; // gitignored source-like file
-    if (count >= cap) break;
-    count += 1;
-    yield posix;
-  }
+  const files = await new fdir()
+    .withRelativePaths() // repo-relative paths, files only (never directory entries)
+    .withPathSeparator('/') // posix on every platform — the gitignore matcher requires it
+    .withMaxFiles(cap) // counts kept files and early-stops the walk (pathological-repo guard)
+    // Directory pruning: never descend baseline dirs (node_modules/vendor/…) or dot-directories. fdir
+    // hands `exclude` the directory basename, matching IGNORED_DIRS' per-segment semantics.
+    .exclude(dirName => dirName.startsWith('.') || IGNORED_DIRS.has(dirName))
+    .filter(path => {
+      const base = path.slice(path.lastIndexOf('/') + 1);
+      if (base.startsWith('.')) return false; // dotfile — parity with node:fs glob (`*` skips leading dot)
+      if (exts !== undefined && !exts.some(e => base.endsWith(e))) return false;
+      return !matcher.ignores(path); // gitignored source-like file (negation-aware)
+    })
+    .crawl(rootDir)
+    .withPromise();
+
+  yield* files;
 }

--- a/packages/mcp/test/repo-walk.test.ts
+++ b/packages/mcp/test/repo-walk.test.ts
@@ -53,6 +53,23 @@ describe('walkRepoFiles', () => {
     ]);
   });
 
+  it('skips dotfiles and never descends dot-directories (parity with the prior node:fs glob)', async () => {
+    const root = await make({
+      'src/Keep.tsx': 'x',
+      '.hidden.tsx': 'x', // root dotfile → skipped
+      'src/.secret.tsx': 'x', // nested dotfile → skipped
+      '.storybook/Preview.tsx': 'x', // non-baseline dot-dir → not descended
+      'sub/.dot/Deep.tsx': 'x', // nested dot-dir → not descended
+    });
+    expect(await collect(root, { extensions: ['.tsx'] })).toEqual(['src/Keep.tsx']);
+  });
+
+  it('yields only files, never directory entries', async () => {
+    const root = await make({ 'src/a.tsx': 'x', 'src/nested/b.css': 'x' });
+    // No extension filter → every file, but never the "src" / "src/nested" directories themselves.
+    expect(await collect(root)).toEqual(['src/a.tsx', 'src/nested/b.css']);
+  });
+
   it('walks a non-baseline dir when there is no .gitignore (degrades to baseline-only)', async () => {
     const root = await make({ 'src/A.tsx': 'x', 'generated/B.tsx': 'x' });
     // No .gitignore → "generated" isn't baseline → it IS walked (matches pre-gitignore behavior).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@msgpack/msgpack':
         specifier: ^3.1.3
         version: 3.1.3
+      fdir:
+        specifier: ^6.5.0
+        version: 6.5.0(picomatch@4.0.5)
       ignore:
         specifier: ^7.0.5
         version: 7.0.5


### PR DESCRIPTION
## Why

`repo-walk.ts` imported `glob` from `node:fs/promises` — a **Node 22+, experimental** API. Consequences:

- **Hard crash on Node < 22.** The static named import fails to load: `SyntaxError: does not provide an export named 'glob'` — the server never starts. (Confirmed on Node 18.20.8.)
- It forced several workarounds that were pure `fs.glob` tax: one glob per extension (single-element brace groups match nothing), Dirent-vs-string result handling, and a basename-only `exclude` that pushed all gitignore work into a post-filter.

## What

Swap `node:fs` glob for [`fdir`](https://github.com/thecodrr/fdir) (the crawler under tinyglobby/Vite; zero-dep, pure JS, `engines >=12`), keeping the `AsyncGenerator<string>` contract so **no caller changes**:

| fdir | purpose |
|---|---|
| `withRelativePaths()` | repo-relative, **files only** (old `**/*` also yielded directory entries — now fixed) |
| `withPathSeparator('/')` | posix on every platform (the gitignore matcher requires it); drops manual normalization |
| `withMaxFiles(cap)` | counts **kept** files and **early-stops traversal** — preserves the pathological-repo guard *and* bounds memory |
| `exclude(dirName)` | directory-level pruning for `IGNORED_DIRS` + dot-dirs |
| `filter(path)` | extension match + per-file gitignore (negation-aware) |

`globExclude` / `isIgnoredPath` are removed — they existed to paper over `fs.glob`'s version-flaky, basename-only exclude, which fdir's robust `exclude` makes unnecessary.

## Behavior: parity-or-better

- Dotfiles / dot-directories still skipped (verified against the old `node:fs` glob semantics).
- gitignore negations (`!Special.tsx` under `*.tsx`) still survive — gitignore stays a per-**file** filter.
- Directory entries no longer leak into results.
- New tests lock the dotfile/dot-dir skip and files-only output.

## Version floor

Removing the `fs.glob` dependency drops the real Node floor to oxc-parser's `^20.19.0 || >=22.12.0`, now declared in `engines` and documented in both READMEs (previously mis-stated as "Node 24 LTS"). The server runs via `npx` as its own process, so this is independent of the consuming project's Node version.

## Verification

- Full gate green: `typecheck`, `lint`, `format:check`, `knip`, `build`, `publint`, **841 tests** (+2 new).
- Real-repo drive: 407 `.ts` files walked in ~5ms with `node_modules`/`.git`/`dist` present — **0 ignored-dir leaks, 0 dotfile leaks**.
- Node 18.20.8 smoke test: old static `import { glob }` hard-crashes; the **new built server boots and completes the MCP initialize handshake** (fdir + oxc-parser both run — only a soft `EBADENGINE` warning remains).
