### PR TITLE
ci: capitalize actionlint workflow name

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,4 @@
-name: actionlint
+name: Actionlint
 
 on:
   push:


### PR DESCRIPTION
Rename the workflow from `actionlint` to `Actionlint` to match the Title Case convention of the other workflows (`CI`, `Release`, `Semantic PR`) in the Actions sidebar and checks list. No functional change.