### PR TITLE
fix(mcp): eliminate zombie leaders via shutdown hardening and newest-build-wins election

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is the canonical guide for AI agents and contributors working in this 
 
 Two halves talk over a local WebSocket relay:
 
-- **MCP server** (`packages/mcp`, published as `@figwright/mcp`) — the Node process an MCP client launches. It exposes 80+ read/write tools, plus higher-level **grounding** tools that join Figma data with the user's codebase (component / token / icon maps) and a codegen prompt. It owns the relay, leader/follower **election** (multiple MCP servers can share one plugin), and request **idempotency**.
+- **MCP server** (`packages/mcp`, published as `@figwright/mcp`) — the Node process an MCP client launches. It exposes 80+ read/write tools, plus higher-level **grounding** tools that join Figma data with the user's codebase (component / token / icon maps) and a codegen prompt. It owns the relay, leader/follower **election** (multiple MCP servers can share one plugin; **newest build wins** — a leader on an older build abdicates to a newer one at the next idle moment), and request **idempotency**.
 - **Figma plugin** (`packages/plugin`) — a Vue 3 + Vite UI plus a sandbox that runs inside Figma and performs the actual Figma API calls. It connects out to the server's WebSocket.
 - **Shared** (`packages/shared`) — types, Zod schemas, the msgpack wire codec, and the plugin↔server protocol. It is **bundled into the server at build time** (not published on its own).
 

--- a/packages/mcp/src/build-id.ts
+++ b/packages/mcp/src/build-id.ts
@@ -1,0 +1,16 @@
+/**
+ * Build timestamp (epoch ms) baked into the bundle by tsdown (see tsdown.config.ts `define`).
+ * Newest-build-wins election orders server processes by it: a follower running a strictly newer
+ * build asks a stale leader to abdicate (see election/election.ts), which is what keeps a
+ * long-lived old process — another session's server, or one launched by hand — from serving stale
+ * code forever. Published releases get their publish-time build stamp, so the ordering holds across
+ * versions too, without parsing semver.
+ *
+ * When running unbundled (vitest, tsx) the define is absent and this is 0: an unbundled process
+ * never claims to be newer than a real build, and two 0s never trigger an abdication.
+ */
+// eslint-disable-next-line no-underscore-dangle -- dunder marks a compile-time define, per convention
+declare const __FIGWRIGHT_BUILD_ID__: string | undefined;
+
+export const BUILD_ID: number =
+  typeof __FIGWRIGHT_BUILD_ID__ === 'string' ? Number(__FIGWRIGHT_BUILD_ID__) : 0;

--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -91,8 +91,12 @@ export const dispatchTool = async (
     );
     if (resp.kind === 'ok') return resp.result;
 
+    // 'relay stopping' is the leader rejecting the call because it's shutting down or abdicating —
+    // by the retry delay a new leader (possibly this very node) has the port, so it's as transient
+    // as a dropped connection. Safe to replay: writes carry a stable requestId the plugin dedupes.
     const isTransient =
-      resp.code === ErrorCode.Internal && /transport|fetch failed|ECONNREFUSED/i.test(resp.message);
+      resp.code === ErrorCode.Internal &&
+      /transport|fetch failed|ECONNREFUSED|relay stopping/i.test(resp.message);
     if (!isTransient || attempt === maxAttempts - 1) {
       throw new DispatchError(resp.code, resp.message);
     }

--- a/packages/mcp/src/election/election.ts
+++ b/packages/mcp/src/election/election.ts
@@ -4,9 +4,33 @@ import { isAddressInUse, type Node, NodeRole } from './node.js';
 export const DEFAULT_TICK_INTERVAL_MS = 1_000;
 const RACE_RETRY_DELAY_MS = 50;
 
+/**
+ * After abdicating, how long this node sits out dead-leader takeovers. The challenger grabs the
+ * port within milliseconds of the release, but until it does, our own tick would see "leader
+ * unresponsive" and re-bind — undoing the handoff we just granted. If the challenger dies before
+ * binding, this expires and normal takeover resumes (brief outage, then self-heal).
+ */
+export const YIELD_GRACE_MS = 5_000;
+
+/**
+ * After a 'refused' or 'unsupported' abdication answer, how long to stop asking. Neither outcome
+ * changes on the next 1s tick (an old leader won't grow the endpoint), so re-asking every tick is
+ * pure log noise; a full minute later is soon enough to notice a replaced leader.
+ */
+export const ABDICATION_BACKOFF_MS = 60_000;
+
+/** How eagerly the challenger grabs the port a leader just released for it (~ms handoff). */
+const ABDICATION_GRAB_ATTEMPTS = 20;
+const ABDICATION_GRAB_DELAY_MS = 50;
+
 export interface ElectionOptions {
   node: Node;
   follower: Follower;
+  /**
+   * This process's build stamp (see build-id.ts); drives newest-build-wins. Default 0 (never
+   * challenges).
+   */
+  buildId?: number;
   tickIntervalMs?: number;
   log?: (msg: string) => void;
 }
