### PR TITLE
feat(styles): update_text_style + update_effect_style (write-side parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **102 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **104 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
@@ -182,7 +182,7 @@ npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-cod
 
 ## Tools
 
-Figwright exposes **102 MCP tools** in three groups:
+Figwright exposes **104 MCP tools** in three groups:
 
 - **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, original image-fill assets, and PDF export.
 - **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components (including authoring their boolean/text/instance-swap properties), pages, and reactions; plus a `batch` tool to apply many edits at once.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **102 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **104 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -105,7 +105,9 @@ import { swapComponentTool } from './swap-component.js';
 import { tokenMapTool } from './token-map.js';
 import { ungroupNodesTool } from './ungroup-nodes.js';
 import { unlockNodesTool } from './unlock-nodes.js';
+import { updateEffectStyleTool } from './update-effect-style.js';
 import { updatePaintStyleTool } from './update-paint-style.js';
+import { updateTextStyleTool } from './update-text-style.js';
 
 /** Every tool the MCP server registers, in ListTools order. */
 export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
@@ -176,6 +178,8 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   createEffectStyleTool,
   createGridStyleTool,
   updatePaintStyleTool,
+  updateTextStyleTool,
+  updateEffectStyleTool,
   applyStyleToNodeTool,
   deleteStyleTool,
   createVariableCollectionTool,

--- a/packages/mcp/src/tools/update-effect-style.ts
+++ b/packages/mcp/src/tools/update-effect-style.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+import { effectItemSchema } from './effect-schema.js';
+import type { ToolSpec } from './spec.js';
+
+export const UPDATE_EFFECT_STYLE_TOOL_NAME = 'update_effect_style';
+
+export const updateEffectStyleTool: ToolSpec = {
+  name: UPDATE_EFFECT_STYLE_TOOL_NAME,
+  description:
+    'Update an existing effect style by id. Any of name / effects / description may be omitted to ' +
+    'leave unchanged; effects, when given, replaces the whole list. Shadows (DROP_SHADOW / ' +
+    'INNER_SHADOW) need color + offset; blurs (LAYER_BLUR / BACKGROUND_BLUR) need radius. Use this ' +
+    'to keep a shared style in sync with code instead of creating a duplicate. Returns { ok, ' +
+    'styleId, name }.',
+  inputShape: {
+    styleId: z.string().describe('Effect style id to update'),
+    name: z.string().optional(),
+    effects: z.array(effectItemSchema).optional().describe('New effects (replaces all)'),
+    description: z.string().optional(),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/update-text-style.ts
+++ b/packages/mcp/src/tools/update-text-style.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const UPDATE_TEXT_STYLE_TOOL_NAME = 'update_text_style';
+
+export const updateTextStyleTool: ToolSpec = {
+  name: UPDATE_TEXT_STYLE_TOOL_NAME,
+  description:
+    'Update an existing text style (typography token) by id. Any of name / fontName / fontSize / ' +
+    'lineHeight / letterSpacing / description may be omitted to leave unchanged. A new font is ' +
+    'loaded before assignment. lineHeight unit is AUTO / PIXELS / PERCENT (AUTO omits value); ' +
+    'letterSpacing unit is PIXELS / PERCENT. Use this to keep a shared style in sync with code ' +
+    'instead of creating a duplicate. Returns { ok, styleId, name }.',
+  inputShape: {
+    styleId: z.string().describe('Text style id to update'),
+    name: z.string().optional(),
+    fontName: z.object({ family: z.string(), style: z.string() }).optional(),
+    fontSize: z.number().optional(),
+    lineHeight: z
+      .object({ unit: z.enum(['AUTO', 'PIXELS', 'PERCENT']), value: z.number().optional() })
+      .optional(),
+    letterSpacing: z.object({ unit: z.enum(['PIXELS', 'PERCENT']), value: z.number() }).optional(),
+    description: z.string().optional(),
+  },
+  kind: 'write',
+};

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -93,7 +93,9 @@ import { createSetVariableValueHandler } from './set-variable-value.js';
 import { createSetVisibleHandler } from './set-visible.js';
 import { createSwapComponentHandler } from './swap-component.js';
 import { createUngroupNodesHandler } from './ungroup-nodes.js';
+import { createUpdateEffectStyleHandler } from './update-effect-style.js';
 import { createUpdatePaintStyleHandler } from './update-paint-style.js';
+import { createUpdateTextStyleHandler } from './update-text-style.js';
 
 /**
  * Build the full sandbox handler map. Read handlers run as-is; write handlers are wrapped with
@@ -141,6 +143,8 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     create_effect_style: createCreateEffectStyleHandler(figmaCtx),
     create_grid_style: createCreateGridStyleHandler(figmaCtx),
     update_paint_style: createUpdatePaintStyleHandler(figmaCtx),
+    update_text_style: createUpdateTextStyleHandler(figmaCtx),
+    update_effect_style: createUpdateEffectStyleHandler(figmaCtx),
     apply_style_to_node: createApplyStyleToNodeHandler(figmaCtx),
     delete_style: createDeleteStyleHandler(figmaCtx),
     // Variables

--- a/packages/plugin/src/handlers/update-effect-style.ts
+++ b/packages/plugin/src/handlers/update-effect-style.ts
@@ -1,0 +1,30 @@
+import type { SerializedEffect, StyleResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { toFigmaEffect } from './convert.js';
+
+export const createUpdateEffectStyleHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as {
+      styleId?: unknown;
+      name?: unknown;
+      effects?: unknown;
+      description?: unknown;
+    };
+    if (typeof p.styleId !== 'string') {
+      throw new TypeError('update_effect_style: styleId must be a string');
+    }
+
+    const style = await figmaCtx.getStyleByIdAsync(p.styleId);
+    if (style === null || style.type !== 'EFFECT') {
+      throw new Error(`update_effect_style: effect style ${p.styleId} not found`);
+    }
+    const es = style as EffectStyle;
+    if (typeof p.name === 'string') es.name = p.name;
+    if (Array.isArray(p.effects)) es.effects = (p.effects as SerializedEffect[]).map(toFigmaEffect);
+    if (typeof p.description === 'string') es.description = p.description;
+
+    const result: StyleResult = { ok: true, styleId: es.id, name: es.name };
+    return result;
+  };

--- a/packages/plugin/src/handlers/update-text-style.ts
+++ b/packages/plugin/src/handlers/update-text-style.ts
@@ -1,0 +1,51 @@
+import type {
+  SerializedFontName,
+  SerializedLetterSpacing,
+  SerializedLineHeight,
+  StyleResult,
+} from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { toFigmaLineHeight } from './convert.js';
+
+export const createUpdateTextStyleHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as {
+      styleId?: unknown;
+      name?: unknown;
+      fontName?: unknown;
+      fontSize?: unknown;
+      lineHeight?: unknown;
+      letterSpacing?: unknown;
+      description?: unknown;
+    };
+    if (typeof p.styleId !== 'string') {
+      throw new TypeError('update_text_style: styleId must be a string');
+    }
+
+    const style = await figmaCtx.getStyleByIdAsync(p.styleId);
+    if (style === null || style.type !== 'TEXT') {
+      throw new Error(`update_text_style: text style ${p.styleId} not found`);
+    }
+    const ts = style as TextStyle;
+    if (typeof p.name === 'string') ts.name = p.name;
+    // A new fontName must be loaded before assignment (Figma throws otherwise). Numeric fields
+    // (fontSize / lineHeight / letterSpacing) don't need a load — they don't touch the glyph set.
+    if (p.fontName !== undefined) {
+      const fn = p.fontName as SerializedFontName;
+      await figmaCtx.loadFontAsync({ family: fn.family, style: fn.style });
+      ts.fontName = { family: fn.family, style: fn.style };
+    }
+    if (typeof p.fontSize === 'number') ts.fontSize = p.fontSize;
+    if (p.lineHeight !== undefined)
+      ts.lineHeight = toFigmaLineHeight(p.lineHeight as SerializedLineHeight);
+    if (p.letterSpacing !== undefined) {
+      const ls = p.letterSpacing as SerializedLetterSpacing;
+      ts.letterSpacing = { unit: ls.unit as 'PIXELS' | 'PERCENT', value: ls.value };
+    }
+    if (typeof p.description === 'string') ts.description = p.description;
+
+    const result: StyleResult = { ok: true, styleId: ts.id, name: ts.name };
+    return result;
+  };

--- a/packages/plugin/test/handlers/update-effect-style.test.ts
+++ b/packages/plugin/test/handlers/update-effect-style.test.ts
@@ -1,0 +1,39 @@
+import type { StyleResult } from '@figwright/shared';
+import { describe, expect, it } from 'vitest';
+
+import { createUpdateEffectStyleHandler } from '../../src/handlers/update-effect-style.js';
+
+const fakeFigma = (style: unknown): typeof figma =>
+  ({ getStyleByIdAsync: async () => style }) as unknown as typeof figma;
+
+describe('update_effect_style handler', () => {
+  it('replaces effects + name and leaves an omitted field unchanged', async () => {
+    const style = {
+      id: 'E:0',
+      type: 'EFFECT',
+      name: 'old',
+      effects: [] as unknown,
+      description: 'keep',
+    };
+    const result = (await createUpdateEffectStyleHandler(fakeFigma(style))({
+      styleId: 'E:0',
+      name: 'Elevation/Card',
+      effects: [{ type: 'LAYER_BLUR', visible: true, radius: 8 }],
+    })) as StyleResult;
+
+    expect(style.name).toBe('Elevation/Card');
+    expect(style.effects).toEqual([{ type: 'LAYER_BLUR', visible: true, radius: 8 }]);
+    expect(style.description).toBe('keep'); // omitted → unchanged
+    expect(result).toEqual({ ok: true, styleId: 'E:0', name: 'Elevation/Card' });
+  });
+
+  it('throws when the style is missing or not an effect style', async () => {
+    await expect(
+      createUpdateEffectStyleHandler(fakeFigma(null))({ styleId: 'E:9' }),
+    ).rejects.toThrow(/not found/);
+    await expect(
+      createUpdateEffectStyleHandler(fakeFigma({ id: 'E:0', type: 'PAINT' }))({ styleId: 'E:0' }),
+    ).rejects.toThrow(/not found/);
+    await expect(createUpdateEffectStyleHandler(fakeFigma(null))({})).rejects.toThrow(/styleId/);
+  });
+});

--- a/packages/plugin/test/handlers/update-text-style.test.ts
+++ b/packages/plugin/test/handlers/update-text-style.test.ts
@@ -1,0 +1,71 @@
+import type { StyleResult } from '@figwright/shared';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createUpdateTextStyleHandler } from '../../src/handlers/update-text-style.js';
+
+const fakeFigma = (
+  style: Record<string, unknown> | null,
+): { figma: typeof figma; loaded: FontName[] } => {
+  const loaded: FontName[] = [];
+  const figmaCtx = {
+    getStyleByIdAsync: async () => style,
+    loadFontAsync: vi.fn<(fn: FontName) => Promise<void>>(async (fn: FontName) => {
+      loaded.push(fn);
+    }),
+  } as unknown as typeof figma;
+  return { figma: figmaCtx, loaded };
+};
+
+describe('update_text_style handler', () => {
+  it('updates given fields (loading a new font first) and leaves omitted ones unchanged', async () => {
+    const style: Record<string, unknown> = {
+      id: 'S:0',
+      type: 'TEXT',
+      name: 'old',
+      fontName: { family: 'Inter', style: 'Regular' },
+      fontSize: 12,
+      lineHeight: { unit: 'AUTO' },
+      letterSpacing: { unit: 'PIXELS', value: 0 },
+      description: 'keep',
+    };
+    const { figma: f, loaded } = fakeFigma(style);
+    const result = (await createUpdateTextStyleHandler(f)({
+      styleId: 'S:0',
+      name: 'Heading/H1',
+      fontName: { family: 'Inter', style: 'Bold' },
+      fontSize: 32,
+      lineHeight: { unit: 'PERCENT', value: 120 },
+    })) as StyleResult;
+
+    expect(loaded).toEqual([{ family: 'Inter', style: 'Bold' }]); // new font loaded before assign
+    expect(style.name).toBe('Heading/H1');
+    expect(style.fontName).toEqual({ family: 'Inter', style: 'Bold' });
+    expect(style.fontSize).toBe(32);
+    expect(style.lineHeight).toEqual({ unit: 'PERCENT', value: 120 });
+    expect(style.letterSpacing).toEqual({ unit: 'PIXELS', value: 0 }); // omitted → unchanged
+    expect(style.description).toBe('keep'); // omitted → unchanged
+    expect(result).toEqual({ ok: true, styleId: 'S:0', name: 'Heading/H1' });
+  });
+
+  it('does not load a font for a numeric-only update (fontName omitted)', async () => {
+    const style: Record<string, unknown> = { id: 'S:0', type: 'TEXT', name: 'x', fontSize: 12 };
+    const { figma: f, loaded } = fakeFigma(style);
+    await createUpdateTextStyleHandler(f)({ styleId: 'S:0', fontSize: 16 });
+    expect(loaded).toEqual([]); // a size-only change touches no glyphs → no font work
+    expect(style.fontSize).toBe(16);
+  });
+
+  it('throws when the style is missing or not a text style', async () => {
+    await expect(
+      createUpdateTextStyleHandler(fakeFigma(null).figma)({ styleId: 'S:9' }),
+    ).rejects.toThrow(/not found/);
+    await expect(
+      createUpdateTextStyleHandler(fakeFigma({ id: 'S:0', type: 'PAINT' }).figma)({
+        styleId: 'S:0',
+      }),
+    ).rejects.toThrow(/not found/);
+    await expect(createUpdateTextStyleHandler(fakeFigma(null).figma)({})).rejects.toThrow(
+      /styleId/,
+    );
+  });
+});

--- a/skills/figma-build/references/author-design-system.md
+++ b/skills/figma-build/references/author-design-system.md
@@ -52,6 +52,11 @@ an orphan collection behind.
   is loaded before assignment; `lineHeight.unit` is `AUTO` / `PIXELS` / `PERCENT` (AUTO omits the
   value).
 - Effect / grid styles have their own create tools.
+- **Editing an existing style** (the design system already has it, and code changed its value): use
+  `update_paint_style` / `update_text_style` / `update_effect_style` (`styleId` + only the fields that
+  changed; omitted fields stay as-is) — **don't** `create_*` a second style with the same name, which
+  leaves a duplicate. Re-syncing a style ramp from code is the common case; `get_styles` gives you the
+  `styleId`s to target.
 
 Apply a style to a node with `apply_style_to_node` (`field`: fill / stroke / effect / grid / text).
 Prefer a **variable** for a single colour/scalar token and a **style** for a reusable multi-property


### PR DESCRIPTION
## What & why

PR-5b — the **頂級雙向 (top-tier bidirectional)** write-parity gap. Paint styles could be updated (`update_paint_style`), but **text and effect styles could only be created**. So re-syncing a shared style from code (a design system evolves, you push it back to Figma) had no way to *edit* the existing style — it left a **duplicate** (`Heading/H1`, `Heading/H1 2`, …). This closes the asymmetry.

### New tools (mirror `update_paint_style`)
- **`update_text_style`** — `styleId` + any of `name` / `fontName` / `fontSize` / `lineHeight` / `letterSpacing` / `description`; omitted fields stay unchanged. A **new** `fontName` is loaded before assignment; numeric fields need no font load (proven by the shipped `create_text_style`, which already sets them without one).
- **`update_effect_style`** — `styleId` + any of `name` / `effects` / `description`; `effects`, when given, replaces the whole list.

Both resolve the style by id via `getStyleByIdAsync` and **reject a missing / wrong-type style** (a paint id passed to `update_text_style` throws, not silently mutates).

### Wiring
Registered in the MCP tool registry + the plugin handler registry → **104 tools** (README counts bumped, guarded by the docs-sync test). `figma-build`'s `author-design-system` reference gains an "edit an existing style, don't `create_*` a duplicate" note so the tools are discoverable.

## Guarantees
- **持平或更好**: purely additive — two new tools, no existing tool or handler changed. Registry edits are additive imports/entries.
- Handlers mirror the audited `update_paint_style` shape exactly.

## Tests
+5 handler tests: field update with font-loaded-only-on-`fontName`, numeric-only update loads no font, effects-replace, omitted-field-preserved, and missing/wrong-type throws. Full gate suite green: typecheck, lint, format, knip, build, test (922).

## Live-smoke note
This is a **write path** (mutates Figma via the plugin), so a live round-trip — create a style, `update_*` it, confirm the edit lands and no duplicate appears — is worth doing before merge. It needs a `/mcp` reconnect first (the new tools ship in the rebuilt dist). The font-load-on-numeric-update uncertainty is already resolved by the shipped `create_text_style`'s behavior, so the smoke is a happy-path confirmation, not a risk probe.