### PR TITLE
feat(component_map,profile): first-class Angular framework support

### DIFF
--- a/packages/mcp/src/profile/profile.ts
+++ b/packages/mcp/src/profile/profile.ts
@@ -10,7 +10,16 @@ import { walkRepoFiles } from '../repo-walk.js';
 // This first cut covers the JS/TS ecosystem; the framework/styling detectors are an ordered cascade so
 // a PHP (composer.json) or .NET (*.csproj) detector is just another entry appended later.
 
-export const FRAMEWORKS = ['next', 'nuxt', 'react', 'vue', 'svelte', 'solid', 'unknown'] as const;
+export const FRAMEWORKS = [
+  'next',
+  'nuxt',
+  'react',
+  'vue',
+  'svelte',
+  'solid',
+  'angular',
+  'unknown',
+] as const;
 export type Framework = (typeof FRAMEWORKS)[number];
 
 export const STYLING_SYSTEMS = [
@@ -187,6 +196,10 @@ const COMPONENT_EXTENSIONS: Record<Framework, string[]> = {
   // emitted conventions differ (`class` not `className`, `createSignal`), which the framework label
   // steers.
   solid: ['.tsx', '.jsx'],
+  // Angular components are @Component-decorated classes in .ts (conventionally *.component.ts). The
+  // scanner reads every .ts but only keeps classes carrying @Component, so a service/pipe/guard .ts
+  // contributes nothing. .ts is Angular-exclusive here — no other framework globs it.
+  angular: ['.ts'],
   unknown: ['.tsx', '.jsx', '.vue', '.svelte'],
 };
 
@@ -204,6 +217,9 @@ const detectFramework = (
   if ('svelte' in deps) return { framework: 'svelte', reason: 'svelte in dependencies' };
   // solid-js is the base dep of both plain Solid and SolidStart, so one check covers both.
   if ('solid-js' in deps) return { framework: 'solid', reason: 'solid-js in dependencies' };
+  // @angular/core is the base dep of every Angular app (incl. AnalogJS / Angular Universal).
+  if ('@angular/core' in deps)
+    return { framework: 'angular', reason: '@angular/core in dependencies' };
   return { framework: 'unknown', reason: 'no known framework dependency' };
 };
 

--- a/packages/mcp/src/scan/scan.ts
+++ b/packages/mcp/src/scan/scan.ts
@@ -9,10 +9,11 @@ import { walkRepoFiles } from '../repo-walk.js';
 // against them. The guiding principle: never pattern-match the directory layout (feature-based, atomic,
 // flat all differ); identify a component by its *AST signature* (a PascalCase, exported, function-ish
 // binding) and take its name from the export/filename. Folder is only a confidence hint, applied later
-// in the join. React (.tsx/.jsx) is parsed with oxc; Vue/Svelte fall back to filename-derived names
-// (their SFC name is the file by convention) as a baseline until a dedicated pass is added.
+// in the join. React (.tsx/.jsx) and Angular (.ts, an @Component-decorated class) are parsed with oxc;
+// Vue/Svelte fall back to filename-derived names (their SFC name is the file by convention) as a
+// baseline until a dedicated pass is added.
 
-export type ComponentFramework = 'react' | 'vue' | 'svelte';
+export type ComponentFramework = 'react' | 'vue' | 'svelte' | 'angular';
 
 export interface ScannedComponent {
   name: string;
@@ -121,6 +122,94 @@ export const extractReactComponents = (filePath: string, code: string): ScannedC
       propNames: propNamesOf(cand.fn),
       propsExtracted: true,
       framework: 'react',
+    });
+  }
+  return out;
+};
+
+/** Whether an oxc class/member node carries a decorator called `name` (e.g. Component, Input). */
+const hasDecorator = (node: any, name: string): boolean =>
+  (node.decorators ?? []).some(
+    (d: any) => (d.expression?.callee?.name ?? d.expression?.name) === name,
+  );
+
+/**
+ * The public input name for an @Input()-decorated member: the alias when one is given
+ * (`@Input('foo')` / `@Input({ alias: 'foo' })`), else the property/accessor name. The alias is the
+ * template-binding name, so it's what a Figma property axis should line up against.
+ */
+const angularInputName = (member: any, keyName: string): string => {
+  const arg0 = (member.decorators ?? []).find(
+    (d: any) => (d.expression?.callee?.name ?? d.expression?.name) === 'Input',
+  )?.expression?.arguments?.[0];
+  if (arg0?.type === 'Literal' && typeof arg0.value === 'string') return arg0.value;
+  if (arg0?.type === 'ObjectExpression') {
+    const alias = (arg0.properties ?? []).find(
+      (p: any) => (p?.key?.name ?? p?.key?.value) === 'alias',
+    )?.value;
+    if (alias?.type === 'Literal' && typeof alias.value === 'string') return alias.value;
+  }
+  return keyName;
+};
+
+/** True for a signal-input field initializer: input(), input.required(), model(), model.required(). */
+const isSignalInput = (value: any): boolean => {
+  if (value?.type !== 'CallExpression') return false;
+  const callee = value.callee;
+  const base = callee?.type === 'MemberExpression' ? callee.object?.name : callee?.name;
+  return base === 'input' || base === 'model';
+};
+
+/** Public input names of an @Component class — both classic @Input() and signal input()/model(). */
+const angularInputs = (cls: any): string[] => {
+  const names = new Set<string>();
+  for (const member of cls.body?.body ?? []) {
+    const keyName = member?.key?.name;
+    if (typeof keyName !== 'string') continue;
+    if (hasDecorator(member, 'Input')) names.add(angularInputName(member, keyName));
+    else if (member.type === 'PropertyDefinition' && isSignalInput(member.value))
+      names.add(keyName);
+  }
+  return [...names];
+};
+
+/** Strip Angular's conventional `Component` class-name suffix so it matches suffix-free Figma names. */
+const angularLogicalName = (className: string): string =>
+  className.endsWith('Component') && className.length > 'Component'.length
+    ? className.slice(0, -'Component'.length)
+    : className;
+
+/**
+ * Extract Angular components from one file's source. A component is an exported class carrying the
+ * `@Component` decorator (`@Injectable` / `@Directive` / `@Pipe` and plain classes are skipped).
+ * Inputs come from both eras: classic `@Input()` (incl. aliases and `set` accessor inputs) and
+ * signal inputs (`input()` / `input.required()` / `model()`). Standalone vs NgModule doesn't change
+ * detection — both declare the component with `@Component`, it only changes how codegen imports it.
+ * The class name's conventional `Component` suffix is stripped for the join (so `ButtonComponent`
+ * matches a Figma `Button`); the importable class symbol is that name + `Component`.
+ */
+export const extractAngularComponents = (filePath: string, code: string): ScannedComponent[] => {
+  let program: any;
+  try {
+    program = parseSync(filePath, code).program;
+  } catch {
+    return [];
+  }
+  const out: ScannedComponent[] = [];
+  for (const node of program.body ?? []) {
+    if (node.type !== 'ExportNamedDeclaration' && node.type !== 'ExportDefaultDeclaration')
+      continue;
+    const cls = node.declaration;
+    if (cls?.type !== 'ClassDeclaration' || !hasDecorator(cls, 'Component')) continue;
+    const className = cls.id?.name;
+    if (typeof className !== 'string') continue;
+    out.push({
+      name: angularLogicalName(className),
+      filePath,
+      exportKind: node.type === 'ExportDefaultDeclaration' ? 'default' : 'named',
+      propNames: angularInputs(cls),
+      propsExtracted: true,
+      framework: 'angular',
     });
   }
   return out;
@@ -306,6 +395,9 @@ const frameworkForExt = (ext: string): ComponentFramework | null => {
   if (REACT_EXTS.has(ext)) return 'react';
   if (ext === '.vue') return 'vue';
   if (ext === '.svelte') return 'svelte';
+  // .ts is only globbed for an Angular project (its componentExtensions), so it never collides with
+  // the React/Vue/Svelte extensions above; a non-component .ts simply yields no @Component classes.
+  if (ext === '.ts') return 'angular';
   return null;
 };
 
@@ -330,6 +422,7 @@ export const scanComponents = async (
       continue;
     }
     if (framework === 'react') out.push(...extractReactComponents(rel, code));
+    else if (framework === 'angular') out.push(...extractAngularComponents(rel, code));
     else out.push(...extractSfcComponent(rel, code, framework));
   }
   return out;

