### PR TITLE
docs: reword server description + add Codex, fix repo topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Where Playwright drives the browser, Figwright drives Figma.
 
 ## What is Figwright?
 
-Figwright connects an **MCP server** to a **Figma plugin** over a local WebSocket relay, so an AI agent — Claude Code, Cursor, or any other MCP client — can work _with_ Figma instead of just looking at it.
+Figwright connects an **MCP server** to a **Figma plugin** over a local WebSocket relay, so an AI agent — Claude Code, Cursor, Codex, or any other MCP client — can work _with_ Figma instead of just looking at it.
 
 It works in both directions:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "figwright",
   "version": "0.0.0",
   "private": true,
-  "description": "Free, bidirectional Figma MCP server — turn designs into framework-aware code and write back to the canvas, for Claude Code, Cursor, and any MCP client.",
+  "description": "Free, two-way Figma MCP server. Turn designs into framework-aware code, and push code back to the canvas. Works with Claude Code, Cursor, Codex, and any MCP client.",
   "homepage": "https://github.com/awdr74100/figwright",
   "bugs": {
     "url": "https://github.com/awdr74100/figwright/issues"

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @figwright/mcp
 
-> The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a bidirectional Figma agent for Claude Code and other MCP clients.
+> The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a two-way Figma agent for Claude Code, Cursor, Codex, and other MCP clients.
 
 Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **104 tools** spanning reads, writes, and codebase-grounded context.
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@figwright/mcp",
   "version": "0.2.0",
-  "description": "Free, bidirectional Figma MCP server — turn designs into framework-aware code and write back to the canvas, for Claude Code, Cursor, and any MCP client.",
+  "description": "Free, two-way Figma MCP server. Turn designs into framework-aware code, and push code back to the canvas. Works with Claude Code, Cursor, Codex, and any MCP client.",
   "keywords": [
     "claude-code",
     "codegen",
+    "codex",
     "cursor",
     "design-to-code",
     "design-tokens",


### PR DESCRIPTION
## What

Reword the server description so it reads less AI-generated, and widen client coverage for discoverability.

### Description copy
Old:
> Free, bidirectional Figma MCP server — turn designs into framework-aware code and write back to the canvas, for Claude Code, Cursor, and any MCP client.

New:
> Free, two-way Figma MCP server. Turn designs into framework-aware code, and push code back to the canvas. Works with Claude Code, Cursor, Codex, and any MCP client.

- Drop the em dash and `bidirectional` (the two biggest AI tells); split into short sentences.
- Keep the MCP-client compatibility line — it's the highest-signal bit for the target audience.
- Add **Codex** alongside Cursor (added, not swapped — Cursor is the higher-volume term).

### Files touched
- `package.json` (root) — description
- `packages/mcp/package.json` — description + `codex` keyword
- `README.md` — Codex added to the intro client list
- `packages/mcp/README.md` — `bidirectional` → `two-way`, subtitle now names Cursor + Codex

## Applied live (not in this diff — repo settings, not files)
- **GitHub About description** updated to match.
- **Topics** fixed: removed the typo `model-control-protocol`, added `model-context-protocol`, `cursor`, `figma-mcp`, `codex`.

## Notes
- The `packages/mcp` description + keyword only reach the npm page on the next `pnpm release`; GitHub + About are already live.