### PR TITLE
chore(github): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: '🐛 Bug report'
+description: Report a problem with Figwright
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Before submitting, please check the [README](https://github.com/awdr74100/figwright#readme) and [existing issues](https://github.com/awdr74100/figwright/issues?q=is%3Aissue) to avoid duplicates.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is — what you expected to happen and what actually happened. If you intend to submit a PR for this issue, tell us in the description.
+      placeholder: I am doing ... I expect ... but what actually happens is ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Step-by-step instructions to reproduce the behavior, including the prompt / tool call you used. For design-related bugs (wrong grounding output, broken canvas writes), describe the Figma structure involved — or better, share a link to a minimal Figma file or a screenshot of the layer tree.
+      placeholder: |
+        1. Connect the plugin to file ...
+        2. Ask the agent to ...
+        3. The `get_design_context` output is missing ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected part
+      description: Which part of Figwright does this seem to affect?
+      options:
+        - MCP server (@figwright/mcp)
+        - Figma plugin
+        - Grounding maps (component / token / icon map)
+        - Codegen (figma-codegen skill / figma_to_code prompt)
+        - Relay / connection (WebSocket, election, reconnects)
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: mcp-client
+    attributes:
+      label: MCP client
+      description: The client you run the server from
+      options:
+        - Claude Code
+        - Claude Desktop
+        - Codex
+        - Cursor
+        - VS Code (Copilot)
+        - Other (specify in Environment)
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Figwright version (`npm ls @figwright/mcp` or the version shown in the plugin), Node version (`node -v`), OS, and whether you use the Figma desktop app or browser.
+      render: shell
+      placeholder: |
+        Figwright: 0.3.0
+        Node: 24.x
+        OS: macOS 15
+        Figma: desktop app
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant output from your MCP client and/or the plugin's Debug tab. Please copy-paste text instead of screenshots where possible.
+
+        ````
+        <details>
+        <summary>Click to expand</summary>
+
+        ```shell
+        // paste the log text here
+        ```
+        </details>
+        ````
+  - type: checkboxes
+    id: validations
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/awdr74100/figwright/issues?q=is%3Aissue) that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: Check that the bug still reproduces on the latest version of `@figwright/mcp` and the matching plugin build.
+          required: true
+        - label: Read the [Contributing Guidelines](https://github.com/awdr74100/figwright/blob/main/CONTRIBUTING.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & setup help
+    url: https://github.com/awdr74100/figwright#readme
+    about: Check the README first — it covers installation, quick start, and supported MCP clients.
+  - name: 📚 Model Context Protocol docs
+    url: https://modelcontextprotocol.io
+    about: For general questions about MCP itself (not Figwright-specific).

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,27 @@
+name: '📖 Documentation'
+description: Report missing, unclear, or incorrect documentation
+labels: ['documentation']
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Which document or section is affected (README, CONTRIBUTING, AGENTS.md, a tool description, …)?
+      placeholder: README.md — Quick start
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+      description: What is missing, unclear, or incorrect — and what would you expect to find instead?
+    validations:
+      required: true
+  - type: checkboxes
+    id: validations
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/awdr74100/figwright/issues?q=is%3Aissue) that reports the same problem to avoid creating a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: '🚀 Feature request'
+description: Propose a new feature or improvement for Figwright
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in the project!
+
+        Figwright is **provider-first** and aims for **generality** — proposals that make a wide range of real designs work better are prioritized over narrow, one-off additions.
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Problem description
+      description: Describe the problem you're trying to solve, not just the solution. What are you doing, and where does Figwright fall short? If you intend to submit a PR for this feature, tell us in the description.
+      placeholder: As a developer using Figwright I want [goal] so that [benefit].
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-solution
+    attributes:
+      label: Suggested solution
+      description: How you imagine this working — a new tool, a change to an existing tool's output, a plugin capability, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context, examples, or screenshots — e.g. a real design or codebase pattern this would help with.
+  - type: checkboxes
+    id: validations
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/awdr74100/figwright/issues?q=is%3Aissue) that requests the same feature to avoid creating a duplicate.
+          required: true
+        - label: Read the [Contributing Guidelines](https://github.com/awdr74100/figwright/blob/main/CONTRIBUTING.md).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Thank you for contributing to Figwright!
+
+Before opening the PR, please make sure:
+- The PR title follows Conventional Commits (`feat: …`, `fix: …`, `docs: …`).
+  It is validated by CI, and with squash merges it becomes the commit on
+  `main` and drives the changelog — write it carefully.
+- For anything non-trivial, an issue was opened first to agree on the
+  approach (see CONTRIBUTING.md).
+-->
+
+## Description
+
+<!--
+What is this PR solving, and why? Keep it clear and concise.
+Link the issues it resolves, e.g. `Fixes #123`.
+-->
+
+## Checklist
+
+- [ ] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test`
+- [ ] Tests are added or updated for any behavior change (in `test/` mirroring `src/`; cross-package tests in the root `test/`)
+- [ ] Read-path / serializer changes are verified with a live round-trip against a real Figma file (plugin connected, running the built `dist`)
+- [ ] Documentation is updated if needed (README, AGENTS.md, tool descriptions)


### PR DESCRIPTION
## Description

The repo had no issue or PR templates, so every contributor (human or agent) wrote reports and PRs in their own style. This standardizes both, following the conventions used by large modern OSS projects (Vite, Vitest, Next.js):

**Issue forms** (`.github/ISSUE_TEMPLATE/`, GitHub YAML issue forms — not legacy markdown):

- **🐛 Bug report** — required description + repro steps, an *Affected part* dropdown matching Figwright's architecture (MCP server / plugin / grounding maps / codegen / relay), an *MCP client* dropdown, a structured environment block, collapsible logs, and duplicate-check validations. Auto-labels `bug`.
- **🚀 Feature request** — problem-first (echoes CONTRIBUTING's provider-first / generality stance), suggested solution, alternatives. Auto-labels `enhancement`.
- **📖 Documentation** — location + problem. Auto-labels `documentation`.
- **config.yml** — disables blank issues; contact links point to the README and MCP docs (Discussions is not enabled on this repo).

**PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) — description prompt plus a checklist tied to this repo's actual gates: Conventional Commits PR title (semantic-pr + squash merge), the canonical local check chain, test placement rules, live Figma round-trip for read-path/serializer changes, and docs updates.

Only labels that already exist in the repo are referenced, and no `type:` fields are used (issue types aren't available on user-owned repos).

## Checklist

- [x] The canonical checks pass locally (`format:check` / `lint`; no runtime code touched)
- [x] Tests — n/a, no behavior change
- [x] Live round-trip — n/a, no read-path changes
- [x] Documentation — n/a