--- a/packages/mcp/test/profile/profile.test.ts
+++ b/packages/mcp/test/profile/profile.test.ts
@@ -56,6 +56,15 @@ describe('detectProfile (pure)', () => {
     expect(p.svg.importHint).toBe("import Icon from './icon.svg?component-solid'");
   });
 
+  it('detects Angular from @angular/core and scans .ts components', () => {
+    const p = detectProfile(
+      baseInput({ packageJson: { dependencies: { '@angular/core': '^19.0.0' } } }),
+    );
+    expect(p.framework).toBe('angular');
+    // Angular components are @Component classes in .ts (the scanner filters to @Component classes).
+    expect(p.componentExtensions).toEqual(['.ts']);
+  });
+
   it('flags ts when tsconfig present, js otherwise', () => {
     expect(detectProfile(baseInput({ hasTsconfig: true })).language).toBe('ts');
     expect(

--- a/packages/mcp/test/scan/scan.test.ts
+++ b/packages/mcp/test/scan/scan.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
+  extractAngularComponents,
   extractReactComponents,
   extractSfcComponent,
   nameFromFile,
@@ -120,6 +121,88 @@ describe('extractSfcComponent (Vue / Svelte props)', () => {
   });
 });
 
+describe('extractAngularComponents (pure)', () => {
+  it('extracts classic @Input() props and strips the Component name suffix for matching', () => {
+    const code = `
+      import { Component, Input } from '@angular/core';
+      @Component({ selector: 'app-button', standalone: true, template: '' })
+      export class ButtonComponent {
+        @Input() size = 'md';
+        @Input() disabled = false;
+      }
+    `;
+    const [c] = extractAngularComponents('src/app/button/button.component.ts', code);
+    expect(c?.name).toBe('Button'); // ButtonComponent → Button, so it matches a Figma "Button"
+    expect(c?.framework).toBe('angular');
+    expect(c?.exportKind).toBe('named');
+    expect(c?.propNames).toEqual(['size', 'disabled']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('extracts signal inputs (input / input.required / model) alongside decorator inputs', () => {
+    const code = `
+      import { Component, Input, input, model } from '@angular/core';
+      @Component({ selector: 'app-card', template: '' })
+      export class CardComponent {
+        @Input() elevated = false;
+        title = input.required<string>();
+        count = input(0);
+        selected = model(false);
+      }
+    `;
+    const [c] = extractAngularComponents('card.component.ts', code);
+    expect(c?.propNames).toEqual(['elevated', 'title', 'count', 'selected']);
+  });
+
+  it('does not mistake internal signals / queries / outputs for inputs', () => {
+    // Only input()/model() (and @Input) are public inputs. signal()/computed() are internal state,
+    // viewChild()/contentChild() are queries, output() is an event — none is a component prop.
+    const code = `
+      import { Component, signal, computed, input, output, viewChild } from '@angular/core';
+      @Component({ selector: 'app-widget', template: '' })
+      export class WidgetComponent {
+        label = input('');
+        count = signal(0);
+        doubled = computed(() => this.count() * 2);
+        changed = output<number>();
+        ref = viewChild('el');
+      }
+    `;
+    const [c] = extractAngularComponents('widget.component.ts', code);
+    expect(c?.propNames).toEqual(['label']); // not count / doubled / changed / ref
+  });
+
+  it('uses the @Input alias (string and object form) as the public prop name', () => {
+    const code = `
+      import { Component, Input } from '@angular/core';
+      @Component({ template: '' })
+      export class FieldComponent {
+        @Input('variant') kind = 'primary';
+        @Input({ alias: 'isBusy', required: true }) busy!: boolean;
+        @Input() set active(v: boolean) {}
+      }
+    `;
+    const [c] = extractAngularComponents('field.component.ts', code);
+    // The alias is the template-binding name (what a Figma axis lines up against); set-accessor
+    // inputs are captured too.
+    expect(c?.propNames).toEqual(['variant', 'isBusy', 'active']);
+  });
+
+  it('skips non-component classes (@Injectable / @Directive / plain) and anonymous classes', () => {
+    const code = `
+      import { Injectable, Directive } from '@angular/core';
+      @Injectable() export class DataService {}
+      @Directive({ selector: '[appHi]' }) export class HiDirective {}
+      export class PlainThing {}
+    `;
+    expect(extractAngularComponents('x.ts', code)).toEqual([]);
+  });
+
+  it('does not crash on unparseable source', () => {
+    expect(extractAngularComponents('x.ts', 'export class = = =')).toEqual([]);
+  });
+});
+
 describe('nameFromFile', () => {
   it('PascalCases kebab and uses parent dir for index files', () => {
     expect(nameFromFile('ui/user-card.tsx')).toBe('UserCard');
@@ -181,6 +264,32 @@ describe('scanComponents (real fs)', () => {
       expect(comps[0]?.propsExtracted).toBe(true);
     } finally {
       await rm(vueDir, { recursive: true, force: true });
+    }
+  });
+
+  // An Angular profile globs .ts: only @Component classes are kept, and a service .ts in the same
+  // sweep contributes nothing (so the scan isn't polluted by every .ts in the repo).
+  it('scans an Angular .ts profile, keeping @Component classes and skipping services', async () => {
+    const ngDir = await mkdtemp(join(tmpdir(), 'scan-ng-'));
+    try {
+      await mkdir(join(ngDir, 'src', 'app', 'button'), { recursive: true });
+      await writeFile(
+        join(ngDir, 'src', 'app', 'button', 'button.component.ts'),
+        `import { Component, input } from '@angular/core';
+         @Component({ selector: 'app-button', template: '' })
+         export class ButtonComponent { size = input('md'); }`,
+      );
+      await writeFile(
+        join(ngDir, 'src', 'app', 'data.service.ts'),
+        `import { Injectable } from '@angular/core';
+         @Injectable() export class DataService {}`,
+      );
+      const comps = await scanComponents(ngDir, ['.ts']);
+      expect(comps.map(c => c.name)).toEqual(['Button']); // not DataService
+      expect(comps[0]?.framework).toBe('angular');
+      expect(comps[0]?.propNames).toEqual(['size']);
+    } finally {
+      await rm(ngDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## What & why

The biggest remaining **generality** gap after react/vue/svelte/solid. Angular projects were previously invisible to `component_map` — the scanner's `componentExtensions` never globbed `.ts`, so a real Angular codebase returned **zero** scanned components. This makes Angular a first-class framework.

### profile
- `@angular/core` in deps → `framework: 'angular'`, `componentExtensions: ['.ts']`.
- `.ts` is Angular-exclusive in this scheme — no other framework globs it, so a service/pipe/guard `.ts` in the sweep simply yields no `@Component` classes.

### scan — `extractAngularComponents` (oxc)
A component is an **exported class carrying `@Component`** (`@Injectable` / `@Directive` / `@Pipe` and plain classes are skipped). Inputs are read across **both eras**:
- Classic `@Input()` — including string (`@Input('variant')`) and object (`@Input({ alias })`) aliases and `set`-accessor inputs.
- Signal inputs — `input()`, `input.required()`, `model()`.

Correctly **excludes** internal `signal()` / `computed()`, queries (`viewChild`/`contentChild`), and `output()` — none is a component prop.

**Standalone vs NgModule** doesn't change detection (both declare with `@Component`); it only changes how codegen imports. The conventional `Component` class-name suffix is stripped so `ButtonComponent` matches a Figma `"Button"` (otherwise the fuzzy match is only ~0.53 → a false `low`).

### Synergy with PR-5a
Two Angular components that strip to the same logical name are caught by the `ambiguousWith` near-tie flag shipped in #65.

## Guarantees
- **持平或更好 / zero regression**: the shared `.ts → angular` dispatch branch is unreachable for react/vue/svelte/solid (they never glob `.ts`). A pure Angular project went from **0 components found → found** — strictly better, no victim.
- Pure server-side scan/profile logic — **no plugin/serializer/wire changes**. AST shapes validated against real `oxc` output.
- Worst-case scan is bounded by the walker's 5000-file cap.

## Tests
+8 (decorator inputs + name strip, signal inputs, aliases + set-accessor, internal-signal/query/output guard, non-component skip, unparseable, real-fs scan skipping a service, profile detection). Full gate suite green: typecheck, lint, format, knip, build, test (917).

## Follow-ups (not blocking)
- Angular-appropriate svg handling (no common Vite-plugin equivalent to add today; `url` mode is a safe default).
- A `*.component.ts`-only glob optimization for very large repos (correctness is already bounded by the cap).