### PR TITLE
ci: harden workflows per zizmor audit, add zizmor and renovate

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       # pnpm before setup-node, so the node cache can resolve the pnpm store.
       # Version is read from the root package.json "packageManager" field.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .node-version
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,20 @@ jobs:
       contents: write # GitHub Release + plugin asset upload
       id-token: write # OIDC: npm trusted publishing + provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # full history so changelogen can diff from the last tag
+          # Release steps talk to GitHub via the API tokens below, never git push.
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
-      - uses: actions/setup-node@v4
+      # No pnpm cache here: this workflow publishes to npm, and restoring a
+      # shared cache into a publish job is a cache-poisoning vector.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .node-version
-          cache: pnpm
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -5,7 +5,7 @@ name: Semantic PR
 # keeps history consistent with the commit convention (CI lints commits at the
 # PR-title level, not per-commit).
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] title-only check, no checkout (see below)
     types: [opened, edited, synchronize, reopened]
 
 # Only reads the PR title via the API — no checkout of PR code, so
@@ -21,7 +21,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Zizmor
+
+# Security audit of the workflow files themselves (actionlint covers syntax;
+# zizmor covers vulnerability patterns like unpinned actions and injection).
+on:
+  push:
+    paths:
+      - .github/workflows/**
+    branches: [main]
+  pull_request:
+    paths:
+      - .github/workflows/**
+
+# Findings fail the run directly (advanced-security: false) instead of being
+# uploaded to code scanning, so no permissions are needed at all.
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        with:
+          advanced-security: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"]
+  "extends": ["config:best-practices", "group:allNonMajor", ":maintainLockFilesWeekly"],
+  "schedule": ["before 9am on Monday"],
+  "minimumReleaseAge": "3 days",
+  "postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## Description

Fixes all findings from a local `zizmor` audit of our workflows, and adds guardrails so they stay fixed:

- **Pin all third-party actions to commit SHAs** (`unpinned-uses`). Tags are mutable and have been hijacked in past supply-chain attacks (e.g. `tj-actions/changed-files`); SHAs are not. The `# vX.Y.Z` comments are kept in sync by Renovate (below).
- **Disable pnpm cache restoration in the release job** (`cache-poisoning`). It publishes to npm, and restoring a shared runner cache into a publish job is a poisoning vector. Also sets `package-manager-cache: false` explicitly, which future-proofs a setup-node v5 bump (cache becomes default-on there).
- **`persist-credentials: false` on all checkouts** (`artipacked`). Nothing in CI or release does `git push` — release talks to GitHub only via API tokens (`changelogen gh release`, `gh release upload`) — so the write-capable token has no reason to sit in `.git/config`. Noted inline for whoever changes the release flow later.
- **Inline-suppress `dangerous-triggers` on semantic-pr.yml**: it is a title-only check via the API with `pull-requests: read` and no code checkout, which is the documented safe use of `pull_request_target`.
- **New `zizmor.yml` workflow**: audits workflow changes in CI (complements actionlint: syntax vs. security). Zero-permission; findings fail the run instead of uploading to code scanning.
- **New `renovate.json`**: keeps the action SHA pins, npm deps, `packageManager` (pnpm) and Node versions updated. `config:best-practices` plus noise/supply-chain tuning: all non-major bumps grouped into one Monday PR, 3-day release cooldown before adopting new versions (vulnerability alerts bypass both), weekly lockfile maintenance with `pnpmDedupe`. Takes effect once the Renovate GitHub App is installed on the repo — that's a manual one-time step after merge.

`zizmor` (v1.25.2) and `actionlint` both pass locally on the result.

## Checklist

- [x] The canonical checks pass locally: CI-config-only change, no package code touched (`pnpm typecheck && pnpm lint && pnpm format:check` pass)
- [ ] Tests are added or updated for any behavior change — n/a, no runtime behavior
- [ ] Read-path / serializer changes are verified with a live round-trip against a real Figma file — n/a
- [x] Documentation is updated if needed — inline comments in the workflows
