### PR TITLE
feat(get_design_context): default to the full codegen view with graceful degradation

### DIFF
--- a/packages/mcp/src/tools/design-context-guard.ts
+++ b/packages/mcp/src/tools/design-context-guard.ts
@@ -10,16 +10,23 @@ import { getDesignContextTool } from './get-design-context.js';
 
 // The public-path guard around get_design_context, the hot grounding read. Internal consumers
 // (design_diff snapshots, component/icon map walks) dispatch the tool directly and are untouched;
-// this wrapper only runs for the MCP tool call, where the result lands in an LLM context:
+// this wrapper only runs for the MCP tool call, where the result lands in an LLM context.
 //
-// 1. It marks the dispatch with budget: true, arming the plugin's pre-serialization node-count
-//    bail (the coarse net — a hopeless tree skips the heavy work and returns a section plan).
-// 2. It measures the returned payload and, past DESIGN_CONTEXT_CHAR_BUDGET, replaces it with a
-//    section plan built from the payload itself (the precise net). Beyond that budget the result
-//    errors out of Claude Code's default MCP result cap today and delivers nothing, so a plan is
-//    strictly an upgrade, not a downgrade.
-// 3. On a below-full detail it attaches a one-line note pointing codegen callers at detail 'full' —
-//    the tool result is the one guidance surface every caller is guaranteed to read.
+// The public call defaults to the CODE-GENERATION view — detail 'full' + dedupeComponents true —
+// because the default caller is someone turning a design into code, and a compact default made
+// exactly that caller eyeball styling off a screenshot (the classic accuracy failure). Structure
+// scans stay one explicit `detail: 'compact'` away. From there the result degrades in a cascade,
+// each step only firing where the previous shape could not be delivered:
+//
+//   full fits the budget                     → full (the accurate default)
+//   full over budget, structure fits         → compact projection of the same payload + note
+//   structure over budget too / below-full   → section plan (ground per section at full)
+//   tree too large to even serialize (bail)  → section plan straight from the plugin, pre-work
+//
+// The plugin's pre-serialization bail is armed with budget: true (the coarse net); the mcp-side
+// char budget is the precise net, anchored to Claude Code's default MCP result cap
+// (MAX_MCP_OUTPUT_TOKENS = 25k tokens ≈ 100k chars of minified JSON) — beyond it the result errors
+// out today and delivers nothing, so every downgrade replaces a dead end, never a working result.
 
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
 
@@ -40,6 +47,40 @@ const countNodes = (nodes: readonly DesignContextNode[]): number => {
   }
   return total;
 };
