### PR TITLE
feat(component_map,profile): flag near-tie component picks + first-class Solid

### DIFF
--- a/packages/mcp/src/join/component-map.ts
+++ b/packages/mcp/src/join/component-map.ts
@@ -59,6 +59,15 @@ export interface ComponentMapping {
      * surfaces these as component-extension TODOs instead of silently dropping the design intent.
      */
     unmatchedProps: string[];
+    /**
+     * Runner-up components whose name scored within a tie epsilon of the winner — the fuzzy match
+     * couldn't confidently pick one. Present only on a `scan` mapping (a `map-file` override is
+     * authoritative, never ambiguous) and only when the pick was a near-tie. Treat the winning
+     * `candidate` as a verify-me pick: check which of these is the right reuse for this context (or
+     * record the confirmed one in the map file), don't import the winner blindly — a wrong reuse is
+     * a silent visual bug. Mirrors token_map's `ambiguousWith`. Absent when unambiguous.
+     */
+    ambiguousWith?: { name: string; filePath: string }[];
   };
   status: MappingStatus;
   /** Which path produced the mapping. */
@@ -109,29 +118,30 @@ const nameCandidates = (figmaName: string): string[] => {
   return [...new Set([figmaName, base, ...slashParts])];
 };
 
-interface NameMatch {
+interface NameScore {
   component: ScannedComponent;
   score: number;
 }
 
-/** Best name-only match for a Figma component across the scanned set (max Dice over name variants). */
-const bestNameMatch = (
-  figmaName: string,
-  scanned: readonly ScannedComponent[],
-): NameMatch | null => {
+/** Name-only Dice score of every scanned component against the Figma name (max over name variants). */
+const scoreNames = (figmaName: string, scanned: readonly ScannedComponent[]): NameScore[] => {
   const candidates = nameCandidates(figmaName).map(norm);
-  let best: NameMatch | null = null;
-  for (const component of scanned) {
+  return scanned.map(component => {
     const target = norm(component.name);
     let score = 0;
     for (const candidate of candidates) score = Math.max(score, diceSimilarity(candidate, target));
-    if (best === null || score > best.score) best = { component, score };
-  }
-  return best;
+    return { component, score };
+  });
 };
 
 const VARIANT_BONUS_PER_PROP = 0.05;
 const MAX_VARIANT_BONUS = 0.1;
+// A runner-up whose name scores within this of the winner is a near-tie: the name match couldn't
+// confidently pick between them, so it's surfaced on `ambiguousWith` for codegen to verify. Kept
+// tight (a genuine ambiguity, not a distant second) to avoid noisy verify prompts.
+const TIE_EPSILON = 0.05;
+// Cap the surfaced runner-ups so a scan with many similar names doesn't dump a long list.
+const MAX_AMBIGUOUS = 3;
 
 const statusFor = (confidence: number, threshold: number): MappingStatus => {
   if (confidence >= 0.85) return 'high';
@@ -242,27 +252,46 @@ const joinScan = (
   opts: JoinOptions,
   shared: Omit<ComponentMapping, 'candidate' | 'status' | 'source' | 'staleOverride'>,
 ): ComponentMapping => {
-  const match = bestNameMatch(usage.name, scanned);
-  if (match === null || match.score < 0.5) {
+  const scores = scoreNames(usage.name, scanned);
+  // Winner: highest name score, first-wins on an exact tie (strict `>`, preserving the prior pick).
+  let winner: NameScore | null = null;
+  for (const s of scores) if (winner === null || s.score > winner.score) winner = s;
+  if (winner === null || winner.score < 0.5) {
     return { ...shared, status: 'unmapped', source: 'scan' };
   }
+  const best = winner;
 
   // Variant bonus: reward code props that cover the instance's variant axes, but only once the name
   // already plausibly matches, so an unrelated component can't be promoted on prop overlap alone.
-  const { matchedProps, unmatchedProps } = partitionAxes(usage.variantAxes, match.component);
+  const { matchedProps, unmatchedProps } = partitionAxes(usage.variantAxes, best.component);
   const bonus = Math.min(MAX_VARIANT_BONUS, matchedProps.length * VARIANT_BONUS_PER_PROP);
-  const confidence = Math.min(1, Number((match.score + bonus).toFixed(3)));
+  const confidence = Math.min(1, Number((best.score + bonus).toFixed(3)));
+
+  // Near-ties: other plausible components (name ≥ 0.5) whose score is within TIE_EPSILON of the
+  // winner. A near-tie means the name couldn't confidently pick one — surface the runner-up(s) so
+  // codegen verifies the reuse instead of silently importing the winner. The winner itself is
+  // unchanged; this only adds a caution signal (and never presents a tie as a confident 'high').
+  const ambiguousWith = scores
+    .filter(
+      s => s.component !== best.component && s.score >= 0.5 && best.score - s.score <= TIE_EPSILON,
+    )
+    .toSorted((a, b) => b.score - a.score)
+    .slice(0, MAX_AMBIGUOUS)
+    .map(s => ({ name: s.component.name, filePath: s.component.filePath }));
+  const baseStatus = statusFor(confidence, opts.threshold);
+  const status = ambiguousWith.length > 0 && baseStatus === 'high' ? 'medium' : baseStatus;
 
   return {
     ...shared,
     candidate: {
-      name: match.component.name,
-      filePath: match.component.filePath,
+      name: best.component.name,
+      filePath: best.component.filePath,
       confidence,
       matchedProps,
       unmatchedProps,
+      ...(ambiguousWith.length > 0 ? { ambiguousWith } : {}),
     },
-    status: statusFor(confidence, opts.threshold),
+    status,
     source: 'scan',
   };
 };

--- a/packages/mcp/src/profile/profile.ts
+++ b/packages/mcp/src/profile/profile.ts
@@ -10,7 +10,7 @@ import { walkRepoFiles } from '../repo-walk.js';
 // This first cut covers the JS/TS ecosystem; the framework/styling detectors are an ordered cascade so
 // a PHP (composer.json) or .NET (*.csproj) detector is just another entry appended later.
 
-export const FRAMEWORKS = ['next', 'nuxt', 'react', 'vue', 'svelte', 'unknown'] as const;
+export const FRAMEWORKS = ['next', 'nuxt', 'react', 'vue', 'svelte', 'solid', 'unknown'] as const;
 export type Framework = (typeof FRAMEWORKS)[number];
 
 export const STYLING_SYSTEMS = [
@@ -183,6 +183,10 @@ const COMPONENT_EXTENSIONS: Record<Framework, string[]> = {
   nuxt: ['.vue'],
   vue: ['.vue'],
   svelte: ['.svelte'],
+  // Solid authors components as JSX in .tsx/.jsx, parsed by the same (react) extractor — only the
+  // emitted conventions differ (`class` not `className`, `createSignal`), which the framework label
+  // steers.
+  solid: ['.tsx', '.jsx'],
   unknown: ['.tsx', '.jsx', '.vue', '.svelte'],
 };
 
@@ -198,6 +202,8 @@ const detectFramework = (
   if ('react' in deps) return { framework: 'react', reason: 'react in dependencies' };
   if ('vue' in deps) return { framework: 'vue', reason: 'vue in dependencies' };
   if ('svelte' in deps) return { framework: 'svelte', reason: 'svelte in dependencies' };
+  // solid-js is the base dep of both plain Solid and SolidStart, so one check covers both.
+  if ('solid-js' in deps) return { framework: 'solid', reason: 'solid-js in dependencies' };
   return { framework: 'unknown', reason: 'no known framework dependency' };
 };
 
@@ -272,6 +278,11 @@ const SVG_LOADERS: { dep: string; loader: string; hint: string }[] = [
     dep: 'vite-svg-loader',
     loader: 'vite-svg-loader',
     hint: "import Icon from './icon.svg?component'",
+  },
+  {
+    dep: 'vite-plugin-solid-svg',
+    loader: 'vite-plugin-solid-svg',
+    hint: "import Icon from './icon.svg?component-solid'",
   },
   {
     dep: '@svgr/webpack',

--- a/packages/mcp/src/prompts/figma-to-code.ts
+++ b/packages/mcp/src/prompts/figma-to-code.ts
@@ -20,6 +20,7 @@ const promptText = (nodeId: string | undefined): string => {
 
 2. component_map — every Figma component grouped to a local code component with a status.
    - high / medium: import and reuse candidate.filePath; do not regenerate it.
+   - candidate.ambiguousWith (a list of { name, filePath }): the name matched two+ code components nearly equally and the join could not confidently pick — a verify-me pick, not a confident reuse. Check which of the winner + these runner-ups is the right component for THIS context before importing (a wrong reuse is a silent visual bug), then record the confirmed one in docs/figma-component-map.md so next run is certain.
    - Wire each entry's instances[].props (resolved variant / boolean / text values) onto the reused component — one element per instance, each with its own props.
    - candidate.unmatchedProps are props the design needs but the component lacks → surface them as component-extension TODOs, never fake them with ad-hoc markup.
    - unmapped: build it new in the project's style. For a repeated unmapped component (instanceCount > 1, e.g. a table row), build from its first instance's subtree; drill instances[0].nodeId if it was scoped away.

--- a/packages/mcp/test/join/component-map.test.ts
+++ b/packages/mcp/test/join/component-map.test.ts
@@ -113,6 +113,34 @@ describe('joinComponents', () => {
     expect(m?.candidate).toBeUndefined();
   });
 
+  it('surfaces a near-tie runner-up on ambiguousWith and never presents it as a confident high', () => {
+    // A real casing split: NavBar.tsx + Navbar.tsx both normalize to "navbar", so both match a Figma
+    // "NavBar" identically — the fuzzy join can't confidently pick one.
+    const twins = [comp('NavBar'), comp('Navbar')]; // distinct files, same normalized name
+    const [m] = joinComponents([usage({ name: 'NavBar' })], twins, { threshold: 0.7 });
+    // The winning pick is unchanged (first scanned), but the runner-up is surfaced for verification.
+    expect(m?.candidate?.name).toBe('NavBar');
+    expect(m?.candidate?.ambiguousWith).toEqual([
+      { name: 'Navbar', filePath: 'src/components/Navbar.tsx' },
+    ]);
+    // Score 1 would be 'high' — the tie caps it to 'medium' so codegen treats it as verify-me.
+    expect(m?.status).toBe('medium');
+  });
+
+  it('does not flag a distant runner-up (below the tie epsilon)', () => {
+    // Card matches cleanly; Avatar/Button are far off → not ambiguous, so full high, no ambiguousWith.
+    const [m] = joinComponents([usage({ name: 'Card' })], scanned, { threshold: 0.7 });
+    expect(m?.status).toBe('high');
+    expect(m?.candidate?.ambiguousWith).toBeUndefined();
+  });
+
+  it('caps the surfaced runner-ups instead of dumping a long list', () => {
+    // Five identically-normalized siblings → only the top MAX_AMBIGUOUS (3) runner-ups are surfaced.
+    const sibs = ['NavBar', 'Navbar', 'NAVBAR', 'Nav_Bar', 'Nav-Bar'].map(n => comp(n));
+    const [m] = joinComponents([usage({ name: 'NavBar' })], sibs, { threshold: 0.7 });
+    expect(m?.candidate?.ambiguousWith).toHaveLength(3);
+  });
+
   it('trusts an override whose file is on disk even when the scan did not parse it', () => {
     // The scanner can miss a real component (an unusual export). The override still wins at full
     // confidence — but only because the tool confirmed the file is on disk (overridesOnDisk).

--- a/packages/mcp/test/profile/profile.test.ts
+++ b/packages/mcp/test/profile/profile.test.ts
@@ -36,6 +36,26 @@ describe('detectProfile (pure)', () => {
     expect(p.componentExtensions).toEqual(['.vue']);
   });
 
+  it('detects Solid from solid-js and scans its JSX extensions', () => {
+    const p = detectProfile(baseInput({ packageJson: { dependencies: { 'solid-js': '^1.8.0' } } }));
+    expect(p.framework).toBe('solid');
+    // Solid JSX lives in .tsx/.jsx, parsed by the same extractor as React.
+    expect(p.componentExtensions).toEqual(['.tsx', '.jsx']);
+  });
+
+  it('resolves the Solid svg loader to its component-solid import form', () => {
+    const p = detectProfile(
+      baseInput({
+        packageJson: {
+          dependencies: { 'solid-js': '^1.8.0' },
+          devDependencies: { 'vite-plugin-solid-svg': '^0.8.0' },
+        },
+      }),
+    );
+    expect(p.svg.mode).toBe('component');
+    expect(p.svg.importHint).toBe("import Icon from './icon.svg?component-solid'");
+  });
+
   it('flags ts when tsconfig present, js otherwise', () => {
     expect(detectProfile(baseInput({ hasTsconfig: true })).language).toBe('ts');
     expect(

--- a/skills/figma-codegen/SKILL.md
+++ b/skills/figma-codegen/SKILL.md
@@ -32,6 +32,12 @@ Run the grounded tools against the selection, then generate — **trust them ove
    (high / medium / low / unmapped), `candidate.filePath`, and `matchedProps`.
    - `high` / `medium`: **reuse that component** (import from `candidate.filePath`), don't regenerate.
      Never invent a component name `component_map` didn't report.
+   - `candidate.ambiguousWith` (a capped list of `{ name, filePath }`): the Figma name matched two or
+     more code components nearly equally and the join couldn't confidently pick — a **verify-me** pick,
+     not a confident reuse (the analogue of `token_map`'s `ambiguousWith`). Check which of the winning
+     `candidate` + these runner-ups is the right component for _this_ context before importing (a wrong
+     reuse is a silent visual bug), then record the confirmed one in the map file so the next run is
+     certain. Absent when the pick was unambiguous.
    - Wire each entry's `instances[].props` (resolved variant / boolean / text values) onto the reused
      component — one element per instance, with its own props.
    - `candidate.unmatchedProps`: Figma axes the component has no prop for (a leading icon, a `required`


### PR DESCRIPTION
## What & why

PR-5a of the PR-5 split — the two **moat** items (codegen accuracy + generality), kept small and strictly additive. The write-side symmetry items (`update_text_style`/`update_effect_style`) go in a follow-up PR-5b; `create_variable` scopes / Astro / Lit stay deferred.

### 1. `component_map` near-tie flag (accuracy)
When a Figma component name matches **two or more code components nearly equally** (within a tight tie epsilon, e.g. a `NavBar.tsx` + `Navbar.tsx` casing split), the fuzzy join can't confidently pick one. Previously it silently returned the winner as `high` — a wrong reuse is a **silent visual bug**.

- Surface the runner-up(s) on `candidate.ambiguousWith` (`{ name, filePath }[]`, capped).
- Cap a near-tie off `high` → `medium` so codegen treats it as **verify-me**.
- **Winner selection is unchanged** (highest name score, first-wins on tie). This is purely additive — the analogue of `token_map`'s `ambiguousWith`.

### 2. First-class `Solid` framework (generality)
`solid-js` in deps → `framework: 'solid'`. Solid's JSX lives in `.tsx/.jsx` and is parsed by the **same extractor as React** (dispatch is by extension), so scanning already works via the `unknown` fallback — this just gives it a real label so codegen emits idiomatic Solid (`class` not `className`, `createSignal`). Also resolves `vite-plugin-solid-svg` → `?component-solid` import form.

## Guarantees
- **持平或更好**: winner pick never changes; new field is optional/emit-when-present; adding `solid` only reaches projects previously detected `unknown`.
- Pure server-side join/profile logic — **no plugin/serializer/wire changes**.
- SKILL + `figma-to-code` prompt updated for `ambiguousWith`.

## Tests
+5 (3 tie-flag: exact tie / distant runner-up / cap; 2 Solid: detection+extensions / svg loader). Full gate suite green: typecheck, lint, format, knip, build, test (909).