### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,27 @@
+name: actionlint
+
+on:
+  push:
+    paths:
+      - .github/workflows/**
+    branches: [main]
+  pull_request:
+    paths:
+      - .github/workflows/**
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # From https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color


### PR DESCRIPTION
Adds a standalone workflow that lints `.github/workflows/*` with [actionlint](https://github.com/rhysd/actionlint) — catches expression type errors, invalid contexts, script-injection risks, and shellchecks `run:` blocks.

Details:

- Runs the official Docker image pinned to `1.7.12` by sha256 digest (digest verified against Docker Hub), rather than curl-installing from the unpinned `main` branch.
- `paths: .github/workflows/**` filter so it only runs when workflow files change. Because of this filter, don't mark it as a required check — PRs that don't touch workflows would hang on "Expected".
- `persist-credentials: false` on checkout; the job needs no token.

All three existing workflows pass 1.7.12 locally.