+
+/**
+ * Project a full node down to its compact shape (identity + geometry + structural flags), the same
+ * fields the plugin's own compact detail emits — so a downgraded result is indistinguishable from
+ * an explicit compact call, minus the second round-trip. Styling, text and token fields are dropped
+ * by construction (only known-compact fields are copied).
+ */
+const projectToCompact = (node: DesignContextNode): DesignContextNode => {
+  const out: DesignContextNode = { id: node.id, name: node.name, type: node.type };
+  if (node.visible === false) out.visible = false;
+  if (node.x !== undefined) out.x = node.x;
+  if (node.y !== undefined) out.y = node.y;
+  if (node.width !== undefined) out.width = node.width;
+  if (node.height !== undefined) out.height = node.height;
+  if (node.truncated === true) out.truncated = true;
+  if (node.deduped === true) out.deduped = true;
+  if (node.children !== undefined) out.children = node.children.map(projectToCompact);
+  return out;
+};
+
+/** The structure-only downgrade of an over-budget full payload (globalVars/tokens dropped). */
+const compactDowngrade = (
+  result: GetDesignContextResult,
+  payloadChars: number,
+): GetDesignContextResult => ({
+  nodes: result.nodes.map(projectToCompact),
+  ...(result.hint === undefined ? {} : { hint: result.hint }),
+  note:
+    `This tree serialized to ~${Math.round(payloadChars / 1000)}k chars at detail "full" — beyond ` +
+    'what a tool result can deliver, so this is the structure-only (compact) view of the same ' +
+    'tree. It carries no styling, text or tokens: pick each section and call get_design_context ' +
+    'on its nodeId (detail: full, dedupeComponents: true) to ground it before building — never ' +
+    'generate code from this structure alone.',
+});
 
 /**
  * Rebuild an oversized payload into a section plan: the roots' identity plus one entry per
@@ -85,7 +126,10 @@ export const sectionPlanFromPayload = (
   };
 };
 
-/** The public MCP handler for get_design_context: dispatch armed with budget, then apply the nets. */
+/**
+ * The public MCP handler for get_design_context: apply the codegen-view defaults, dispatch armed
+ * with budget, then walk the degradation cascade.
+ */
 export const handleDesignContext = async (
   dispatch: ToolDispatcher,
   rawArgs: unknown,
@@ -93,18 +137,26 @@ export const handleDesignContext = async (
   // Parsing with the public shape also strips any caller-supplied `budget` key, so arming the
   // plugin bail stays exclusively this wrapper's decision.
   const args = z.object(getDesignContextTool.inputShape).parse(rawArgs ?? {});
+  const detail = args.detail ?? 'full';
+  const dedupeComponents = args.dedupeComponents ?? true;
   const result = (await dispatch(getDesignContextTool.name, {
     ...args,
+    detail,
+    dedupeComponents,
     budget: true,
   })) as GetDesignContextResult;
 
+  // The plugin's node-count bail already produced the plan — nothing further to measure.
   if (result.sectionPlan !== undefined) return result;
 
-  if ((args.detail ?? 'compact') !== 'full') return { ...result, note: BELOW_FULL_NOTE };
-
   const payloadChars = JSON.stringify(result).length;
-  if (payloadChars > DESIGN_CONTEXT_CHAR_BUDGET) {
-    return sectionPlanFromPayload(result, payloadChars) ?? result;
+  if (payloadChars <= DESIGN_CONTEXT_CHAR_BUDGET) {
+    return detail === 'full' ? result : { ...result, note: BELOW_FULL_NOTE };
   }
-  return result;
+
+  if (detail === 'full') {
+    const downgraded = compactDowngrade(result, payloadChars);
+    if (JSON.stringify(downgraded).length <= DESIGN_CONTEXT_CHAR_BUDGET) return downgraded;
+  }
+  return sectionPlanFromPayload(result, payloadChars) ?? result;
 };

--- a/packages/mcp/src/tools/design-context-guard.ts
+++ b/packages/mcp/src/tools/design-context-guard.ts
@@ -61,6 +61,9 @@ const projectToCompact = (node: DesignContextNode): DesignContextNode => {
   if (node.y !== undefined) out.y = node.y;
   if (node.width !== undefined) out.width = node.width;
   if (node.height !== undefined) out.height = node.height;
+  // The plugin sets an instance's mainComponentId at every detail level (only the resolved
+  // mainComponent object is full-only), so the downgrade keeps instance→component identity too.
+  if (node.mainComponentId !== undefined) out.mainComponentId = node.mainComponentId;
   if (node.truncated === true) out.truncated = true;
   if (node.deduped === true) out.deduped = true;
   if (node.children !== undefined) out.children = node.children.map(projectToCompact);

--- a/packages/mcp/src/tools/get-design-context.ts
+++ b/packages/mcp/src/tools/get-design-context.ts
@@ -11,10 +11,12 @@ export const getDesignContextTool: ToolSpec = {
     'Get a depth-limited, token-efficient node tree — the main design-grounding read; prefer it ' +
     'over get_document / get_node for anything large. Starts from nodeId (a pasted Figma URL also ' +
     'works), else the current selection; errors when neither is available. ' +
-    'detail: minimal (id/name/type) / compact (+ geometry; the default) / full — only full carries ' +
-    'styling, layout, text and design-system tokens resolved to names plus a deduped globalVars ' +
-    'style table, so always use full (with dedupeComponents: true) when generating code; compact ' +
-    'is for cheap structure scans. depth limits child levels (omit or 0 = unlimited; cut nodes are ' +
+    'detail: minimal (id/name/type) / compact (+ geometry) / full (+ styling, layout, text and ' +
+    'design-system tokens resolved to names plus a deduped globalVars style table). Defaults to ' +
+    'full with dedupeComponents true — the code-generation view; pass detail: compact explicitly ' +
+    'for a cheap structure scan. An over-budget full result degrades gracefully: first to the ' +
+    'compact structure of the same tree (note attached), then to a sectionPlan. ' +
+    'depth limits child levels (omit or 0 = unlimited; cut nodes are ' +
     'flagged truncated). dedupeComponents collapses repeated instances of an already-expanded main ' +
     'component (flagged deduped); a deduped instance still carries textOverrides ({ name, ' +
     'characters } — the visible text it actually renders) and propertyOverrides (its per-instance ' +
@@ -34,11 +36,11 @@ export const getDesignContextTool: ToolSpec = {
       .optional(),
     detail: z
       .enum(DETAIL_LEVELS)
-      .describe('How much per-node data: minimal / compact (default) / full')
+      .describe('How much per-node data: minimal / compact / full (default)')
       .optional(),
     dedupeComponents: z
       .boolean()
-      .describe('Collapse repeated instances of the same main component')
+      .describe('Collapse repeated instances of the same main component (default true)')
       .optional(),
   },
   kind: 'read',

--- a/packages/mcp/test/tools/design-context-guard.test.ts
+++ b/packages/mcp/test/tools/design-context-guard.test.ts
@@ -32,25 +32,60 @@ const dispatcher = (
   };
 };
 
+/** An oversized full payload: two FRAME sections of fat leaves (the fat mimics styling data). */
+const oversizedFull = (): GetDesignContextResult => {
+  const fat = 'x'.repeat(2000);
+  const sections = ['a', 'b'].map((s, i) =>
+    leaf(`s${i}`, {
+      name: `Section ${s}`,
+      type: 'FRAME',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      children: Array.from({ length: 40 }, (_c, l) =>
+        leaf(`s${i}-l${l}`, { fills: fat, x: 1, y: 2, width: 3, height: 4 }),
+      ),
+    }),
+  );
+  return {
+    nodes: [leaf('root', { name: 'Page', type: 'FRAME', children: sections })],
+    globalVars: { styles: { deadbeef: { fills: fat } } },
+  };
+};
+
 describe('handleDesignContext (the public-path guard)', () => {
-  it('arms the plugin bail with budget: true and strips a caller-supplied budget', async () => {
+  it('defaults to the codegen view: injects detail full + dedupeComponents true + budget', async () => {
     const { dispatch, seen } = dispatcher({ nodes: [leaf('1:1')] });
-    await handleDesignContext(dispatch, { detail: 'full', budget: false });
-    expect(seen[0]).toMatchObject({ detail: 'full', budget: true });
+    await handleDesignContext(dispatch, {});
+    expect(seen[0]).toMatchObject({ detail: 'full', dedupeComponents: true, budget: true });
   });
 
-  it('attaches the below-full note on the default (compact) detail', async () => {
+  it('respects an explicit detail/dedupe choice and strips a caller-supplied budget', async () => {
+    const { dispatch, seen } = dispatcher({ nodes: [leaf('1:1')] });
+    await handleDesignContext(dispatch, {
+      detail: 'compact',
+      dedupeComponents: false,
+      budget: false,
+    });
+    expect(seen[0]).toMatchObject({ detail: 'compact', dedupeComponents: false, budget: true });
+  });
+
+  it('attaches the below-full note only on an explicit below-full detail', async () => {
+    const { dispatch } = dispatcher({ nodes: [leaf('1:1')] });
+    const compact = await handleDesignContext(dispatch, { detail: 'compact' });
+    expect(compact.note).toMatch(/detail: "full"/);
+
+    const defaulted = await handleDesignContext(dispatch, {});
+    expect(defaulted.note).toBeUndefined();
+    expect(defaulted.sectionPlan).toBeUndefined();
+  });
+
+  it('passes a small (defaulted-full) result through untouched', async () => {
     const { dispatch } = dispatcher({ nodes: [leaf('1:1')] });
     const r = await handleDesignContext(dispatch, {});
-    expect(r.note).toMatch(/detail: "full"/);
-    expect(r.sectionPlan).toBeUndefined();
-  });
-
-  it('passes a small full result through untouched (no note)', async () => {
-    const { dispatch } = dispatcher({ nodes: [leaf('1:1')] });
-    const r = await handleDesignContext(dispatch, { detail: 'full' });
-    expect(r.note).toBeUndefined();
     expect(r.nodes[0]?.id).toBe('1:1');
+    expect(r.note).toBeUndefined();
   });
 
   it('passes a plugin-side section plan through without re-processing', async () => {
@@ -60,47 +95,111 @@ describe('handleDesignContext (the public-path guard)', () => {
       note: 'from plugin',
     };
     const { dispatch } = dispatcher(bail);
-    const r = await handleDesignContext(dispatch, { detail: 'full' });
+    const r = await handleDesignContext(dispatch, {});
     expect(r).toEqual(bail);
   });
 
-  it('replaces an oversized full payload with a payload-size section plan', async () => {
-    // Two sections of fat leaves: the stringified payload must exceed the char budget.
-    const fat = 'x'.repeat(2000);
+  it('downgrades an oversized full payload to its compact structure with a note', async () => {
+    const payload = oversizedFull();
+    expect(JSON.stringify(payload).length).toBeGreaterThan(DESIGN_CONTEXT_CHAR_BUDGET);
+
+    const { dispatch } = dispatcher(payload);
+    const r = await handleDesignContext(dispatch, {});
+
+    // Structure-only: geometry survives, styling and globalVars are gone, the tree shape is intact.
+    expect(r.sectionPlan).toBeUndefined();
+    expect(r.globalVars).toBeUndefined();
+    expect(r.nodes[0]?.children).toHaveLength(2);
+    const firstLeaf = r.nodes[0]?.children?.[0]?.children?.[0];
+    expect(firstLeaf).toEqual({
+      id: 's0-l0',
+      name: 'n-s0-l0',
+      type: 'RECTANGLE',
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    expect(JSON.stringify(r).length).toBeLessThanOrEqual(DESIGN_CONTEXT_CHAR_BUDGET);
+    expect(r.note).toMatch(/structure-only/);
+    expect(r.note).toMatch(/never\s+generate code from this structure alone/);
+  });
+
+  it('keeps the breakpoint hint on a compact downgrade', async () => {
+    const payload = { ...oversizedFull(), hint: 'breakpoints: ground each frame' };
+    const { dispatch } = dispatcher(payload);
+    const r = await handleDesignContext(dispatch, {});
+    expect(r.hint).toBe('breakpoints: ground each frame');
+  });
+
+  it('falls through to a section plan when even the compact structure is over budget', async () => {
+    // Two sections × 1200 leaves with long names: the compact projection alone tops 100k chars.
+    const longName = 'section-content-'.repeat(6);
     const sections = ['a', 'b'].map((s, i) =>
       leaf(`s${i}`, {
         name: `Section ${s}`,
         type: 'FRAME',
-        children: Array.from({ length: 40 }, (_, l) => leaf(`s${i}-l${l}`, { fatField: fat })),
+        children: Array.from({ length: 1200 }, (_c, l) =>
+          leaf(`s${i}-l${l}`, { name: `${longName}${l}`, x: 1, y: 2, width: 3, height: 4 }),
+        ),
       }),
     );
     const payload: GetDesignContextResult = {
       nodes: [leaf('root', { name: 'Page', type: 'FRAME', children: sections })],
     };
-    expect(JSON.stringify(payload).length).toBeGreaterThan(DESIGN_CONTEXT_CHAR_BUDGET);
-
     const { dispatch } = dispatcher(payload);
-    const r = await handleDesignContext(dispatch, { detail: 'full' });
+    const r = await handleDesignContext(dispatch, {});
 
     expect(r.sectionPlan?.reason).toBe('payload-size');
-    expect(r.sectionPlan?.payloadChars).toBe(JSON.stringify(payload).length);
     expect(r.sectionPlan?.sections).toHaveLength(2);
-    expect(r.sectionPlan?.sections[0]).toMatchObject({ nodeId: 's0', childCount: 40, nodes: 41 });
-    // Roots keep identity only; the oversized data does not ride along.
+    expect(r.sectionPlan?.sections[0]).toMatchObject({ nodeId: 's0', nodes: 1201 });
     expect(r.nodes).toEqual([{ id: 'root', name: 'Page', type: 'FRAME' }]);
-    expect(JSON.stringify(r).length).toBeLessThan(DESIGN_CONTEXT_CHAR_BUDGET);
-    expect(r.note).toMatch(/section by section/);
   });
 
-  it('keeps an oversized payload that has nothing to split into', async () => {
-    // One root, one child, no grandchildren: a plan would strand the caller with no way forward.
+  it('turns an oversized explicit-compact payload into a section plan (no downgrade step)', async () => {
+    // A compact tree can blow the client cap too (a giant page at ~80 chars/node); there is no
+    // cheaper detail to degrade to, so the net goes straight to the plan.
+    const sections = ['a', 'b'].map((s, i) =>
+      leaf(`s${i}`, {
+        name: `Section ${s}`,
+        type: 'FRAME',
+        children: Array.from({ length: 900 }, (_c, l) =>
+          leaf(`s${i}-l${l}`, { name: 'x'.repeat(60), x: 1, y: 2, width: 3, height: 4 }),
+        ),
+      }),
+    );
     const payload: GetDesignContextResult = {
-      nodes: [leaf('root', { children: [leaf('only', { fatField: 'x'.repeat(120_000) })] })],
+      nodes: [leaf('root', { name: 'Page', type: 'FRAME', children: sections })],
     };
     const { dispatch } = dispatcher(payload);
-    const r = await handleDesignContext(dispatch, { detail: 'full' });
+    const r = await handleDesignContext(dispatch, { detail: 'compact' });
+
+    expect(r.sectionPlan?.reason).toBe('payload-size');
+    expect(r.nodes).toEqual([{ id: 'root', name: 'Page', type: 'FRAME' }]);
+  });
+
+  it('keeps an oversized explicit-compact payload that has nothing to split into', async () => {
+    // One root, one child: a plan would strand the caller, and compact can't degrade further.
+    const payload: GetDesignContextResult = {
+      nodes: [leaf('root', { children: [leaf('only', { name: 'y'.repeat(120_000) })] })],
+    };
+    const { dispatch } = dispatcher(payload);
+    const r = await handleDesignContext(dispatch, { detail: 'compact' });
     expect(r.sectionPlan).toBeUndefined();
     expect(r.nodes[0]?.children?.[0]?.id).toBe('only');
+  });
+
+  it('rescues an unsplittable oversized full payload via the compact downgrade', async () => {
+    // The fat is styling (unknown fields) — the compact projection strips it, so the downgrade
+    // fits even though there are no sections to plan.
+    const payload: GetDesignContextResult = {
+      nodes: [leaf('root', { children: [leaf('only', { fills: 'x'.repeat(120_000) })] })],
+    };
+    const { dispatch } = dispatcher(payload);
+    const r = await handleDesignContext(dispatch, {});
+    expect(r.sectionPlan).toBeUndefined();
+    expect(r.nodes[0]?.children?.[0]).toEqual({ id: 'only', name: 'n-only', type: 'RECTANGLE' });
+    expect(r.note).toMatch(/structure-only/);
   });
 });
 
@@ -119,7 +218,7 @@ describe('sectionPlanFromPayload', () => {
   });
 
   it('caps very wide plans and reports the omission', () => {
-    const wide = Array.from({ length: 70 }, (_, i) => leaf(`w${i}`));
+    const wide = Array.from({ length: 70 }, (_w, i) => leaf(`w${i}`));
     const plan = sectionPlanFromPayload({ nodes: [leaf('root', { children: wide })] }, 1);
     expect(plan?.sectionPlan?.sections).toHaveLength(60);
     expect(plan?.sectionPlan?.sectionsOmitted).toBe(10);

--- a/packages/mcp/test/tools/design-context-guard.test.ts
+++ b/packages/mcp/test/tools/design-context-guard.test.ts
@@ -38,7 +38,10 @@ const oversizedFull = (): GetDesignContextResult => {
   const sections = ['a', 'b'].map((s, i) =>
     leaf(`s${i}`, {
       name: `Section ${s}`,
-      type: 'FRAME',
+      type: i === 1 ? 'INSTANCE' : 'FRAME',
+      // The second section is an instance: identity (mainComponentId) must survive the compact
+      // downgrade while the full-only resolved mainComponent object must not.
+      ...(i === 1 ? { mainComponentId: 'c:9', mainComponent: { id: 'c:9', name: 'Card' } } : {}),
       x: 0,
       y: 0,
       width: 100,
@@ -110,6 +113,10 @@ describe('handleDesignContext (the public-path guard)', () => {
     expect(r.sectionPlan).toBeUndefined();
     expect(r.globalVars).toBeUndefined();
     expect(r.nodes[0]?.children).toHaveLength(2);
+    // Instance→component identity survives the downgrade (plugin compact carries it too);
+    // the full-only resolved mainComponent object does not.
+    expect(r.nodes[0]?.children?.[1]?.mainComponentId).toBe('c:9');
+    expect(r.nodes[0]?.children?.[1]?.mainComponent).toBeUndefined();
     const firstLeaf = r.nodes[0]?.children?.[0]?.children?.[0];
     expect(firstLeaf).toEqual({
       id: 's0-l0',


### PR DESCRIPTION
## Behaviour change (public MCP tool path only)

An unspecified `detail` now means **`full` + `dedupeComponents: true`** — the code-generation view — instead of `compact`. Owner-approved trade-off: the default caller is turning a design into code, and the compact default handed exactly that caller a styling-free tree whose next step was eyeballing values off a screenshot (the classic accuracy failure). A naive first call now gets accurate grounding out of the box.

**The one cost**: a small-tree structure scan that relied on the bare default now pays ~4–5× the tokens (e.g. 15KB → 79KB on a 182-node frame). Escape hatch: pass `detail: 'compact'` explicitly — unchanged and still taught by the below-full note.

## The degradation cascade

Each step fires only where the previous shape could not be delivered:

| condition | result |
|---|---|
| full fits the 100k-char budget | full — the accurate default |
| full over budget, structure fits | **compact projection of the same payload** + note |
| structure over budget too / explicit compact over budget | section plan |
| tree too large to serialize at all (>1500 nodes) | plugin node-count bail (#58, unchanged) |

The compact projection is a pure mcp-side function — full is a superset of compact, so **no second round-trip and no extra plugin work**: styling/globalVars are dropped; geometry, `deduped`/`truncated` flags and the breakpoint `hint` are kept. The result is indistinguishable from an explicit compact call.

The payload-size net now also covers **explicit compact/minimal** calls: a giant page's compact tree (~80 chars/node) blows the client's result cap today just the same — previously it errored out delivering nothing, now it returns a section plan. (This closes a pre-existing dead end #58 didn't cover.)

## What is NOT changed

- **Plugin default stays compact**; the flip lives in the public handler (`design-context-guard.ts`) only.
- **Internal dispatches** (design_diff snapshots, component/icon map walks) are untouched and keep reading raw full trees — pinned by the existing `not.toHaveProperty('budget')` test.
- Explicit `detail` / `dedupeComponents` choices are always respected.
- Prompts and skills already teach explicit `detail: full` — zero drift.

## Tests

868 green (+5): default injection (full + dedupe + budget), explicit-choice preservation, note only on explicit below-full, compact downgrade (structure intact / styling + globalVars stripped / hint kept / fits budget), downgrade falls through to plan when structure is itself over budget, explicit-compact over budget goes straight to plan, unsplittable payloads (compact keeps original; full is rescued by the projection). All six gates pass.

## After merge

Live matrix verification planned (needs main + build + MCP reconnect): naive bare call on a small frame returns full; on M_home (622 nodes / 217KB full) returns the compact projection + note; on the 6456-node section returns the plugin bail plan; explicit compact keeps today's shape + note.