### PR TITLE
fix(token_map): disambiguate color value-matches shared by several project tokens

### DIFF
--- a/packages/mcp/src/join/token-map.ts
+++ b/packages/mcp/src/join/token-map.ts
@@ -4,7 +4,9 @@ import { diceSimilarity, type MappingStatus } from './component-map.js';
 
 // The token join: Figma variable → project design token. Name-match is the primary, framework-agnostic
 // signal (normalized Figma "Primary/500" vs project "color-primary-500" / utility "primary-500"); an
-// exact color value-match is a strong confirmation that survives naming drift. Value-match is limited
+// exact color value-match is a strong confirmation that survives naming drift — but only a *unique*
+// one is trusted on its own; same-value siblings are split by name or reported as ambiguous (see
+// joinOne). Value-match is limited
 // to hex colors on purpose — Tailwind v4 defaults ship oklch() and Figma exports hex, so cross-space
 // color matching (and unit-aware number matching) is deferred; those still fall back to name-match.
 // Pure, like the component join, so it's unit-testable without Figma or the filesystem.
@@ -32,6 +34,13 @@ export interface TokenMapping {
     confidence: number;
     /** Which signals agreed: name similarity and/or exact color value. */
     matchedBy: ('name' | 'value')[];
+    /**
+     * Other project tokens sharing the exact same color value, present only when the value alone
+     * had to pick among them (no name signal split the tie). The candidate is then a capped,
+     * deterministic pick — verify it semantically (or add an explicit override) before relying on
+     * it; binding the wrong same-value sibling silently diverges when that token is later retuned.
+     */
+    ambiguousWith?: string[];
   };
   /**
    * Set only when status is 'framework-builtin': the Tailwind built-in scale this variable belongs
@@ -162,6 +171,14 @@ interface NameMatch {
   score: number;
 }
 
+/** Name-similarity score of one project token against a pre-split Figma name (max over its names). */
+const nameScore = (target: Scaled, token: ProjectToken, typography: boolean): number => {
+  let score = 0;
+  for (const name of matchNames(token))
+    score = Math.max(score, stepGatedScore(target, splitScale(name), typography));
+  return score;
+};
+
 const bestNameMatch = (
   figmaName: string,
   projectTokens: readonly ProjectToken[],
@@ -170,9 +187,7 @@ const bestNameMatch = (
   const target = splitScale(figmaName);
   let best: NameMatch | null = null;
   for (const token of projectTokens) {
-    let score = 0;
-    for (const name of matchNames(token))
-      score = Math.max(score, stepGatedScore(target, splitScale(name), typography));
+    const score = nameScore(target, token, typography);
     if (best === null || score > best.score) best = { token, score };
   }
   return best;
@@ -192,6 +207,7 @@ const candidateFrom = (
   confidence: number,
   matchedBy: ('name' | 'value')[],
   tailwind: boolean,
+  ambiguousWith?: readonly string[],
 ): NonNullable<TokenMapping['candidate']> => ({
   token: token.name,
   ref: refOf(token, tailwind),
@@ -199,6 +215,9 @@ const candidateFrom = (
   ...(tailwind && token.utility !== undefined ? { utility: token.utility } : {}),
   confidence: Number(confidence.toFixed(3)),
   matchedBy,
+  ...(ambiguousWith !== undefined && ambiguousWith.length > 0
+    ? { ambiguousWith: [...ambiguousWith] }
+    : {}),
 });
 
 const statusFor = (confidence: number, threshold: number): MappingStatus => {
@@ -299,25 +318,55 @@ const joinOne = (
     status: 'unmapped',
   };
 
-  const nameMatch = bestNameMatch(
-    figma.name,
-    projectTokens,
-    isTypographyCollection(figma.collection),
-  );
+  const typography = isTypographyCollection(figma.collection);
+  const nameMatch = bestNameMatch(figma.name, projectTokens, typography);
 
-  // Exact color value-match: strong, naming-independent evidence.
+  // Exact color value-match: strong, naming-independent evidence — but only when it's unique.
+  // Real projects routinely alias one color to several tokens (--white / --background / --card all
+  // #FFFFFF); binding to "the first parsed" would pick an arbitrary sibling at high confidence, and
+  // a semantically wrong token is worse than a raw value (it silently diverges when that token is
+  // later retuned). Duplicates are split by name; when the name carries no signal the pick is
+  // capped below 'high' and the same-value siblings are surfaced on ambiguousWith.
   const figmaHex = typeof figma.value === 'string' ? normHex(figma.value) : null;
-  const valueMatch =
-    figmaHex === null ? undefined : projectTokens.find(t => normHex(t.value) === figmaHex);
+  const valueMatches =
+    figmaHex === null ? [] : projectTokens.filter(t => normHex(t.value) === figmaHex);
 
-  if (valueMatch !== undefined) {
-    const nameAgrees =
-      nameMatch !== null && nameMatch.token === valueMatch && nameMatch.score >= 0.5;
-    const confidence = nameAgrees ? 1 : 0.9;
-    const matchedBy: ('name' | 'value')[] = nameAgrees ? ['name', 'value'] : ['value'];
+  if (valueMatches.length > 0) {
+    const target = splitScale(figma.name);
+    const scored = valueMatches
+      .map(token => ({ token, score: nameScore(target, token, typography) }))
+      .toSorted((a, b) => b.score - a.score || a.token.name.localeCompare(b.token.name));
+    const top = scored[0] as NameMatch;
+    const runnerUp = scored[1];
+    const nameDisambiguates =
+      scored.length === 1 ||
+      (top.score >= 0.5 && (runnerUp === undefined || top.score > runnerUp.score));
+
+    if (nameDisambiguates) {
+      const nameAgrees =
+        nameMatch !== null && nameMatch.token === top.token && nameMatch.score >= 0.5;
+      const confidence = nameAgrees ? 1 : 0.9;
+      const matchedBy: ('name' | 'value')[] =
+        nameAgrees || (scored.length > 1 && top.score >= 0.5) ? ['name', 'value'] : ['value'];
+      return {
+        ...base,
+        candidate: candidateFrom(top.token, confidence, matchedBy, opts.tailwind === true),
+        status: statusFor(confidence, opts.threshold),
+      };
+    }
+
+    // Same-value siblings the name can't split: a deterministic pick (best name score, then token
+    // name), capped below the high bar so it reads as "verify me", with the alternatives attached.
+    const confidence = 0.7;
     return {
       ...base,
-      candidate: candidateFrom(valueMatch, confidence, matchedBy, opts.tailwind === true),
+      candidate: candidateFrom(
+        top.token,
+        confidence,
+        ['value'],
+        opts.tailwind === true,
+        scored.slice(1).map(s => s.token.name),
+      ),
       status: statusFor(confidence, opts.threshold),
     };
   }

--- a/packages/mcp/src/join/token-map.ts
+++ b/packages/mcp/src/join/token-map.ts
@@ -335,7 +335,12 @@ const joinOne = (
     const target = splitScale(figma.name);
     const scored = valueMatches
       .map(token => ({ token, score: nameScore(target, token, typography) }))
-      .toSorted((a, b) => b.score - a.score || a.token.name.localeCompare(b.token.name));
+      // Code-point name compare (not localeCompare) so the tie-break order is environment-independent.
+      .toSorted(
+        (a, b) =>
+          b.score - a.score ||
+          (a.token.name < b.token.name ? -1 : a.token.name > b.token.name ? 1 : 0),
+      );
     const top = scored[0] as NameMatch;
     const runnerUp = scored[1];
     const nameDisambiguates =

--- a/packages/mcp/src/tools/token-map.ts
+++ b/packages/mcp/src/tools/token-map.ts
@@ -54,7 +54,10 @@ export const tokenMapTool: ToolSpec = {
     "Map the document's Figma variables to the project's design tokens, so generated code references " +
     'existing tokens instead of hard-coded values. Joins the grounded Figma variable names + values ' +
     'against tokens parsed from the project CSS (Tailwind v4 @theme or :root custom properties); the ' +
-    'match is name-based with an exact color value-match as confirmation. On a Tailwind project a ' +
+    'match is name-based with an exact color value-match as confirmation. When several project ' +
+    'tokens share the exact same color value and the name cannot pick one, the mapping is capped ' +
+    "below 'high' and candidate.ambiguousWith lists the other same-value tokens — verify that pick " +
+    'semantically instead of trusting it blindly. On a Tailwind project a ' +
     'variable that hits a framework built-in scale (spacing/N, line-height/N, weight/*) is reported as ' +
     "status 'framework-builtin' with { builtin: { scale, step } } rather than unmapped — it has no " +
     '@theme token but the utility (p-4 / gap-4, leading-7, font-bold) is still usable. A variable in ' +

--- a/packages/mcp/test/join/token-map.test.ts
+++ b/packages/mcp/test/join/token-map.test.ts
@@ -275,3 +275,61 @@ describe('joinTokens', () => {
     expect(m?.status).not.toBe('high');
   });
 });
+
+describe('joinTokens — same-value siblings (value-match ambiguity)', () => {
+  // Real projects alias one color to several tokens; #FFFFFF is the canonical case. A value-only
+  // match must never bind an arbitrary sibling at high confidence — that silently diverges the
+  // moment the wrongly-chosen token is retuned.
+  const whites: ProjectToken[] = [
+    proj('color-white', '#FFFFFF', 'white', 'color'),
+    proj('color-background', '#FFFFFF', 'background', 'color'),
+    proj('color-card', '#FFFFFF', 'card', 'color'),
+  ];
+
+  it('lets the name pick the winner among same-value tokens', () => {
+    const [m] = joinTokens([fig('Colors/Card', '#FFFFFF')], whites, { threshold: 0.7 });
+    expect(m?.candidate?.token).toBe('color-card');
+    expect(m?.candidate?.matchedBy).toEqual(['name', 'value']);
+    expect(m?.candidate?.ambiguousWith).toBeUndefined();
+    expect(m?.status).toBe('high');
+  });
+
+  it('caps below high and lists the siblings when the name carries no signal', () => {
+    const [m] = joinTokens([fig('Brand/Snow', '#FFFFFF')], whites, { threshold: 0.7 });
+    expect(m?.candidate).toBeDefined();
+    expect(m?.candidate?.matchedBy).toEqual(['value']);
+    expect(m?.candidate?.confidence).toBeLessThan(0.85);
+    expect(m?.status).toBe('medium');
+    // The pick plus its listed siblings must cover all three same-value tokens exactly.
+    const names = [m?.candidate?.token, ...(m?.candidate?.ambiguousWith ?? [])].toSorted();
+    expect(names).toEqual(['color-background', 'color-card', 'color-white']);
+  });
+
+  it('is deterministic regardless of project token order', () => {
+    const [a] = joinTokens([fig('Brand/Snow', '#FFFFFF')], whites, { threshold: 0.7 });
+    const [b] = joinTokens([fig('Brand/Snow', '#FFFFFF')], whites.toReversed(), {
+      threshold: 0.7,
+    });
+    expect(a?.candidate?.token).toBe(b?.candidate?.token);
+    expect(a?.candidate?.ambiguousWith).toEqual(b?.candidate?.ambiguousWith);
+  });
+
+  it('treats a name-score tie among siblings as ambiguous, not a confident pick', () => {
+    // Without utilities, "brand" Dice-scores identically against color-brand and brand-color
+    // (0.615 each) — no split, so the pick must be flagged, not confidently bound.
+    const tied = [proj('color-brand', '#123456'), proj('brand-color', '#123456')];
+    const [m] = joinTokens([fig('brand', '#123456')], tied, { threshold: 0.7 });
+    expect(m?.candidate?.ambiguousWith).toHaveLength(1);
+    expect(m?.status).not.toBe('high');
+  });
+
+  it('keeps the unique value-match at 0.9 high (unchanged behaviour)', () => {
+    const unique = [proj('color-primary-500', '#6266F0', 'primary-500', 'color')];
+    const [m] = joinTokens([fig('Brand/Indigo', '#6266F0')], unique, { threshold: 0.7 });
+    expect(m?.candidate?.token).toBe('color-primary-500');
+    expect(m?.candidate?.matchedBy).toEqual(['value']);
+    expect(m?.candidate?.confidence).toBe(0.9);
+    expect(m?.candidate?.ambiguousWith).toBeUndefined();
+    expect(m?.status).toBe('high');
+  });
+});


### PR DESCRIPTION
## Problem

`joinOne`'s exact-color value-match used `find()` — **first token wins**. Real projects routinely alias one color to several tokens (`--white` / `--background` / `--card` all `#FFFFFF`), so a Figma variable with no name signal got bound to whichever same-value sibling happened to parse first, at 0.9 confidence (**high** — which codegen guidance treats as a confirmed reuse). A semantically wrong token is worse than a raw value: it renders identically today and silently diverges the moment that token is retuned.

## Fix

Collect **all** same-value tokens and split them by name score (`nameScore`, extracted from `bestNameMatch`):

| case | result |
|---|---|
| unique value match | unchanged — 0.9, or 1.0 when the name agrees |
| name picks a strict winner (≥ 0.5) | 0.9, `matchedBy: ['name','value']` |
| no name signal, or a tie | capped at **0.7** (below the high bar) + `candidate.ambiguousWith` lists the other same-value tokens; pick is deterministic (score, then token name) |

Tool description documents `ambiguousWith` (verify the pick semantically instead of trusting it blindly).

## Tests

+5 cases: name disambiguates / no-signal capped+flagged / order-independent determinism / score tie = ambiguous / unique value-match unchanged. Full suite 846 green; typecheck / lint (`--deny-warnings`) / format:check / knip / build all pass.

Precision > recall, per the join family's standing doctrine — a wrong binding is a silent visual bug, a flagged ambiguity is a review prompt.