@@ -14,14 +38,19 @@ export interface ElectionOptions {
 export class Election {
   private readonly node: Node;
   private readonly follower: Follower;
+  private readonly buildId: number;
   private readonly tickIntervalMs: number;
   private readonly log: (msg: string) => void;
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
+  private tickInFlight = false;
+  private yieldUntil = 0;
+  private abdicationBackoffUntil = 0;
 
   constructor(opts: ElectionOptions) {
     this.node = opts.node;
     this.follower = opts.follower;
+    this.buildId = opts.buildId ?? 0;
     this.tickIntervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS;
     this.log = opts.log ?? ((): void => {});
   }
@@ -88,7 +117,33 @@ export class Election {
     return false;
   }
 
+  /**
+   * Release leadership because a newer build asked for it (wired to the /abdicate endpoint).
+   * Demotes to follower and opens the yield window so this node's own tick doesn't immediately
+   * re-take the port it just released. Safe to call in any state (no-op unless leading).
+   */
+  yieldLeadership(): void {
+    if (!this.node.isLeader()) return;
+    this.yieldUntil = Date.now() + YIELD_GRACE_MS;
+    this.node.becomeFollower();
+    this.log('[election] abdicated — a newer build is taking over');
+  }
+
   private async tick(): Promise<void> {
+    // A tick can outlive the interval (leaderInfo's ping timeout is 2s, the post-abdication grab
+    // loop ~1s, vs 1s ticks). Every stacked interleaving is idempotent and converges, but skipping
+    // is strictly simpler to reason about than proving that: one tick in flight at a time, and a
+    // tick is bounded (~3s worst case), so the next one is never starved.
+    if (this.tickInFlight) return;
+    this.tickInFlight = true;
+    try {
+      await this.tickBody();
+    } finally {
+      this.tickInFlight = false;
+    }
+  }
+
+  private async tickBody(): Promise<void> {
     if (this.node.role === NodeRole.Conflicted) {
       // Keep contending: the squatter may release the port, or a real Figwright leader may appear.
       // tryLeadOrFollow promotes us the moment either happens; otherwise we stay conflicted.
@@ -98,7 +153,21 @@ export class Election {
 
     if (this.node.role !== NodeRole.Follower) return;
 
-    if (await this.follower.ping()) return;
+    const leader = await this.follower.leaderInfo();
+    if (leader !== undefined) {
+      // Healthy leader — but if it runs a strictly older build than us, it's serving stale code
+      // (the "zombie leader" a rebuild leaves behind when an old process still owns the port).
+      // Newest build wins: ask it to step down and take over. Same single /ping round-trip as the
+      // old health check.
+      if (this.buildId > (leader.buildId ?? 0) && Date.now() >= this.abdicationBackoffUntil) {
+        await this.challengeStaleLeader();
+      }
+      return;
+    }
+
+    // We just granted an abdication: the challenger is grabbing the port, so a failed ping in this
+    // window is the handoff, not a dead leader. Don't undo it by re-binding.
+    if (Date.now() < this.yieldUntil) return;
 
     this.log('[election] leader unresponsive — attempting takeover');
     try {
@@ -110,5 +179,41 @@ export class Election {
         this.log(`[election] takeover failed: ${(err as Error).message}`);
       }
     }
+  }
+
+  /**
+   * The leader runs a strictly older build: ask it to abdicate, and on acceptance grab the port it
+   * releases. Losing the grab race is fine — whoever won is either newer than us (we're done) or
+   * older (we challenge again on a later tick); the lattice converges on the newest build.
+   */
+  private async challengeStaleLeader(): Promise<void> {
+    const outcome = await this.follower.requestAbdication(this.buildId);
+    if (outcome === 'busy' || outcome === 'error') return; // retry naturally on a later tick
+    if (outcome === 'refused' || outcome === 'unsupported') {
+      this.abdicationBackoffUntil = Date.now() + ABDICATION_BACKOFF_MS;
+      this.log(
+        outcome === 'unsupported'
+          ? '[election] stale leader predates abdication — it must be retired manually (see ping)'
+          : '[election] abdication refused — leader no longer older; backing off',
+      );
+      return;
+    }
+
+    this.log('[election] stale leader is abdicating — grabbing the port');
+    /* eslint-disable no-await-in-loop -- deliberate short retry loop over the handoff window */
+    for (let attempt = 0; attempt < ABDICATION_GRAB_ATTEMPTS; attempt += 1) {
+      try {
+        await this.node.becomeLeader();
+        return;
+      } catch (err) {
+        if (!isAddressInUse(err)) {
+          this.log(`[election] post-abdication takeover failed: ${(err as Error).message}`);
+          return;
+        }
+      }
+      await new Promise<void>(resolve => setTimeout(resolve, ABDICATION_GRAB_DELAY_MS));
+    }
+    /* eslint-enable no-await-in-loop */
+    this.log('[election] post-abdication grab lost — another node took the port');
   }
 }

--- a/packages/mcp/src/election/follower.ts
+++ b/packages/mcp/src/election/follower.ts
@@ -7,10 +7,27 @@ import {
 } from '@figwright/shared';
 import { decode, encode } from '@msgpack/msgpack';
 
-import { PING_PATH, RPC_PATH } from './leader-endpoints.js';
+import { ABDICATE_PATH, PING_PATH, RPC_PATH } from './leader-endpoints.js';
 
 export const DEFAULT_FOLLOWER_RPC_TIMEOUT_MS = 35_000;
 export const DEFAULT_PING_TIMEOUT_MS = 2_000;
+
+/** What a confirmed Figwright leader reports about itself over /ping (see leader-endpoints). */
+export interface LeaderInfo {
+  serverVersion: string;
+  /** Build stamp of the leader's bundle; undefined on leaders that predate build ids. */
+  buildId: number | undefined;
+}
+
+/**
+ * Outcome of asking the leader to step down for this (newer-build) node: - 'ok' — leader accepted
+ * and is releasing the port; grab it now. - 'busy' — leader has (or just had) tool traffic; retry
+ * on a later tick. - 'refused' — leader says we're not actually newer; stop asking for a while. -
+ * 'unsupported' — leader predates the /abdicate endpoint; only a human can retire it. - 'error' —
+ * transport-level failure; treat like an unhealthy leader and let the normal dead-leader takeover
+ * path handle it.
+ */
+export type AbdicationOutcome = 'ok' | 'busy' | 'refused' | 'unsupported' | 'error';
 
 export type FetchFn = typeof globalThis.fetch;
 
@@ -39,24 +56,77 @@ export class Follower {
     return this.opts.leaderUrl;
   }
 
-  async ping(): Promise<boolean> {
+  /**
+   * One GET /ping, parsed to the raw JSON body (or undefined on any transport/HTTP/parse failure).
+   * Single source for every /ping-derived read below, so timeout and error semantics can't drift
+   * between them.
+   */
+  private async fetchPing(): Promise<Record<string, unknown> | undefined> {
     try {
       const res = await this.opts.fetch(`${this.opts.leaderUrl}${PING_PATH}`, {
         signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
       });
-      if (!res.ok) return false;
-      // Confirm the responder is actually a figwright leader, not some unrelated process that happens
-      // to hold the port and answer 200 — otherwise this node would attach as a follower and every
-      // RPC it forwards would fail. The leader's /ping returns { ok: true, serverVersion, … }.
+      if (!res.ok) return undefined;
       const body: unknown = await res.json();
-      return (
-        typeof body === 'object' &&
-        body !== null &&
-        (body as { ok?: unknown }).ok === true &&
-        typeof (body as { serverVersion?: unknown }).serverVersion === 'string'
-      );
+      return typeof body === 'object' && body !== null
+        ? (body as Record<string, unknown>)
+        : undefined;
     } catch {
-      return false;
+      return undefined;
+    }
+  }
+
+  async ping(): Promise<boolean> {
+    // Confirm the responder is actually a figwright leader, not some unrelated process that happens
+    // to hold the port and answer 200 — otherwise this node would attach as a follower and every
+    // RPC it forwards would fail. The leader's /ping returns { ok: true, serverVersion, … }.
+    const body = await this.fetchPing();
+    return body !== undefined && body.ok === true && typeof body.serverVersion === 'string';
+  }
+
+  /**
+   * Ping(), but returning what the confirmed leader reports about itself — the election tick uses
+   * the buildId to spot a stale-build leader worth challenging. undefined exactly when ping() would
+   * be false, so callers can use it as the health check and the info read in one round-trip.
+   */
+  async leaderInfo(): Promise<LeaderInfo | undefined> {
+    const body = await this.fetchPing();
+    if (body === undefined || body.ok !== true || typeof body.serverVersion !== 'string') {
+      return undefined;
+    }
+    return {
+      serverVersion: body.serverVersion,
+      buildId: typeof body.buildId === 'number' ? body.buildId : undefined,
+    };
+  }
+
+  /**
+   * Ask the leader to step down because this node runs a strictly newer build. On 'ok' the leader
+   * releases the port right after its reply flushes, so the caller should immediately contend for
+   * it (see Election.challengeStaleLeader).
+   */
+  async requestAbdication(buildId: number): Promise<AbdicationOutcome> {
+    try {
+      const res = await this.opts.fetch(`${this.opts.leaderUrl}${ABDICATE_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ buildId }),
+        signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
+      });
+      // A leader that predates the endpoint 404s ("not found" catch-all) — it can't be retired
+      // programmatically, only by a human killing it (ping's buildSkew message covers that).
+      if (res.status === 404) return 'unsupported';
+      if (!res.ok) return 'error';
+      const body: unknown = await res.json();
+      if (typeof body !== 'object' || body === null) return 'error';
+      if ((body as { ok?: unknown }).ok === true) return 'ok';
+      const reason = (body as { reason?: unknown }).reason;
+      if (reason === 'busy') return 'busy';
+      if (reason === 'stale') return 'refused';
+      if (reason === 'unsupported') return 'unsupported';
+      return 'error';
+    } catch {
+      return 'error';
     }
   }
 
@@ -67,43 +137,9 @@ export class Follower {
    * behavior.
    */
   async resolveActiveSession(): Promise<string | undefined> {
-    try {
-      const res = await this.opts.fetch(`${this.opts.leaderUrl}${PING_PATH}`, {
-        signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
-      });
-      if (!res.ok) return undefined;
-      const body: unknown = await res.json();
-      const id =
-        typeof body === 'object' && body !== null
-          ? (body as { activeSessionId?: unknown }).activeSessionId
-          : undefined;
-      return typeof id === 'string' ? id : undefined;
-    } catch {
-      return undefined;
-    }
-  }
-
-  /**
-   * Read the leader's reported serverVersion (from its /ping). Lets the ping tool surface a
-   * leader/follower version skew — e.g. a stale older leader process still owns the plugin while a
-   * newer client attaches as a follower (so ping reports the new version but the work runs on the
-   * old one). Returns undefined on any failure — purely informational, never gates routing.
-   */
-  async resolveLeaderVersion(): Promise<string | undefined> {
-    try {
-      const res = await this.opts.fetch(`${this.opts.leaderUrl}${PING_PATH}`, {
-        signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
-      });
-      if (!res.ok) return undefined;
-      const body: unknown = await res.json();
-      const version =
-        typeof body === 'object' && body !== null
-          ? (body as { serverVersion?: unknown }).serverVersion
-          : undefined;
-      return typeof version === 'string' ? version : undefined;
-    } catch {
-      return undefined;
-    }
+    const body = await this.fetchPing();
+    const id = body?.activeSessionId;
+    return typeof id === 'string' ? id : undefined;
   }
 
   async sendRpc(

--- a/packages/mcp/src/election/leader-endpoints.ts
+++ b/packages/mcp/src/election/leader-endpoints.ts
@@ -7,12 +7,31 @@ import type { Relay } from '../relay/relay.js';
 
 export const PING_PATH = '/ping';
 export const RPC_PATH = '/rpc';
+export const ABDICATE_PATH = '/abdicate';
+
+/**
+ * Refuse to abdicate while relay traffic is this recent, even with nothing in flight: a multi-call
+ * tool has idle gaps _between_ its pinned sub-calls, and a handoff inside one of those gaps would
+ * strand the remaining sub-calls on the takeover window. A stale leader with an agent actively
+ * working through it steps down at the next lull instead.
+ */
+export const ABDICATE_QUIET_WINDOW_MS = 10_000;
 
 export interface LeaderEndpointDeps {
   relay: Relay;
   serverVersion: string;
+  /** This process's build stamp (see build-id.ts); advertised on /ping, compared on /abdicate. */
+  buildId?: number;
+  /**
+   * Release leadership (called after an accepted /abdicate response has flushed). Wired to
+   * Election.yieldLeadership in production; leaving it unset makes /abdicate answer 'unsupported',
+   * which followers treat like a pre-abdication leader.
+   */
+  onAbdicate?: () => void;
   log?: (msg: string) => void;
   rpcTimeoutMs?: number;
+  /** Test override for ABDICATE_QUIET_WINDOW_MS. */
+  abdicateQuietWindowMs?: number;
 }
 
 const readBody = (req: IncomingMessage): Promise<Buffer> =>
@@ -51,11 +70,64 @@ export const attachLeaderEndpoints = (http: HttpServer, deps: LeaderEndpointDeps
       writeJson(res, 200, {
         ok: true,
         serverVersion,
+        // Build stamp for newest-build-wins election; 0 marks an unbundled process (never treated
+        // as newer than a real build).
+        buildId: deps.buildId ?? 0,
         plugins: relay.sessions.connected().length,
         // Lets a follower resolve the leader's current routing target once, then pin a multi-call
         // tool's sub-calls to it. Absent/undefined when no plugin is connected.
         activeSessionId: relay.pickActiveSessionId() ?? null,
       });
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === ABDICATE_PATH) {
+      void (async (): Promise<void> => {
+        let requesterBuildId: unknown;
+        try {
+          const body: unknown = JSON.parse((await readBody(req)).toString('utf8'));
+          requesterBuildId =
+            typeof body === 'object' && body !== null
+              ? (body as { buildId?: unknown }).buildId
+              : undefined;
+        } catch {
+          writeJson(res, 400, { ok: false, reason: 'invalid' });
+          return;
+        }
+        if (typeof requesterBuildId !== 'number' || !Number.isFinite(requesterBuildId)) {
+          writeJson(res, 400, { ok: false, reason: 'invalid' });
+          return;
+        }
+
+        // Only a strictly newer build may retire this leader — the requester decided the same from
+        // our /ping, so this re-check just closes the race where we were rebuilt/replaced between
+        // its read and this request.
+        if (requesterBuildId <= (deps.buildId ?? 0)) {
+          writeJson(res, 200, { ok: false, reason: 'stale' });
+          return;
+        }
+
+        if (deps.onAbdicate === undefined) {
+          writeJson(res, 200, { ok: false, reason: 'unsupported' });
+          return;
+        }
+
+        const quietWindowMs = deps.abdicateQuietWindowMs ?? ABDICATE_QUIET_WINDOW_MS;
+        const lastRequestAt = relay.lastRequestAt();
+        const busy =
+          relay.pendingCount() > 0 ||
+          (lastRequestAt !== 0 && Date.now() - lastRequestAt < quietWindowMs);
+        if (busy) {
+          writeJson(res, 200, { ok: false, reason: 'busy' });
+          return;
+        }
+
+        log(`[leader] abdicating to a newer build (${requesterBuildId} > ${deps.buildId ?? 0})`);
+        // Release only after the acceptance has flushed to the requester, so it knows to grab the
+        // port the moment it frees — keeping the handoff gap to milliseconds.
+        res.once('finish', () => deps.onAbdicate?.());
+        writeJson(res, 200, { ok: true });
+      })();
       return;
     }
 

--- a/packages/mcp/src/election/node.ts
+++ b/packages/mcp/src/election/node.ts
@@ -111,14 +111,7 @@ export class Node {
 
   becomeFollower(): void {
     if (this.currentRole === NodeRole.Follower) return;
-    if (this.leader !== null) {
-      const { http, relay } = this.leader;
-      this.leader = null;
-      void relay.stop().catch(() => {
-        /* ignore */
-      });
-      http.close();
-    }
+    this.releaseLeader();
     this.setRole(NodeRole.Follower);
     this.opts.log(`[node] became FOLLOWER (leader @ ${this.leaderUrl})`);
   }
@@ -131,14 +124,7 @@ export class Node {
    */
   becomeConflicted(): void {
     if (this.currentRole === NodeRole.Conflicted) return;
-    if (this.leader !== null) {
-      const { http, relay } = this.leader;
-      this.leader = null;
-      void relay.stop().catch(() => {
-        /* ignore */
-      });
-      http.close();
-    }
+    this.releaseLeader();
     this.setRole(NodeRole.Conflicted);
     this.opts.log(`[node] PORT CONFLICT — :${this.opts.port} is held by a non-Figwright process`);
   }
@@ -159,10 +145,36 @@ export class Node {
       const { http, relay } = this.leader;
       this.leader = null;
       await relay.stop();
-      await new Promise<void>(resolve => http.close(() => resolve()));
+      await new Promise<void>(resolve => {
+        http.close(() => resolve());
+        // close() waits for in-flight requests to finish before its callback fires (idle keep-alive
+        // connections it closes itself on Node ≥19). A follower /rpc landing in this shutdown window
+        // sits on the now-stopped relay until its tool budget (up to minutes) expires — during which
+        // this stop() hasn't resolved, process.exit is never reached, and the process lingers as a
+        // zombie leader still answering /ping on live connections (so no follower takes over).
+        // Sever everything so stop completes and takeover is immediate.
+        http.closeAllConnections();
+      });
     }
     this.currentRole = NodeRole.Unknown;
     this.listeners.clear();
+  }
+
+  /**
+   * Tear down leader resources on demotion (follower/conflicted). Fire-and-forget by design — the
+   * demoted role must not wait on the old relay draining. closeAllConnections severs in-flight
+   * connections for the same reason as stop(): close() alone would keep serving them off a server
+   * that no longer leads until their (possibly minutes-long) tool budgets expire.
+   */
+  private releaseLeader(): void {
+    if (this.leader === null) return;
+    const { http, relay } = this.leader;
+    this.leader = null;
+    void relay.stop().catch(() => {
+      /* ignore */
+    });
+    http.close();
+    http.closeAllConnections();
   }
 
   private setRole(role: NodeRole): void {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 
 import pkg from '../package.json' with { type: 'json' };
+import { BUILD_ID } from './build-id.js';
 import { dispatchTool, resolveRoutingSession } from './dispatch.js';
 import { Election } from './election/election.js';
 import { Follower } from './election/follower.js';
@@ -35,9 +36,15 @@ const log = (msg: string): void => {
   process.stderr.write(`${msg}\n`);
 };
 
-const node = new Node({ serverVersion: SERVER_VERSION, port: DEFAULT_PORT, log });
+// FIGWRIGHT_PORT is a test/debug seam (the process-lifecycle e2e spawns real servers on a random
+// port). The plugin always connects to DEFAULT_PORT, so overriding this in normal use just makes
+// the server unreachable — hence undocumented.
+const envPort = Number(process.env.FIGWRIGHT_PORT);
+const PORT = Number.isInteger(envPort) && envPort > 0 && envPort < 65_536 ? envPort : DEFAULT_PORT;
+
+const node = new Node({ serverVersion: SERVER_VERSION, port: PORT, log });
 const follower = new Follower({ leaderUrl: node.leaderUrl, log });
-const election = new Election({ node, follower, log });
+const election = new Election({ node, follower, buildId: BUILD_ID, log });
 
 let currentDetach: (() => void) | null = null;
 node.onRoleChange(role => {
@@ -51,6 +58,10 @@ node.onRoleChange(role => {
       currentDetach = attachLeaderEndpoints(res.http, {
         relay: res.relay,
         serverVersion: SERVER_VERSION,
+        buildId: BUILD_ID,
+        // Newest build wins: a follower on a newer build asks us to step down; the port frees for
+        // it within ms and the plugin reconnects to the new leader on its next retry (~250ms).
+        onAbdicate: () => election.yieldLeadership(),
         log,
       });
     }
@@ -88,7 +99,13 @@ const SPECIAL_HANDLERS: Record<string, ToolHandler> = {
       {
         type: 'text',
         text: formatPingResult(
-          await handlePing({ node, follower, serverVersion: SERVER_VERSION, log }),
+          await handlePing({
+            node,
+            follower,
+            serverVersion: SERVER_VERSION,
+            buildId: BUILD_ID,
+            log,
+          }),
         ),
       },
     ],
@@ -160,9 +177,9 @@ const transport = new StdioServerTransport();
 await mcp.connect(transport);
 
 const roleDetail = node.isLeader()
-  ? `relay on :${node.getLeader()?.port ?? DEFAULT_PORT}`
+  ? `relay on :${node.getLeader()?.port ?? PORT}`
   : node.isConflicted()
-    ? `:${DEFAULT_PORT} held by a non-Figwright process — contending for it`
+    ? `:${PORT} held by a non-Figwright process — contending for it`
     : `follower → ${node.leaderUrl}`;
 log(
   `[figwright] server ${SERVER_VERSION} (protocol ${PROTOCOL_VERSION}) ready as ${node.role}, ${roleDetail}`,
@@ -176,4 +193,14 @@ const shutdown = async (): Promise<void> => {
 // Exit on SIGINT/SIGTERM and on stdin EOF. stdin closes when the client that spawned us goes away
 // (including a crash that sends no signal); without this the process would linger holding the relay
 // port as a stale "zombie" leader serving an old build. wireShutdown runs shutdown at most once.
-wireShutdown({ proc: process, stdin: process.stdin, shutdown });
+// hardExit is the backstop for the graceful path itself stalling (e.g. a close waiting on
+// connections that never drain) — exit code 1 marks the forced, non-clean variant.
+wireShutdown({
+  proc: process,
+  stdin: process.stdin,
+  shutdown,
+  hardExit: () => {
+    log('[figwright] graceful shutdown stalled — forcing exit');
+    process.exit(1);
+  },
+});

--- a/packages/mcp/src/lifecycle.ts
+++ b/packages/mcp/src/lifecycle.ts
@@ -1,5 +1,7 @@
 type Listenable = Pick<NodeJS.EventEmitter, 'on'>;
 
+export const DEFAULT_HARD_EXIT_DELAY_MS = 5_000;
+
 export interface ShutdownWiring {
   /** The process, for SIGINT / SIGTERM. */
   proc: Listenable;
@@ -7,6 +9,14 @@ export interface ShutdownWiring {
   stdin: Listenable;
   /** Performs the actual graceful shutdown; invoked at most once. */
   shutdown: () => void | Promise<void>;
+  /**
+   * Backstop invoked if the graceful shutdown hasn't exited the process within hardExitDelayMs of
+   * the trigger (e.g. process.exit). A graceful path that stalls on an undrainable resource would
+   * otherwise leave the process alive forever as a zombie. The timer is unref'd so it never keeps
+   * an otherwise-finished process running.
+   */
+  hardExit?: () => void;
+  hardExitDelayMs?: number;
 }
 
 /**
@@ -19,12 +29,28 @@ export interface ShutdownWiring {
  * "zombie" leader serving an old build. stdin 'end' / 'close' is the reliable "client is gone"
  * signal, so we treat it as a shutdown trigger too. shutdown runs at most once even if several
  * triggers fire together (e.g. 'end' then 'close').
+ *
+ * Triggering shutdown is not the same as finishing it: if the graceful path stalls (a close that
+ * waits on connections that never drain, a leaked timer pinning the event loop), the process still
+ * lingers as a zombie even though shutdown "ran". hardExit is the backstop for that second zombie
+ * class — armed when the trigger fires, it force-exits after hardExitDelayMs unless the graceful
+ * path exited first.
  */
-export const wireShutdown = ({ proc, stdin, shutdown }: ShutdownWiring): void => {
+export const wireShutdown = ({
+  proc,
+  stdin,
+  shutdown,
+  hardExit,
+  hardExitDelayMs,
+}: ShutdownWiring): void => {
   let triggered = false;
   const once = (): void => {
     if (triggered) return;
     triggered = true;
+    if (hardExit !== undefined) {
+      const timer = setTimeout(hardExit, hardExitDelayMs ?? DEFAULT_HARD_EXIT_DELAY_MS);
+      timer.unref();
+    }
     void shutdown();
   };
   proc.on('SIGINT', once);

--- a/packages/mcp/src/relay/relay.ts
+++ b/packages/mcp/src/relay/relay.ts
@@ -54,6 +54,7 @@ export class Relay {
   private readonly opts: Required<Omit<RelayOptions, 'server'>>;
   private readonly pending = new Map<string, Pending>();
   private heartbeatDeferrals = 0;
+  private lastRequestAtMs = 0;
 
   constructor(opts: RelayOptions) {
     this.opts = {
@@ -87,6 +88,7 @@ export class Relay {
     sessionId?: string,
   ): Promise<unknown> {
     const id = newId();
+    this.lastRequestAtMs = Date.now();
     return new Promise<unknown>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
@@ -148,6 +150,16 @@ export class Relay {
   /** How many heartbeat timeouts were deferred because the session was mid-request (busy ≠ dead). */
   heartbeatDeferralCount(): number {
     return this.heartbeatDeferrals;
+  }
+
+  /**
+   * Epoch ms of the most recent sendRequest, 0 if none yet. The abdication handler uses it as a
+   * quiet-window signal: a multi-call tool has idle moments _between_ sub-calls where pendingCount
+   * is 0, and abdicating in one of those gaps would strand the tool's remaining pinned sub-calls on
+   * the takeover window. Recent traffic means "probably mid-sequence — not now".
+   */
+  lastRequestAt(): number {
+    return this.lastRequestAtMs;
   }
 
   /**

--- a/packages/mcp/src/relay/session.ts
+++ b/packages/mcp/src/relay/session.ts
@@ -110,6 +110,12 @@ export class SessionManager {
   clear(): void {
     for (const s of this.sessions.values()) {
       if (s.disconnectTimer !== null) clearTimeout(s.disconnectTimer);
+      // Stop heartbeats here, not via the socket-close path: Relay.stop() clears sessions before
+      // terminating sockets, so markDisconnected (which normally stops the heartbeat) early-returns
+      // for a session that's no longer in the map — leaking a live setInterval that pins the event
+      // loop open and keeps a shutting-down process alive as a zombie.
+      s.heartbeat?.stop();
+      s.heartbeat = null;
     }
     this.sessions.clear();
   }

--- a/packages/mcp/src/tools/ping.ts
+++ b/packages/mcp/src/tools/ping.ts
@@ -9,8 +9,8 @@ export const pingTool: ToolSpec = {
   name: PING_TOOL_NAME,
   description:
     'Health check. Returns server info plus, when a plugin is connected, end-to-end info from the ' +
-    'Figma sandbox. On a follower it also reports the leader’s version and warns (versionSkew) ' +
-    'when a stale older server still owns the plugin.',
+    'Figma sandbox. On a follower it also reports the leader’s version and build, and warns ' +
+    '(versionSkew / buildSkew) when a stale older server still owns the plugin.',
   inputShape: {},
   kind: 'read',
 };
@@ -21,11 +21,22 @@ export interface PingServerInfo {
   role: NodeRole;
   port: number | null;
   ts: number;
+  /** This process's build stamp (epoch ms; 0 when running unbundled). See build-id.ts. */
+  buildId: number;
   /**
    * Follower path only: the version of the leader process that actually owns the plugin and runs
    * the work. Usually equal to `version`; differs when a stale older server still holds the port.
    */
   leaderVersion?: string;
+  /** Follower path only: the leader's build stamp (0 for pre-buildId leaders). */
+  leaderBuildId?: number;
+  /**
+   * Present when the leader runs an older build than this client (same or different version).
+   * Normally transient — the election challenges stale leaders automatically (newest build wins) —
+   * so a persistent warning means the leader predates abdication support and must be killed by
+   * hand.
+   */
+  buildSkew?: string;
   /**
    * Present only when `leaderVersion` differs from `version` — a human-readable warning that a
    * stale server process is serving the plugin, so this client's newer build isn't actually in
@@ -75,6 +86,8 @@ export interface PingContext {
   node: Node;
   follower: Follower;
   serverVersion: string;
+  /** This process's build stamp (see build-id.ts); defaults to 0 (unbundled). */
+  buildId?: number;
   log?: (msg: string) => void;
 }
 
@@ -83,6 +96,7 @@ const serverInfo = (ctx: PingContext): PingServerInfo => ({
   role: ctx.node.role,
   port: ctx.node.isLeader() ? (ctx.node.getLeader()?.port ?? null) : null,
   ts: Date.now(),
+  buildId: ctx.buildId ?? 0,
 });
 
 export const handlePing = async (ctx: PingContext): Promise<PingResult> => {
@@ -159,23 +173,32 @@ export const handlePing = async (ctx: PingContext): Promise<PingResult> => {
     }
   }
 
-  // Follower path — no direct relay visibility, so no sessions info. Surface the leader's version so
-  // a stale older leader still owning the plugin (this client's new build never took effect) is
-  // visible instead of silent — the zombie-leader trap. Best-effort, never gates routing.
-  const leaderVersion = await ctx.follower.resolveLeaderVersion();
+  // Follower path — no direct relay visibility, so no sessions info. Surface the leader's version
+  // and build so a stale leader still owning the plugin (this client's new build never took effect)
+  // is visible instead of silent — the zombie-leader trap. Best-effort, never gates routing.
+  const leader = await ctx.follower.leaderInfo();
+  const buildSkew =
+    leader !== undefined && server.buildId > (leader.buildId ?? 0)
+      ? `leader runs an older build than this client (leader ${leader.buildId ?? 0} < ours ` +
+        `${server.buildId}). The election challenges stale leaders automatically, so this normally ` +
+        `clears within seconds; if it persists, the leader predates abdication support — kill it ` +
+        `(lsof -iTCP:${ctx.node.port} -sTCP:LISTEN) so election promotes this build.`
+      : undefined;
   const followerServer: PingServerInfo =
-    leaderVersion === undefined
+    leader === undefined
       ? server
       : {
           ...server,
-          leaderVersion,
-          ...(leaderVersion === server.version
+          leaderVersion: leader.serverVersion,
+          leaderBuildId: leader.buildId ?? 0,
+          ...(buildSkew === undefined ? {} : { buildSkew }),
+          ...(leader.serverVersion === server.version
             ? {}
             : {
                 versionSkew:
-                  `leader is v${leaderVersion} but this client's server is v${server.version} — a ` +
+                  `leader is v${leader.serverVersion} but this client's server is v${server.version} — a ` +
                   `stale server process still owns the plugin, so your newer build isn't in effect. ` +
-                  `Kill the leader (lsof -iTCP:3055 -sTCP:LISTEN) so election promotes this version.`,
+                  `Kill the leader (lsof -iTCP:${ctx.node.port} -sTCP:LISTEN) so election promotes this version.`,
               }),
         };
 

--- a/packages/mcp/test/dispatch.test.ts
+++ b/packages/mcp/test/dispatch.test.ts
@@ -106,6 +106,30 @@ describe('dispatchTool', () => {
     expect(attempts).toBe(2);
   });
 
+  it('retries a "relay stopping" rejection (leader shutting down / abdicating) and recovers', async () => {
+    const node = makeNode({ isLeader: () => false, getLeader: () => null });
+    let attempts = 0;
+    const follower = makeFollower({
+      sendRpc: async (): Promise<RpcResponse> => {
+        attempts += 1;
+        if (attempts < 2) {
+          return {
+            kind: 'err',
+            requestId: 'r',
+            code: ErrorCode.Internal,
+            message: 'relay stopping (pending get_document)',
+          };
+        }
+        // By the retry the new leader owns the port and serves the call.
+        return { kind: 'ok', requestId: 'r', result: { from: 'new-leader' } };
+      },
+    });
+
+    const result = await dispatchTool({ node, follower }, 'get_document', {}, { retryDelayMs: 5 });
+    expect(result).toEqual({ from: 'new-leader' });
+    expect(attempts).toBe(2);
+  });
+
   it('switches from follower to leader path when role changes mid-retry', async () => {
     let attempts = 0;
     const leaderResult = { from: 'new-leader' };

--- a/packages/mcp/test/e2e/process-lifecycle.test.ts
+++ b/packages/mcp/test/e2e/process-lifecycle.test.ts
@@ -1,0 +1,100 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Process-level proof of the zombie fixes: real spawned servers (the built dist), a real stdin
+// EOF, and a real election takeover — the layers no in-process test exercises (process.exit
+// wiring, undici keep-alive followers, the OS port release). Runs against dist, so it needs a
+// build first; CI always builds before testing, and locally it skips instead of failing when the
+// artifact is missing.
+const DIST_ENTRY = join(import.meta.dirname, '..', '..', 'dist', 'index.mjs');
+
+const freePort = async (): Promise<number> => {
+  const s = createServer();
+  await new Promise<void>(resolve => s.listen(0, '127.0.0.1', () => resolve()));
+  const port = (s.address() as AddressInfo).port;
+  await new Promise<void>(resolve => s.close(() => resolve()));
+  return port;
+};
+
+interface Server {
+  child: ChildProcess;
+  stderr: () => string;
+  exited: () => { code: number | null } | null;
+}
+
+const servers: Server[] = [];
+
+afterEach(() => {
+  for (const s of servers) {
+    if (s.exited() === null) s.child.kill('SIGKILL');
+  }
+  servers.length = 0;
+});
+
+const spawnServer = (port: number): Server => {
+  const child = spawn(process.execPath, [DIST_ENTRY], {
+    env: { ...process.env, FIGWRIGHT_PORT: String(port) },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr?.on('data', (d: Buffer) => {
+    stderr += d.toString('utf8');
+  });
+  let exit: { code: number | null } | null = null;
+  child.on('exit', code => {
+    exit = { code };
+  });
+  const s: Server = { child, stderr: () => stderr, exited: () => exit };
+  servers.push(s);
+  return s;
+};
+
+const waitFor = async (pred: () => boolean, label: string, timeoutMs: number): Promise<void> => {
+  const t0 = Date.now();
+  while (!pred()) {
+    if (Date.now() - t0 > timeoutMs) throw new Error(`timed out waiting for ${label}`);
+    // eslint-disable-next-line no-await-in-loop -- polling loop
+    await new Promise<void>(resolve => setTimeout(resolve, 25));
+  }
+};
+
+describe.skipIf(!existsSync(DIST_ENTRY))('process lifecycle (built dist)', () => {
+  it(
+    'leader exits promptly on stdin EOF and a live follower takes over the port',
+    { timeout: 20_000 },
+    async () => {
+      const port = await freePort();
+
+      const leader = spawnServer(port);
+      await waitFor(() => leader.stderr().includes('ready as leader'), 'leader ready', 8_000);
+
+      const follower = spawnServer(port);
+      await waitFor(() => follower.stderr().includes('ready as follower'), 'follower ready', 8_000);
+
+      // Let the follower run a few election ticks so its keep-alive /ping connection to the leader
+      // is live — the exact connection that used to pin a shutting-down leader open.
+      await new Promise<void>(resolve => setTimeout(resolve, 1_500));
+
+      // The MCP client goes away: stdin EOF. The leader must fully exit (not just stop serving) —
+      // before the closeAllConnections/hardExit fixes it could linger holding its followers.
+      leader.child.stdin?.end();
+      await waitFor(() => leader.exited() !== null, 'leader exit after stdin EOF', 8_000);
+      expect(leader.exited()?.code).toBe(0);
+
+      // With the dead leader's connections severed, the follower's next tick must fail its ping
+      // and win the port.
+      await waitFor(() => follower.stderr().includes('became LEADER'), 'follower takeover', 8_000);
+      expect(follower.exited()).toBeNull();
+
+      // And the promoted process itself dies cleanly when its client goes away.
+      follower.child.stdin?.end();
+      await waitFor(() => follower.exited() !== null, 'promoted follower exit', 8_000);
+      expect(follower.exited()?.code).toBe(0);
+    },
+  );
+});

--- a/packages/mcp/test/election/election.test.ts
+++ b/packages/mcp/test/election/election.test.ts
@@ -69,6 +69,8 @@ const startLeaderHarness = async (port: number): Promise<LeaderHarness> => {
 const buildElection = (
   port: number,
   pingTimeoutMs = 200,
+  buildId = 0,
+  log?: (msg: string) => void,
 ): { node: Node; election: Election; follower: Follower } => {
   const node = new Node({ serverVersion: 'challenger-1.0.0', port });
   extraNodes.push(node);
@@ -76,9 +78,43 @@ const buildElection = (
     leaderUrl: `http://127.0.0.1:${port}`,
     pingTimeoutMs,
   });
-  const election = new Election({ node, follower, tickIntervalMs: 1_000_000 });
+  const election = new Election({
+    node,
+    follower,
+    buildId,
+    tickIntervalMs: 1_000_000,
+    ...(log === undefined ? {} : { log }),
+  });
   extraElections.push(election);
   return { node, election, follower };
+};
+
+/**
+ * A leader wired the way index.ts wires production: its own Election owns the node, and the
+ * /abdicate endpoint releases leadership via election.yieldLeadership. quiet window 0 so tests
+ * don't wait out ABDICATE_QUIET_WINDOW_MS.
+ */
+const startLeaderWithElection = async (
+  port: number,
+  buildId: number,
+): Promise<{ node: Node; election: Election }> => {
+  const node = new Node({ serverVersion: 'leader-1.0.0', port });
+  extraNodes.push(node);
+  const follower = new Follower({ leaderUrl: `http://127.0.0.1:${port}`, pingTimeoutMs: 200 });
+  const election = new Election({ node, follower, buildId, tickIntervalMs: 1_000_000 });
+  extraElections.push(election);
+  await election.determineRole();
+  expect(node.role).toBe(NodeRole.Leader);
+  const res = node.getLeader();
+  if (res === null) throw new Error('leader resources missing');
+  attachLeaderEndpoints(res.http, {
+    relay: res.relay,
+    serverVersion: 'leader-1.0.0',
+    buildId,
+    onAbdicate: () => election.yieldLeadership(),
+    abdicateQuietWindowMs: 0,
+  });
+  return { node, election };
 };
 
 describe('Election', () => {
@@ -183,5 +219,116 @@ describe('Election', () => {
     await election.start();
     expect(node.role).toBe(NodeRole.Follower);
     election.stop();
+  });
+});
+
+describe('Election: newest build wins (abdication)', () => {
+  it('a follower on a newer build takes over from a stale leader, which stays demoted', async () => {
+    const port = await freePort();
+    const old = await startLeaderWithElection(port, 100);
+    const { node, election } = buildElection(port, 200, 200);
+
+    await election.determineRole();
+    expect(node.role).toBe(NodeRole.Follower);
+
+    // One tick: leaderInfo shows an older build → request abdication → grab the released port.
+    await election.tickOnce();
+    expect(node.role).toBe(NodeRole.Leader);
+    expect(node.getLeader()?.port).toBe(port);
+    expect(old.node.role).toBe(NodeRole.Follower);
+
+    // The demoted old leader's own tick must not challenge back or re-take the port.
+    await old.election.tickOnce();
+    expect(old.node.role).toBe(NodeRole.Follower);
+    expect(node.role).toBe(NodeRole.Leader);
+  });
+
+  it('equal builds never challenge', async () => {
+    const port = await freePort();
+    const old = await startLeaderWithElection(port, 100);
+    const { node, election } = buildElection(port, 200, 100);
+    await election.determineRole();
+    await election.tickOnce();
+    expect(node.role).toBe(NodeRole.Follower);
+    expect(old.node.role).toBe(NodeRole.Leader);
+  });
+
+  it('a busy leader defers the handoff (challenger retries on later ticks)', async () => {
+    const port = await freePort();
+    const old = await startLeaderWithElection(port, 100);
+    // No plugin connected → the request stays pending, so the leader reports busy.
+    const pending = old.node
+      .getLeader()
+      ?.relay.sendRequest('slow_tool', {}, 1_500)
+      .catch(() => {});
+    const { node, election } = buildElection(port, 200, 200);
+    await election.determineRole();
+    await election.tickOnce();
+    expect(node.role).toBe(NodeRole.Follower);
+    expect(old.node.role).toBe(NodeRole.Leader);
+    await pending;
+  });
+
+  it('a pre-abdication leader stays; the challenger backs off instead of spamming', async () => {
+    const port = await freePort();
+    // startLeaderHarness attaches endpoints without buildId/onAbdicate — the old-release shape.
+    await startLeaderHarness(port);
+    const logs: string[] = [];
+    const { node, election } = buildElection(port, 200, 200, msg => logs.push(msg));
+    await election.determineRole();
+
+    await election.tickOnce();
+    await election.tickOnce();
+    expect(node.role).toBe(NodeRole.Follower);
+    const manualRetirements = logs.filter(l => l.includes('retired manually')).length;
+    expect(manualRetirements).toBe(1);
+  });
+
+  it('yieldLeadership opens a window where the ex-leader will not re-take the free port', async () => {
+    const port = await freePort();
+    const old = await startLeaderWithElection(port, 100);
+    old.election.yieldLeadership();
+    expect(old.node.role).toBe(NodeRole.Follower);
+
+    // The port is now free and the leader ping fails, but the yield window holds takeover back.
+    await old.election.tickOnce();
+    expect(old.node.role).toBe(NodeRole.Follower);
+  });
+
+  it('yieldLeadership is a no-op unless leading', async () => {
+    const port = await freePort();
+    const { node, election } = buildElection(port, 200, 100);
+    election.yieldLeadership();
+    expect(node.role).toBe(NodeRole.Unknown);
+  });
+
+  it('overlapping ticks coalesce — a second tick while one is in flight is a no-op', async () => {
+    const port = await freePort();
+    // No leader on the port: each real tick tries a takeover. Overlap is realistic because a
+    // tick can outlive the 1s interval (ping timeout 2s, grab loop ~1s).
+    const node = new Node({ serverVersion: 'x', port });
+    extraNodes.push(node);
+    let pings = 0;
+    const follower = {
+      ping: async () => {
+        pings += 1;
+        await new Promise(r => setTimeout(r, 50));
+        return false;
+      },
+      leaderInfo: async () => {
+        pings += 1;
+        await new Promise(r => setTimeout(r, 50));
+        return undefined;
+      },
+      requestAbdication: async () => 'error' as const,
+    } as unknown as Follower;
+    const election = new Election({ node, follower, tickIntervalMs: 1_000_000 });
+    extraElections.push(election);
+    node.becomeFollower();
+
+    // Fire two ticks concurrently: the second must return without probing the leader again.
+    await Promise.all([election.tickOnce(), election.tickOnce()]);
+    expect(pings).toBe(1);
+    expect(node.role).toBe(NodeRole.Leader);
   });
 });

--- a/packages/mcp/test/election/follower.test.ts
+++ b/packages/mcp/test/election/follower.test.ts
@@ -194,15 +194,58 @@ describe('Follower HTTP client', () => {
     expect(await f.resolveActiveSession()).toBeUndefined();
   });
 
-  it('resolveLeaderVersion reads the leader-reported serverVersion', async () => {
-    const b = await startLeader();
-    const f = new Follower({ leaderUrl: `http://127.0.0.1:${b.port}` });
-    expect(await f.resolveLeaderVersion()).toBe('test-1.0.0');
+  it('leaderInfo reports version and buildId of a confirmed leader', async () => {
+    const http = createServer();
+    await new Promise<void>(resolve => http.listen(0, '127.0.0.1', () => resolve()));
+    const port = (http.address() as AddressInfo).port;
+    const relay = new Relay({ serverVersion: 'test-2.0.0', server: http });
+    const detach = attachLeaderEndpoints(http, {
+      relay,
+      serverVersion: 'test-2.0.0',
+      buildId: 777,
+    });
+    all.push({ http, relay, port, detach, plugins: [] });
+
+    const f = new Follower({ leaderUrl: `http://127.0.0.1:${port}` });
+    expect(await f.leaderInfo()).toEqual({ serverVersion: 'test-2.0.0', buildId: 777 });
   });
 
-  it('resolveLeaderVersion returns undefined when the leader is unreachable', async () => {
+  it('leaderInfo is undefined for a non-figwright responder and an unreachable leader', async () => {
+    const http = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ hello: 'world' }));
+    });
+    await new Promise<void>(resolve => http.listen(0, '127.0.0.1', () => resolve()));
+    const port = (http.address() as AddressInfo).port;
+    try {
+      const f = new Follower({ leaderUrl: `http://127.0.0.1:${port}` });
+      expect(await f.leaderInfo()).toBeUndefined();
+    } finally {
+      await new Promise<void>(resolve => http.close(() => resolve()));
+    }
+
+    const dead = new Follower({ leaderUrl: 'http://127.0.0.1:1', pingTimeoutMs: 200 });
+    expect(await dead.leaderInfo()).toBeUndefined();
+  });
+
+  it('requestAbdication maps a 404 (pre-abdication leader) to unsupported', async () => {
+    const http = createServer((_req, res) => {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+    await new Promise<void>(resolve => http.listen(0, '127.0.0.1', () => resolve()));
+    const port = (http.address() as AddressInfo).port;
+    try {
+      const f = new Follower({ leaderUrl: `http://127.0.0.1:${port}` });
+      expect(await f.requestAbdication(200)).toBe('unsupported');
+    } finally {
+      await new Promise<void>(resolve => http.close(() => resolve()));
+    }
+  });
+
+  it('requestAbdication maps transport failure to error', async () => {
     const f = new Follower({ leaderUrl: 'http://127.0.0.1:1', pingTimeoutMs: 200 });
-    expect(await f.resolveLeaderVersion()).toBeUndefined();
+    expect(await f.requestAbdication(200)).toBe('error');
   });
 
   it('sendRpc threads sessionId so the leader pins the call', async () => {

--- a/packages/mcp/test/election/leader-endpoints.test.ts
+++ b/packages/mcp/test/election/leader-endpoints.test.ts
@@ -19,7 +19,13 @@ import { decode, encode } from '@msgpack/msgpack';
 import { afterEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 
-import { attachLeaderEndpoints, PING_PATH, RPC_PATH } from '../../src/election/leader-endpoints.js';
+import {
+  ABDICATE_PATH,
+  attachLeaderEndpoints,
+  type LeaderEndpointDeps,
+  PING_PATH,
+  RPC_PATH,
+} from '../../src/election/leader-endpoints.js';
 import { Relay } from '../../src/relay/relay.js';
 
 interface Bound {
@@ -44,7 +50,10 @@ afterEach(async () => {
   all.length = 0;
 });
 
-const startLeader = async (rpcTimeoutMs = 5_000): Promise<Bound> => {
+const startLeader = async (
+  rpcTimeoutMs = 5_000,
+  extraDeps: Partial<LeaderEndpointDeps> = {},
+): Promise<Bound> => {
   const http = createServer();
   await new Promise<void>(resolve => http.listen(0, '127.0.0.1', () => resolve()));
   const port = (http.address() as AddressInfo).port;
@@ -53,10 +62,23 @@ const startLeader = async (rpcTimeoutMs = 5_000): Promise<Bound> => {
     relay,
     serverVersion: 'test-1.0.0',
     rpcTimeoutMs,
+    ...extraDeps,
   });
   const b: Bound = { http, relay, port, detach, plugins: [] };
   all.push(b);
   return b;
+};
+
+const postAbdicate = async (
+  port: number,
+  body: unknown,
+): Promise<{ status: number; body: { ok: boolean; reason?: string } }> => {
+  const res = await fetch(`http://127.0.0.1:${port}${ABDICATE_PATH}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as { ok: boolean; reason?: string } };
 };
 
 const attachFakePlugin = async (
@@ -271,5 +293,116 @@ describe('leader endpoints', () => {
     const b = await startLeader();
     const res = await fetch(`http://127.0.0.1:${b.port}/nope`);
     expect(res.status).toBe(404);
+  });
+
+  it('GET /ping advertises the buildId (0 when unset)', async () => {
+    const bare = await startLeader();
+    const bareBody = (await (await fetch(`http://127.0.0.1:${bare.port}${PING_PATH}`)).json()) as {
+      buildId: number;
+    };
+    expect(bareBody.buildId).toBe(0);
+
+    const stamped = await startLeader(5_000, { buildId: 1234 });
+    const stampedBody = (await (
+      await fetch(`http://127.0.0.1:${stamped.port}${PING_PATH}`)
+    ).json()) as { buildId: number };
+    expect(stampedBody.buildId).toBe(1234);
+  });
+});
+
+describe('POST /abdicate', () => {
+  it('accepts a strictly newer build and releases after the response flushes', async () => {
+    let released = 0;
+    const b = await startLeader(5_000, {
+      buildId: 100,
+      onAbdicate: () => {
+        released += 1;
+      },
+      abdicateQuietWindowMs: 0,
+    });
+    const { status, body } = await postAbdicate(b.port, { buildId: 200 });
+    expect(status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    // onAbdicate fires on the response's 'finish' — by the time fetch resolved, it flushed.
+    await new Promise(r => setTimeout(r, 20));
+    expect(released).toBe(1);
+  });
+
+  it('refuses an equal or older build', async () => {
+    let released = 0;
+    const b = await startLeader(5_000, {
+      buildId: 100,
+      onAbdicate: () => {
+        released += 1;
+      },
+      abdicateQuietWindowMs: 0,
+    });
+    expect((await postAbdicate(b.port, { buildId: 100 })).body).toEqual({
+      ok: false,
+      reason: 'stale',
+    });
+    expect((await postAbdicate(b.port, { buildId: 50 })).body).toEqual({
+      ok: false,
+      reason: 'stale',
+    });
+    expect(released).toBe(0);
+  });
+
+  it('answers unsupported when no release hook is wired', async () => {
+    const b = await startLeader(5_000, { buildId: 100, abdicateQuietWindowMs: 0 });
+    expect((await postAbdicate(b.port, { buildId: 200 })).body).toEqual({
+      ok: false,
+      reason: 'unsupported',
+    });
+  });
+
+  it('defers while a relay request is in flight', async () => {
+    let released = 0;
+    const b = await startLeader(5_000, {
+      buildId: 100,
+      onAbdicate: () => {
+        released += 1;
+      },
+      abdicateQuietWindowMs: 0,
+    });
+    // No plugin connected → the request queues as pending until its own timeout.
+    const pending = b.relay.sendRequest('slow_tool', {}, 1_000).catch(() => {});
+    await new Promise(r => setTimeout(r, 20));
+    expect((await postAbdicate(b.port, { buildId: 200 })).body).toEqual({
+      ok: false,
+      reason: 'busy',
+    });
+    expect(released).toBe(0);
+    await pending;
+  });
+
+  it('defers inside the quiet window after recent traffic, then accepts once it elapses', async () => {
+    let released = 0;
+    const b = await startLeader(5_000, {
+      buildId: 100,
+      onAbdicate: () => {
+        released += 1;
+      },
+      abdicateQuietWindowMs: 150,
+    });
+    // A completed (timed-out) request leaves no pending entry but stamps lastRequestAt.
+    await b.relay.sendRequest('quick_tool', {}, 10).catch(() => {});
+    expect((await postAbdicate(b.port, { buildId: 200 })).body).toEqual({
+      ok: false,
+      reason: 'busy',
+    });
+    expect(released).toBe(0);
+
+    await new Promise(r => setTimeout(r, 160));
+    expect((await postAbdicate(b.port, { buildId: 200 })).body).toEqual({ ok: true });
+    await new Promise(r => setTimeout(r, 20));
+    expect(released).toBe(1);
+  });
+
+  it('rejects malformed bodies', async () => {
+    const b = await startLeader(5_000, { buildId: 100, abdicateQuietWindowMs: 0 });
+    expect((await postAbdicate(b.port, 'not json{{')).status).toBe(400);
+    expect((await postAbdicate(b.port, {})).status).toBe(400);
+    expect((await postAbdicate(b.port, { buildId: 'newest' })).status).toBe(400);
   });
 });

--- a/packages/mcp/test/election/node.test.ts
+++ b/packages/mcp/test/election/node.test.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server as HttpServer } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import { type AddressInfo, connect as netConnect, type Socket } from 'node:net';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -7,6 +7,24 @@ import { isAddressInUse, Node, NodeRole } from '../../src/election/node.js';
 
 const blockers: HttpServer[] = [];
 const nodes: Node[] = [];
+const sockets: Socket[] = [];
+
+// Open a connection to the leader with an HTTP request in flight that nothing will ever answer
+// (the bare leader http server has no request listener in these tests). Node ≥19's server.close()
+// closes *idle* connections itself, so only an in-flight request reproduces the hang these
+// regression tests pin down.
+const connectWithInflightRequest = async (port: number): Promise<Socket> => {
+  const sock = netConnect(port, '127.0.0.1');
+  sockets.push(sock);
+  await new Promise<void>((resolve, reject) => {
+    sock.once('connect', resolve);
+    sock.once('error', reject);
+  });
+  sock.write('GET /never-answered HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n');
+  // Give the server a beat to parse the request so the connection counts as in-flight.
+  await new Promise<void>(resolve => setTimeout(resolve, 30));
+  return sock;
+};
 
 const blockPort = async (port: number): Promise<void> => {
   const s = createServer();
@@ -23,6 +41,8 @@ const freePort = async (): Promise<number> => {
 };
 
 afterEach(async () => {
+  for (const s of sockets) s.destroy();
+  sockets.length = 0;
   await Promise.all(nodes.map(n => n.stop()));
   nodes.length = 0;
   await Promise.all(blockers.map(s => new Promise<void>(r => s.close(() => r()))));
@@ -105,6 +125,31 @@ describe('Node role state machine', () => {
     await n.becomeLeader();
     n.becomeFollower();
     expect(seen).toEqual([NodeRole.Leader, NodeRole.Follower]);
+  });
+
+  // Regression: http.close() waits for in-flight requests to finish before its callback fires. A
+  // follower /rpc that lands in the shutdown window sits on a stopped relay until its tool budget
+  // (up to minutes) expires, so a shutting-down leader lingers that whole time as a zombie — still
+  // answering /ping on live connections, so no follower takes over. stop must sever connections,
+  // not wait them out.
+  it('stop resolves even while a connection has a request in flight', async () => {
+    const port = await freePort();
+    const n = makeNode(port);
+    await n.becomeLeader();
+    await connectWithInflightRequest(port);
+    await n.stop();
+    expect(n.role).toBe(NodeRole.Unknown);
+  });
+
+  it('becomeFollower severs in-flight connections to the demoted leader', async () => {
+    const port = await freePort();
+    const n = makeNode(port);
+    await n.becomeLeader();
+    const sock = await connectWithInflightRequest(port);
+    const closed = new Promise<void>(resolve => sock.once('close', () => resolve()));
+    n.becomeFollower();
+    await closed;
+    expect(n.role).toBe(NodeRole.Follower);
   });
 
   it('stop releases the bound port so it can be re-bound', async () => {

--- a/packages/mcp/test/lifecycle.test.ts
+++ b/packages/mcp/test/lifecycle.test.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'node:events';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { wireShutdown } from '../src/lifecycle.js';
+import { DEFAULT_HARD_EXIT_DELAY_MS, wireShutdown } from '../src/lifecycle.js';
 
 describe('wireShutdown', () => {
   it.each([
@@ -40,5 +40,71 @@ describe('wireShutdown', () => {
     wireShutdown({ proc, stdin, shutdown: () => void calls++ });
 
     expect(calls).toBe(0);
+  });
+});
+
+describe('wireShutdown hardExit backstop', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('invokes hardExit when the graceful shutdown has not exited after the delay', () => {
+    vi.useFakeTimers();
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    const hardExit = vi.fn<() => void>();
+    // A shutdown that stalls forever (e.g. a close waiting on connections that never drain).
+    wireShutdown({ proc, stdin, shutdown: () => new Promise<void>(() => {}), hardExit });
+
+    stdin.emit('end');
+    expect(hardExit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(DEFAULT_HARD_EXIT_DELAY_MS);
+    expect(hardExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects a custom hardExitDelayMs', () => {
+    vi.useFakeTimers();
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    const hardExit = vi.fn<() => void>();
+    wireShutdown({
+      proc,
+      stdin,
+      shutdown: () => new Promise<void>(() => {}),
+      hardExit,
+      hardExitDelayMs: 1_000,
+    });
+
+    proc.emit('SIGTERM');
+    vi.advanceTimersByTime(999);
+    expect(hardExit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(hardExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not arm the backstop before a trigger fires', () => {
+    vi.useFakeTimers();
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    const hardExit = vi.fn<() => void>();
+    wireShutdown({ proc, stdin, shutdown: () => {}, hardExit });
+
+    vi.advanceTimersByTime(DEFAULT_HARD_EXIT_DELAY_MS * 2);
+    expect(hardExit).not.toHaveBeenCalled();
+  });
+
+  it('arms the backstop only once across multiple triggers', () => {
+    vi.useFakeTimers();
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    const hardExit = vi.fn<() => void>();
+    wireShutdown({ proc, stdin, shutdown: () => new Promise<void>(() => {}), hardExit });
+
+    stdin.emit('end');
+    stdin.emit('close');
+    proc.emit('SIGTERM');
+    vi.advanceTimersByTime(DEFAULT_HARD_EXIT_DELAY_MS * 2);
+    expect(hardExit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mcp/test/relay/session.test.ts
+++ b/packages/mcp/test/relay/session.test.ts
@@ -1,0 +1,41 @@
+import { HeartbeatMonitor } from '@figwright/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { WebSocket } from 'ws';
+
+import { SessionManager } from '../../src/relay/session.js';
+
+const fakeSocket = (): WebSocket => ({ close: () => {} }) as unknown as WebSocket;
+
+describe('SessionManager.clear', () => {
+  // Regression: Relay.stop() clears sessions before terminating sockets, so the socket-close path
+  // (markDisconnected) early-returns and never stops the heartbeat. If clear() doesn't stop it
+  // either, the leaked setInterval pins the event loop open and a shutting-down process lingers
+  // as a zombie.
+  it('stops session heartbeats so no interval outlives the manager', () => {
+    vi.useFakeTimers();
+    try {
+      const manager = new SessionManager();
+      const { session } = manager.register({
+        id: 's1',
+        socket: fakeSocket(),
+        clientVersion: '0.0.0',
+      });
+      const sendPing = vi.fn<() => void>();
+      session.heartbeat = new HeartbeatMonitor({
+        intervalMs: 10,
+        maxMisses: 2,
+        sendPing,
+        onTimeout: () => {},
+      });
+      session.heartbeat.start();
+
+      manager.clear();
+
+      vi.advanceTimersByTime(100);
+      expect(sendPing).not.toHaveBeenCalled();
+      expect(session.heartbeat).toBe(null);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/mcp/test/tools/ping.test.ts
+++ b/packages/mcp/test/tools/ping.test.ts
@@ -110,7 +110,7 @@ describe('ping tool', () => {
       getLeader: () => null,
     });
     const follower = makeFollower({
-      resolveLeaderVersion: async () => '1.0.0',
+      leaderInfo: async () => ({ serverVersion: '1.0.0', buildId: 0 }),
       sendRpc: async () => ({
         kind: 'err' as const,
         requestId: 'r',
@@ -138,18 +138,57 @@ describe('ping tool', () => {
       getLeader: () => null,
     });
     const follower = makeFollower({
-      resolveLeaderVersion: async () => '0.1.0', // stale older leader still owns the plugin
+      // stale older leader still owns the plugin
+      leaderInfo: async () => ({ serverVersion: '0.1.0', buildId: 100 }),
       sendRpc: async () => ({
         kind: 'ok' as const,
         requestId: 'r',
         result: { apiVersion: '1.0.0' },
       }),
     });
-    const result = await handlePing({ node, follower, serverVersion: '0.2.0', log: () => {} });
+    const result = await handlePing({
+      node,
+      follower,
+      serverVersion: '0.2.0',
+      buildId: 200,
+      log: () => {},
+    });
 
     expect(result.server.version).toBe('0.2.0');
     expect(result.server.leaderVersion).toBe('0.1.0');
     expect(result.server.versionSkew).toMatch(/leader is v0\.1\.0.*v0\.2\.0/);
+    // An older version implies an older build, so both warnings fire; buildSkew explains the
+    // auto-heal (abdication) and the manual fallback.
+    expect(result.server.leaderBuildId).toBe(100);
+    expect(result.server.buildSkew).toMatch(/older build/);
+  });
+
+  it('flags a build skew alone when versions match but the leader build is older', async () => {
+    const node = makeNode({
+      role: NodeRole.Follower,
+      isLeader: () => false,
+      getLeader: () => null,
+    });
+    const follower = makeFollower({
+      // Same released version, older local build — the dev-iteration zombie ping must expose.
+      leaderInfo: async () => ({ serverVersion: '0.2.0', buildId: 100 }),
+      sendRpc: async () => ({
+        kind: 'ok' as const,
+        requestId: 'r',
+        result: { apiVersion: '1.0.0' },
+      }),
+    });
+    const result = await handlePing({
+      node,
+      follower,
+      serverVersion: '0.2.0',
+      buildId: 200,
+      log: () => {},
+    });
+
+    expect(result.server.versionSkew).toBeUndefined();
+    expect(result.server.buildSkew).toMatch(/older build/);
+    expect(result.server.buildSkew).toMatch(/lsof -iTCP:3055/);
   });
 
   it('reports leaderVersion with no skew warning when versions match', async () => {
@@ -159,17 +198,24 @@ describe('ping tool', () => {
       getLeader: () => null,
     });
     const follower = makeFollower({
-      resolveLeaderVersion: async () => '0.2.0',
+      leaderInfo: async () => ({ serverVersion: '0.2.0', buildId: 200 }),
       sendRpc: async () => ({
         kind: 'ok' as const,
         requestId: 'r',
         result: { apiVersion: '1.0.0' },
       }),
     });
-    const result = await handlePing({ node, follower, serverVersion: '0.2.0', log: () => {} });
+    const result = await handlePing({
+      node,
+      follower,
+      serverVersion: '0.2.0',
+      buildId: 200,
+      log: () => {},
+    });
 
     expect(result.server.leaderVersion).toBe('0.2.0');
     expect(result.server.versionSkew).toBeUndefined();
+    expect(result.server.buildSkew).toBeUndefined();
   });
 
   it('omits leaderVersion when the leader version is unreachable', async () => {
@@ -179,7 +225,7 @@ describe('ping tool', () => {
       getLeader: () => null,
     });
     const follower = makeFollower({
-      resolveLeaderVersion: async () => undefined,
+      leaderInfo: async () => undefined,
       sendRpc: async () => ({
         kind: 'ok' as const,
         requestId: 'r',
@@ -190,5 +236,6 @@ describe('ping tool', () => {
 
     expect(result.server.leaderVersion).toBeUndefined();
     expect(result.server.versionSkew).toBeUndefined();
+    expect(result.server.buildSkew).toBeUndefined();
   });
 });

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   shims: false,
+  // Build stamp for newest-build-wins election (src/build-id.ts). Epoch ms of this build; absent
+  // (→ 0) when running unbundled, so only real builds participate in build ordering.
+  define: {
+    __FIGWRIGHT_BUILD_ID__: JSON.stringify(String(Date.now())),
+  },
   fixedExtension: true,
   publint: true,
   deps: { alwaysBundle: ['@figwright/shared'] },


### PR DESCRIPTION
## Problem

Two classes of "zombie leader" could leave a stale server process owning the relay port while still answering `/ping` — so followers never took over, and every tool call ran against dead or outdated code. This has been burning real agent sessions for a while.

## Fix 1 — shutdowns that actually finish

Triggering shutdown is not the same as completing it. `http.close()` waits for in-flight requests, and a follower `/rpc` landing in the shutdown window sits on the stopped relay for its whole tool budget (up to ~125s) — during which the half-dead leader still answers `/ping` on live connections, so no follower takes over. (Node ≥19 closes *idle* keep-alives itself; only in-flight requests hang it — the regression tests pin the real mechanism.)

- `Node.stop()` and demotion (`becomeFollower`/`becomeConflicted`, deduped into `releaseLeader()`) now sever connections via `closeAllConnections()`.
- `wireShutdown` gains a `hardExit` backstop: unref'd 5s timer → `exit(1)` if the graceful path ever stalls again, whatever the cause.
- `SessionManager.clear()` stops heartbeat intervals that the `Relay.stop()` ordering leaked (clear-before-terminate skipped `markDisconnected`), which could pin the event loop open.
- Dispatch treats `relay stopping` as transient, so calls in flight during a handoff retry onto the new leader. Writes stay safe: the per-call `requestId` is created once and reused across retries, and the plugin sandbox's idempotency map survives the reconnect.

## Fix 2 — newest build wins (abdication)

A *live* stale leader — another session's server, or one hand-launched in a terminal (TTY stdin never EOFs) — is HTTP-healthy forever, and after a local rebuild it even has the same semver, so version skew can't detect it.

- tsdown bakes a build stamp (epoch ms) into the bundle (`build-id.ts`; 0 when unbundled, so dev/test processes never claim to be newer).
- The leader advertises `buildId` on `/ping`; a follower on a strictly newer build POSTs `/abdicate` (same 1s election tick, same single round-trip as the old health check).
- The leader refuses while busy — pending requests, or relay traffic in the last 10s (protects the idle gaps *between* a multi-call tool's pinned sub-calls) — otherwise releases the port after the acceptance flushes.
- The challenger grabs the port within ms (20×50ms); the ex-leader sits out takeovers for 5s so it can't flap back, and stays alive as a follower so its own MCP client keeps working through the new leader.
- Only strictly newer builds challenge ⇒ leadership moves monotonically to the newest build; equal builds never contend; no flapping.
- Pre-abdication leaders 404 → challenger backs off 60s, and the `ping` tool's new `buildSkew` warning names the stale process with the kill command. `versionSkew` reporting is preserved unchanged.

## Hardening found during review

- Election ticks are reentrancy-guarded: a tick can outlive the 1s interval (ping timeout 2s, grab loop ~1s); every stacked interleaving was idempotent, but coalescing is simpler to trust than that proof.
- Race walkthroughs covered in tests or by construction: double-accepted `/abdicate` (`yieldLeadership` is a no-op unless leading), acceptance lost to the connection teardown (challenger falls back to the dead-leader takeover path within 1 tick; yield window only binds the *old* leader), challenger dying before binding (5s yield expiry → self-heal), two challengers (loser re-evaluates against the new leader's buildId).

## Verification

- 948 tests pass (+19), plus typecheck / lint / format / knip / build.
- New process-level e2e (`process-lifecycle.test.ts`) spawns the **built dist**, sends a real stdin EOF, and asserts prompt exit + live takeover — the layers no in-process test exercises. `FIGWRIGHT_PORT` is a test-only seam for it.
- Mutation-checked: removing `closeAllConnections()` fails exactly the two new node tests; zeroing the yield window fails exactly the yield test.
- Live drills on real processes: leader exits **52ms** after stdin EOF with a live follower attached; a forged old-build leader hands off to the real build in **~1.0s**, stays alive as follower, no flapping, both exit 0.

## Compatibility

Wire changes are additive (`buildId` on `/ping`, new `/abdicate`); plugin protocol untouched. Old leaders degrade gracefully (404 → backoff + actionable ping warning). All mechanisms are Node-core APIs (cross-platform); SIGTERM never fires on Windows but stdin-EOF — the primary trigger — does.