### PR TITLE
feat: add Figma Motion API tools and animated-frame video export

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything runs on your machine and talks to Figma through a plugin, so it needs
 ## Why Figwright
 
 - **Free** — no Figma Dev Mode or paid seat. The official Dev Mode MCP is gated; Figwright isn't.
-- **Bidirectional** — not read-only. **104 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
+- **Bidirectional** — not read-only. **112 tools** span reading _and_ writing the canvas, so an agent can both implement designs and build them.
 - **Provider-first codegen** — Figwright detects your real stack (framework + styling system) and reuses your existing components, tokens, and icons, instead of emitting generic markup you have to rewrite.
 - **Any MCP client** — Claude Code, Cursor, and other MCP-capable agents all work the same way.
 - **Open & extensible** — the read/write workflows ship as installable [skills](#skills) you can adopt or fork.
@@ -182,10 +182,10 @@ npx skills add https://github.com/awdr74100/figwright/tree/main/skills/figma-cod
 
 ## Tools
 
-Figwright exposes **104 MCP tools** in three groups:
+Figwright exposes **112 MCP tools** in three groups:
 
-- **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, screenshots, original image-fill assets, and PDF export.
-- **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components (including authoring their boolean/text/instance-swap properties), pages, and reactions; plus a `batch` tool to apply many edits at once.
+- **Read** — selection, document and node inspection, styles, variables, components, fonts, reactions, motion (animation) state, screenshots, original image-fill assets, PDF export, and video export of animated frames (MP4 / GIF / WebM).
+- **Write** — create and edit frames, text, shapes, auto-layout, effects, styles, variables, components (including authoring their boolean/text/instance-swap properties), pages, reactions, and Motion animations (keyframes, animation-style presets, timelines); plus a `batch` tool to apply many edits at once.
 - **Grounding** — `get_design_context` for faithful, de-duplicated design context, and `component_map` / `token_map` / `icon_map`, which join Figma data to your codebase so codegen reuses what you already have; plus `design_diff`, which reports what changed in a design against a saved baseline so you update only the affected code.
 
 > [!TIP]

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 > The MCP server for **[Figwright](https://github.com/awdr74100/figwright)** — a two-way Figma agent for Claude Code, Cursor, Codex, and other MCP clients.
 
-Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **104 tools** spanning reads, writes, and codebase-grounded context.
+Figwright bridges MCP clients to a Figma plugin over a local WebSocket relay, so an AI agent can both **read** your designs with high-fidelity grounding and **write** back to the canvas — no Figma paid tier required. The server exposes **112 tools** spanning reads, writes, and codebase-grounded context.
 
 ## Usage
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -18,6 +18,7 @@ import { COMPONENT_MAP_TOOL_NAME, handleComponentMap } from './tools/component-m
 import { handleDesignContext } from './tools/design-context-guard.js';
 import { DESIGN_DIFF_TOOL_NAME, handleDesignDiff } from './tools/design-diff.js';
 import { EXPORT_PDF_TOOL_NAME, handleExportPdf } from './tools/export-pdf.js';
+import { EXPORT_VIDEO_TOOL_NAME, handleExportVideo } from './tools/export-video.js';
 import { GET_DESIGN_CONTEXT_TOOL_NAME } from './tools/get-design-context.js';
 import { GET_SCREENSHOT_TOOL_NAME, screenshotContent } from './tools/get-screenshot.js';
 import { handleIconMap, ICON_MAP_TOOL_NAME } from './tools/icon-map.js';
@@ -115,6 +116,7 @@ const SPECIAL_HANDLERS: Record<string, ToolHandler> = {
   [SAVE_IMAGE_FILLS_TOOL_NAME]: async args =>
     textResult(await handleSaveImageFills(dispatch, args)),
   [EXPORT_PDF_TOOL_NAME]: async args => textResult(await handleExportPdf(dispatch, args)),
+  [EXPORT_VIDEO_TOOL_NAME]: async args => textResult(await handleExportVideo(dispatch, args)),
   [GET_SCREENSHOT_TOOL_NAME]: async args => ({
     content: screenshotContent(
       (await dispatch(GET_SCREENSHOT_TOOL_NAME, args)) as GetScreenshotResult,

--- a/packages/mcp/src/tools/apply-animation-style.ts
+++ b/packages/mcp/src/tools/apply-animation-style.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import { animationStyleConfigSchema } from './motion-schemas.js';
+import type { ToolSpec } from './spec.js';
+
+export const APPLY_ANIMATION_STYLE_TOOL_NAME = 'apply_animation_style';
+
+export const applyAnimationStyleTool: ToolSpec = {
+  name: APPLY_ANIMATION_STYLE_TOOL_NAME,
+  description:
+    'Apply a Figma Motion animation-style preset to a node (get styleIds from get_motion_styles). ' +
+    'config tunes it: duration (seconds), timelineOffset (seconds — the lever for staggered ' +
+    'entrances: give each node index * step), and preset-specific props. Returns ' +
+    '{ ok, nodeId, appliedStyleId } — keep appliedStyleId to remove exactly this instance later. To ' +
+    'stagger a whole row in one atomic, undoable call, drive N apply_animation_style ops through ' +
+    '`batch` with increasing timelineOffset. Motion is a Figma-Design-only beta feature.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id to animate'),
+    styleId: z.string().describe('A styleId from get_motion_styles'),
+    config: animationStyleConfigSchema
+      .describe('Optional tuning: duration, timelineOffset (for stagger), preset props')
+      .optional(),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/apply-manual-keyframe-track.ts
+++ b/packages/mcp/src/tools/apply-manual-keyframe-track.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+import { keyframeFieldSchema, manualKeyframeTrackInputSchema } from './motion-schemas.js';
+import type { ToolSpec } from './spec.js';
+
+export const APPLY_MANUAL_KEYFRAME_TRACK_TOOL_NAME = 'apply_manual_keyframe_track';
+
+export const applyManualKeyframeTrackTool: ToolSpec = {
+  name: APPLY_MANUAL_KEYFRAME_TRACK_TOOL_NAME,
+  description:
+    'Set a hand-authored Figma Motion keyframe track on a node for one field — e.g. TRANSLATION_X, ' +
+    'OPACITY, ROTATION, SCALE_XY, or an indexed fills / strokes / effects item. `field` selects what ' +
+    'to animate; `track` carries an optional baseValue plus keyframes (each with timelinePosition in ' +
+    'seconds, a typed value, and optional easing). Replaces any existing track on that field. Returns ' +
+    '{ ok, nodeId }. Motion is a Figma-Design-only beta feature.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id to keyframe'),
+    field: keyframeFieldSchema,
+    track: manualKeyframeTrackInputSchema.describe('baseValue + keyframes for this field'),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/src/tools/export-video.ts
+++ b/packages/mcp/src/tools/export-video.ts
@@ -1,0 +1,85 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import type { ExportVideoResult, VideoExport } from '@figwright/shared';
+import { z } from 'zod';
+
+import { videoExportConstraintSchema } from './motion-schemas.js';
+import type { ToolSpec } from './spec.js';
+
+export const EXPORT_VIDEO_TOOL_NAME = 'export_video';
+
+const inputShape = {
+  nodeId: z
+    .string()
+    .describe(
+      'A node in the animated frame to export; its enclosing top-level frame (a frame placed ' +
+        'directly on a page) is what gets encoded — pass the frame itself or any descendant',
+    ),
+  format: z.enum(['MP4', 'GIF', 'WEBM']).describe('MP4 / WebM (video) or GIF (looping)'),
+  fps: z
+    .number()
+    .describe('Frames per second (MP4/WebM: 12/24/30/60; GIF: 8/12/15/24/30). Defaults per format.')
+    .optional(),
+  quality: z
+    .enum(['LOW', 'MEDIUM', 'HIGH'])
+    .describe('MP4/WebM quality; ignored for GIF')
+    .optional(),
+  loopCount: z
+    .number()
+    .int()
+    .min(0)
+    .max(1000)
+    .describe('GIF only: number of loops; 0 = loop forever')
+    .optional(),
+  constraint: videoExportConstraintSchema.optional(),
+  outPath: z.string().describe('File path to write the video to (parent dirs created if missing)'),
+};
+
+export const exportVideoTool: ToolSpec = {
+  name: EXPORT_VIDEO_TOOL_NAME,
+  description:
+    'Export an animated Figma top-level frame to an MP4 / WebM / GIF file on disk. Pass any node in ' +
+    'the frame (or the frame itself) — its enclosing top-level frame is encoded across the ' +
+    "animation's duration. Requires the Figma Design editor and a frame with animated content " +
+    '(Smart Animate / Motion keyframes); a static frame, a nested frame, or FigJam / Dev Mode ' +
+    'yields path:null with a reason (and, when reason is `failed`, Figma’s own message in ' +
+    'error). Encoding is a heavy render — call it on its own, not concurrently with other tool ' +
+    'calls, or the render can fail. Returns { nodeId, format, path, reason?, error? }.',
+  inputShape,
+  kind: 'local',
+};
+
+export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
+
+/**
+ * Land the exported video bytes on the server filesystem. Pure-fs and dispatch-free so it can be
+ * unit-tested against a temp directory. path is null (with the plugin's reason) when nothing
+ * encoded.
+ */
+export const writeExportedVideo = async (
+  outPath: string,
+  video: VideoExport,
+): Promise<ExportVideoResult> => {
+  const miss = {
+    ...(video.reason !== undefined ? { reason: video.reason } : {}),
+    ...(video.error !== undefined ? { error: video.error } : {}),
+  };
+  if (video.base64 === null) {
+    return { nodeId: video.nodeId, format: video.format, path: null, ...miss };
+  }
+  const path = resolve(outPath);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, Buffer.from(video.base64, 'base64'));
+  return { nodeId: video.nodeId, format: video.format, path };
+};
+
+/** Reuses the plugin-side export_video handler to fetch base64 bytes, then writes them to disk. */
+export const handleExportVideo = async (
+  dispatch: ToolDispatcher,
+  rawArgs: unknown,
+): Promise<ExportVideoResult> => {
+  const { outPath, ...pluginArgs } = z.object(inputShape).parse(rawArgs);
+  const video = (await dispatch(EXPORT_VIDEO_TOOL_NAME, pluginArgs)) as VideoExport;
+  return writeExportedVideo(outPath, video);
+};

--- a/packages/mcp/src/tools/get-motion-styles.ts
+++ b/packages/mcp/src/tools/get-motion-styles.ts
@@ -1,0 +1,14 @@
+import type { ToolSpec } from './spec.js';
+
+export const GET_MOTION_STYLES_TOOL_NAME = 'get_motion_styles';
+
+export const getMotionStylesTool: ToolSpec = {
+  name: GET_MOTION_STYLES_TOOL_NAME,
+  description:
+    "List the file's available Figma Motion animation-style presets — the templates you apply with " +
+    'apply_animation_style. Returns { styles: [{ styleId, name, description?, props? }] }; the styleId ' +
+    'is what apply_animation_style takes and props lists a preset’s tunable keys. Motion is a beta ' +
+    'feature, only available in the Figma Design editor.',
+  inputShape: {},
+  kind: 'read',
+};

--- a/packages/mcp/src/tools/get-node-motion.ts
+++ b/packages/mcp/src/tools/get-node-motion.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const GET_NODE_MOTION_TOOL_NAME = 'get_node_motion';
+
+export const getNodeMotionTool: ToolSpec = {
+  name: GET_NODE_MOTION_TOOL_NAME,
+  description:
+    "Read a node's Figma Motion (animation) state: applied animation styles, all keyframe animations, " +
+    'manual keyframe tracks, and the timelines it belongs to. Call it before editing to discover ' +
+    'styleIds / timelineIds and existing keyframes. Returns { nodeId, animationStyles, animations, ' +
+    'manualKeyframeTracks, timelines }, or { nodeId, motion: null } when the node supports no Motion.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id to read Motion state from'),
+  },
+  kind: 'read',
+};

--- a/packages/mcp/src/tools/motion-schemas.ts
+++ b/packages/mcp/src/tools/motion-schemas.ts
@@ -1,0 +1,215 @@
+import { z } from 'zod';
+
+// Shared, grounded Zod schemas for Figma's Motion API (beta). Reused by every apply_* / set_* Motion
+// tool so the keyframe / easing / config shape can't drift between them. This is our edge over the
+// competitor's raw port (gethopp #38), which types field / track / config as z.record(z.unknown()) —
+// the LLM cannot author reliably against `unknown`. Modeling the real typed shape (mostly enums) is
+// cheap and turns blind guessing into reliable authoring. Mirrors @figma/plugin-typings 1.131
+// (MotionEasing / KeyframeValue / KeyframeField / ManualKeyframeTrackInput / AnimationStyleConfiguration).
+//
+// Idiom, matching the rest of the repo: keep these schemas simple (enum + describe + basic bounds)
+// and defer cross-field semantics (e.g. "an effects field needs `field` or `propertyId`") to the
+// hand-written type-guards in the plugin handlers — the repo does not use Zod .superRefine / .refine.
+
+const rgba = z
+  .object({
+    r: z.number().min(0).max(1),
+    g: z.number().min(0).max(1),
+    b: z.number().min(0).max(1),
+    a: z.number().min(0).max(1),
+  })
+  .describe('Color as RGBA channels 0–1');
+
+// MotionEasing.type — 14 presets. Named presets (EASE_*, GENTLE/QUICK/BOUNCY/SLOW, LINEAR, HOLD) need
+// no extra params; CUSTOM_CUBIC_BEZIER pairs with easingFunctionCubicBezier, CUSTOM_SPRING with a
+// normalized 0–1 bounce.
+export const MOTION_EASING_TYPES = [
+  'EASE_IN',
+  'EASE_OUT',
+  'EASE_IN_AND_OUT',
+  'LINEAR',
+  'EASE_IN_BACK',
+  'EASE_OUT_BACK',
+  'EASE_IN_AND_OUT_BACK',
+  'CUSTOM_CUBIC_BEZIER',
+  'GENTLE',
+  'QUICK',
+  'BOUNCY',
+  'SLOW',
+  'CUSTOM_SPRING',
+  'HOLD',
+] as const;
+
+export const motionEasingSchema = z
+  .object({
+    type: z.enum(MOTION_EASING_TYPES),
+    easingFunctionCubicBezier: z
+      .object({ x1: z.number(), y1: z.number(), x2: z.number(), y2: z.number() })
+      .describe('Bezier control points; only for type "CUSTOM_CUBIC_BEZIER"')
+      .optional(),
+    easingFunctionSpring: z
+      .object({ bounce: z.number().min(0).max(1) })
+      .describe('Normalized bounce 0–1; only for type "CUSTOM_SPRING"')
+      .optional(),
+  })
+  .describe(
+    'Motion easing: a named preset, or CUSTOM_CUBIC_BEZIER / CUSTOM_SPRING with its params',
+  );
+
+// KeyframeValue — discriminated on `type`. FLOAT/BOOL/TEXT_DATA cover most property animations;
+// COLOR / VECTOR / the geometric point types cover paint stops and vector fields.
+export const keyframeValueSchema = z
+  .discriminatedUnion('type', [
+    z.object({ type: z.literal('FLOAT'), value: z.number() }),
+    z.object({ type: z.literal('COLOR'), value: rgba }),
+    z.object({ type: z.literal('TEXT_DATA'), value: z.string() }),
+    z.object({ type: z.literal('VECTOR'), value: z.object({ x: z.number(), y: z.number() }) }),
+    z.object({ type: z.literal('BOOL'), value: z.boolean() }),
+    z.object({
+      type: z.literal('CIRCLE'),
+      value: z.object({ x: z.number(), y: z.number(), radius: z.number() }),
+    }),
+    z.object({
+      type: z.literal('LINE'),
+      value: z.object({ x: z.number(), y: z.number(), x2: z.number(), y2: z.number() }),
+    }),
+    z.object({
+      type: z.literal('CIRCLE_POINT'),
+      value: z.object({ x: z.number(), y: z.number(), radius: z.number(), angle: z.number() }),
+    }),
+    z.object({
+      type: z.literal('COLOR_POINT'),
+      value: z.object({ x: z.number(), y: z.number(), color: rgba }),
+    }),
+  ])
+  .describe(
+    'A keyframe value tagged by its animated field type (FLOAT for translate/scale/opacity, …)',
+  );
+
+export const manualKeyframeInputSchema = z.object({
+  id: z.string().optional(),
+  timelinePosition: z.number().describe('Keyframe position on the timeline, in seconds'),
+  easing: motionEasingSchema.optional(),
+  value: keyframeValueSchema,
+});
+
+export const manualKeyframeTrackInputSchema = z.object({
+  id: z.string().optional(),
+  baseValue: keyframeValueSchema.describe('The value before the first keyframe').optional(),
+  keyframes: z.array(manualKeyframeInputSchema).min(1).describe('Keyframes in timeline order'),
+});
+
+// KeyframePropertyFieldName — 30 animatable node properties.
+export const KEYFRAME_PROPERTY_FIELDS = [
+  'CORNER_RADIUS',
+  'STROKE_WEIGHT',
+  'STACK_SPACING',
+  'STACK_PADDING_LEFT',
+  'STACK_PADDING_TOP',
+  'STACK_PADDING_RIGHT',
+  'STACK_PADDING_BOTTOM',
+  'WIDTH',
+  'HEIGHT',
+  'RECTANGLE_TOP_LEFT_CORNER_RADIUS',
+  'RECTANGLE_TOP_RIGHT_CORNER_RADIUS',
+  'RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS',
+  'RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS',
+  'BORDER_TOP_WEIGHT',
+  'BORDER_BOTTOM_WEIGHT',
+  'BORDER_LEFT_WEIGHT',
+  'BORDER_RIGHT_WEIGHT',
+  'STACK_COUNTER_SPACING',
+  'OPACITY',
+  'GRID_ROW_GAP',
+  'GRID_COLUMN_GAP',
+  'TRANSLATION_X',
+  'TRANSLATION_Y',
+  'TRANSLATION_XY',
+  'ROTATION',
+  'SCALE_X',
+  'SCALE_Y',
+  'SCALE_XY',
+  'PATH_TRIM_START',
+  'PATH_TRIM_END',
+] as const;
+
+// EffectKeyframeFieldName — 17 animatable effect sub-fields (shadow offset/radius, noise, glass, …).
+export const EFFECT_KEYFRAME_FIELDS = [
+  'OFFSET_X',
+  'OFFSET_Y',
+  'RADIUS',
+  'SPREAD',
+  'COLOR',
+  'REFRACTION_RADIUS',
+  'SPECULAR_ANGLE',
+  'SPECULAR_INTENSITY',
+  'CHROMATIC_ABERRATION',
+  'SPLAY',
+  'REFRACTION_INTENSITY',
+  'START_RADIUS',
+  'NOISE_SIZE_X',
+  'NOISE_SIZE_Y',
+  'DENSITY',
+  'EFFECT_OPACITY',
+  'SECONDARY_COLOR',
+] as const;
+
+// KeyframeField — what a track animates. A top-level node PROPERTY, or an INDEXED_ITEM inside the
+// node's fills / strokes / effects. The typings split INDEXED_ITEM into paint vs effect variants; we
+// collapse them into one loose branch and let the plugin handler enforce "effects need `field` or
+// `propertyId`; fills/strokes take neither `field`". Discriminated on `type` for good top-level errors.
+export const keyframeFieldSchema = z
+  .discriminatedUnion('type', [
+    z.object({ type: z.literal('PROPERTY'), name: z.enum(KEYFRAME_PROPERTY_FIELDS) }),
+    z.object({
+      type: z.literal('INDEXED_ITEM'),
+      collection: z.enum(['fills', 'strokes', 'effects']),
+      index: z.number().int().min(0),
+      field: z
+        .enum(EFFECT_KEYFRAME_FIELDS)
+        .describe('Effect sub-field to animate; only when collection is "effects"')
+        .optional(),
+      propertyId: z
+        .string()
+        .describe('Animate a bound component-property on the paint/effect instead of a field')
+        .optional(),
+    }),
+  ])
+  .describe(
+    'Which field a keyframe track drives: a node PROPERTY or an INDEXED_ITEM in fills/strokes/effects',
+  );
+
+// AnimationStyleConfiguration — how an applied preset is tuned. `timelineOffset` is the lever for
+// staggered entrances (give each node index * step). VariableAlias-valued props are not modeled yet.
+export const animationStyleConfigSchema = z.object({
+  duration: z.number().positive().describe('Duration in seconds').optional(),
+  timelineOffset: z
+    .number()
+    .describe('Start offset in seconds; use index * step for staggered entrances')
+    .optional(),
+  props: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean(), motionEasingSchema]))
+    .describe('Preset-specific props (e.g. direction, distance, easing) keyed by prop name')
+    .optional(),
+});
+
+// Video export size constraint (export_video). SCALE is a multiplier from the standard Export-panel
+// scales; WIDTH / HEIGHT pin the output to a fixed pixel size. Mirrors VideoExportConstraint.
+export const videoExportConstraintSchema = z
+  .union([
+    z.object({
+      type: z.literal('SCALE'),
+      value: z.union([
+        z.literal(0.5),
+        z.literal(0.75),
+        z.literal(1),
+        z.literal(1.5),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+      ]),
+    }),
+    z.object({ type: z.literal('WIDTH'), value: z.number().positive() }),
+    z.object({ type: z.literal('HEIGHT'), value: z.number().positive() }),
+  ])
+  .describe('Output size: a SCALE multiplier (0.5/0.75/1/1.5/2/3/4) or a fixed WIDTH/HEIGHT in px');

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -7,6 +7,8 @@ import { addComponentPropertyTool } from './add-component-property.js';
 import { addPageTool } from './add-page.js';
 import { addVariableModeTool } from './add-variable-mode.js';
 import { analyzeProjectTool } from './analyze-project.js';
+import { applyAnimationStyleTool } from './apply-animation-style.js';
+import { applyManualKeyframeTrackTool } from './apply-manual-keyframe-track.js';
 import { applyStyleToNodeTool } from './apply-style-to-node.js';
 import { batchRenameNodesTool } from './batch-rename-nodes.js';
 import { batchTool } from './batch.js';
@@ -39,6 +41,7 @@ import { designDiffTool } from './design-diff.js';
 import { detachInstanceTool } from './detach-instance.js';
 import { editComponentPropertyTool } from './edit-component-property.js';
 import { exportPdfTool } from './export-pdf.js';
+import { exportVideoTool } from './export-video.js';
 import { findReplaceTextTool } from './find-replace-text.js';
 import { getAnnotationsTool } from './get-annotations.js';
 import { getComponentApiTool } from './get-component-api.js';
@@ -47,6 +50,8 @@ import { getDocumentTool } from './get-document.js';
 import { getFontsTool } from './get-fonts.js';
 import { getLocalComponentsTool } from './get-local-components.js';
 import { getMetadataTool } from './get-metadata.js';
+import { getMotionStylesTool } from './get-motion-styles.js';
+import { getNodeMotionTool } from './get-node-motion.js';
 import { getNodeTool } from './get-node.js';
 import { getNodesInfoTool } from './get-nodes-info.js';
 import { getPagesTool } from './get-pages.js';
@@ -65,6 +70,8 @@ import { lockNodesTool } from './lock-nodes.js';
 import { moveNodesTool } from './move-nodes.js';
 import { navigateToPageTool } from './navigate-to-page.js';
 import { pingTool } from './ping.js';
+import { removeAnimationStyleTool } from './remove-animation-style.js';
+import { removeManualKeyframeTrackTool } from './remove-manual-keyframe-track.js';
 import { removeReactionsTool } from './remove-reactions.js';
 import { renameNodeTool } from './rename-node.js';
 import { renamePageTool } from './rename-page.js';
@@ -97,6 +104,7 @@ import { setStrokesTool } from './set-strokes.js';
 import { setTextPropertiesTool } from './set-text-properties.js';
 import { setTextRangeTool } from './set-text-range.js';
 import { setTextTool } from './set-text.js';
+import { setTimelineDurationTool } from './set-timeline-duration.js';
 import { setVariableCodeSyntaxTool } from './set-variable-code-syntax.js';
 import { setVariableValueTool } from './set-variable-value.js';
 import { setVisibleTool } from './set-visible.js';
@@ -130,12 +138,15 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   getFontsTool,
   getAnnotationsTool,
   getReactionsTool,
+  getMotionStylesTool,
+  getNodeMotionTool,
   listFilesTool,
   getDesignContextTool,
   getScreenshotTool,
   saveScreenshotsTool,
   saveImageFillsTool,
   exportPdfTool,
+  exportVideoTool,
   // Server-local (filesystem; no plugin handler — like save_screenshots). analyze_project is an
   // optional standalone probe; scan_components / component_map also run detection internally.
   analyzeProjectTool,
@@ -218,6 +229,12 @@ export const ALL_TOOL_SPECS: readonly ToolSpec[] = [
   createSectionTool,
   createInstanceTool,
   combineAsVariantsTool,
+  // Motion (beta) — Figma Design only
+  applyAnimationStyleTool,
+  removeAnimationStyleTool,
+  applyManualKeyframeTrackTool,
+  removeManualKeyframeTrackTool,
+  setTimelineDurationTool,
   batchTool,
 ];
 

--- a/packages/mcp/src/tools/remove-animation-style.ts
+++ b/packages/mcp/src/tools/remove-animation-style.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const REMOVE_ANIMATION_STYLE_TOOL_NAME = 'remove_animation_style';
+
+export const removeAnimationStyleTool: ToolSpec = {
+  name: REMOVE_ANIMATION_STYLE_TOOL_NAME,
+  description:
+    'Remove an applied Figma Motion animation style from a node. Pass animationStyleId (the ' +
+    'appliedStyleId returned by apply_animation_style, or read from get_node_motion) to remove one; ' +
+    'omit it to remove all applied styles on the node. Returns { ok, nodeId }.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id to remove animation style(s) from'),
+    animationStyleId: z
+      .string()
+      .describe('The applied-style instance id to remove; omit to remove all on the node')
+      .optional(),
+  },
+  kind: 'write',
+  destructive: true,
+};

--- a/packages/mcp/src/tools/remove-manual-keyframe-track.ts
+++ b/packages/mcp/src/tools/remove-manual-keyframe-track.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+import { keyframeFieldSchema } from './motion-schemas.js';
+import type { ToolSpec } from './spec.js';
+
+export const REMOVE_MANUAL_KEYFRAME_TRACK_TOOL_NAME = 'remove_manual_keyframe_track';
+
+export const removeManualKeyframeTrackTool: ToolSpec = {
+  name: REMOVE_MANUAL_KEYFRAME_TRACK_TOOL_NAME,
+  description:
+    'Remove the manual Figma Motion keyframe track for a given field on a node. `field` selects the ' +
+    'same target as apply_manual_keyframe_track (a node PROPERTY or an indexed fills/strokes/effects ' +
+    'item). Returns { ok, nodeId }.',
+  inputShape: {
+    nodeId: z.string().describe('Figma node id to clear a keyframe track from'),
+    field: keyframeFieldSchema,
+  },
+  kind: 'write',
+  destructive: true,
+};

--- a/packages/mcp/src/tools/set-timeline-duration.ts
+++ b/packages/mcp/src/tools/set-timeline-duration.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+import type { ToolSpec } from './spec.js';
+
+export const SET_TIMELINE_DURATION_TOOL_NAME = 'set_timeline_duration';
+
+export const setTimelineDurationTool: ToolSpec = {
+  name: SET_TIMELINE_DURATION_TOOL_NAME,
+  description:
+    'Set the duration (in seconds, must be > 0) of a Figma Motion timeline. Get the timelineId from ' +
+    "get_node_motion (a node's `timelines`). Returns { ok, nodeId }.",
+  inputShape: {
+    nodeId: z.string().describe('A node on the timeline (used to resolve the Motion API)'),
+    timelineId: z.string().describe('Timeline id from get_node_motion'),
+    duration: z.number().positive().describe('New timeline duration in seconds (> 0)'),
+  },
+  kind: 'write',
+};

--- a/packages/mcp/test/node-id.test.ts
+++ b/packages/mcp/test/node-id.test.ts
@@ -117,6 +117,8 @@ describe('normalizeIdArgs', () => {
       'collectionId', // variable-collection ids
       'propertyId', // component-property handles (name#id)
       'modeId', // variable-mode ids
+      'animationStyleId', // Motion applied-style instance ids
+      'timelineId', // Motion timeline ids
     ]);
     const covered = new Set<string>([...STRING_ID_FIELDS, 'nodeIds']);
     const offenders: string[] = [];

--- a/packages/mcp/test/tools/export-video.test.ts
+++ b/packages/mcp/test/tools/export-video.test.ts
@@ -1,0 +1,148 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ExportVideoResult, VideoExport } from '@figwright/shared';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  EXPORT_VIDEO_TOOL_NAME,
+  exportVideoTool,
+  handleExportVideo,
+  type ToolDispatcher,
+  writeExportedVideo,
+} from '../../src/tools/export-video.js';
+import { toToolDefinition } from '../tool-schema.js';
+
+const exportVideoToolDefinition = toToolDefinition(exportVideoTool);
+
+const dirs: string[] = [];
+const makeDir = async (): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), 'export-video-'));
+  dirs.push(dir);
+  return dir;
+};
+
+afterEach(async () => {
+  await Promise.all(dirs.map(d => rm(d, { recursive: true, force: true })));
+  dirs.length = 0;
+});
+
+describe('export_video — definition', () => {
+  it('requires nodeId + format + outPath and declares the format enum', () => {
+    expect(exportVideoToolDefinition.name).toBe(EXPORT_VIDEO_TOOL_NAME);
+    expect(exportVideoToolDefinition.inputSchema).toMatchObject({
+      type: 'object',
+      required: ['nodeId', 'format', 'outPath'],
+      properties: {
+        nodeId: { type: 'string' },
+        format: { enum: ['MP4', 'GIF', 'WEBM'] },
+        outPath: { type: 'string' },
+      },
+    });
+  });
+});
+
+describe('writeExportedVideo', () => {
+  it('writes the bytes to outPath, creating missing parent dirs', async () => {
+    const base = await makeDir();
+    const path = join(base, 'nested', 'clip.mp4');
+    const video: VideoExport = { nodeId: '2:3', format: 'MP4', base64: 'AAAA' };
+    const result = await writeExportedVideo(path, video);
+
+    expect(result).toEqual({ nodeId: '2:3', format: 'MP4', path });
+    expect((await readFile(path)).toString('base64')).toBe('AAAA');
+  });
+
+  it('returns path null with the reason and writes nothing when base64 is null', async () => {
+    const dir = await makeDir();
+    const path = join(dir, 'x.gif');
+    const result = await writeExportedVideo(path, {
+      nodeId: '9:9',
+      format: 'GIF',
+      base64: null,
+      reason: 'no-top-level-frame',
+    });
+    expect(result).toEqual({
+      nodeId: '9:9',
+      format: 'GIF',
+      path: null,
+      reason: 'no-top-level-frame',
+    });
+    await expect(readFile(path)).rejects.toThrow(/ENOENT/);
+  });
+
+  it("carries Figma's own error message through on a failed export", async () => {
+    const dir = await makeDir();
+    const path = join(dir, 'y.mp4');
+    const result = await writeExportedVideo(path, {
+      nodeId: '4:4',
+      format: 'MP4',
+      base64: null,
+      reason: 'failed',
+      error: 'The frame has no animation to export',
+    });
+    expect(result).toEqual({
+      nodeId: '4:4',
+      format: 'MP4',
+      path: null,
+      reason: 'failed',
+      error: 'The frame has no animation to export',
+    });
+    await expect(readFile(path)).rejects.toThrow(/ENOENT/);
+  });
+});
+
+describe('handleExportVideo', () => {
+  it('dispatches export_video with the plugin args (outPath stripped) and writes the file', async () => {
+    const dir = await makeDir();
+    const path = join(dir, 'out.mp4');
+    let dispatched: { tool: string; args: unknown } | null = null;
+    const dispatch: ToolDispatcher = async (tool, args) => {
+      dispatched = { tool, args };
+      return { nodeId: '5:5', format: 'MP4', base64: 'AAAA' } satisfies VideoExport;
+    };
+
+    const result = (await handleExportVideo(dispatch, {
+      nodeId: '5:5',
+      format: 'MP4',
+      outPath: path,
+    })) as ExportVideoResult;
+
+    expect(dispatched).toEqual({ tool: 'export_video', args: { nodeId: '5:5', format: 'MP4' } });
+    expect(result).toEqual({ nodeId: '5:5', format: 'MP4', path });
+    expect((await readFile(path)).toString('base64')).toBe('AAAA');
+  });
+
+  it('forwards fps / quality / constraint to the plugin export', async () => {
+    const dir = await makeDir();
+    let forwarded: unknown = null;
+    const dispatch: ToolDispatcher = async (_tool, args) => {
+      forwarded = args;
+      return { nodeId: '3:21', format: 'WEBM', base64: 'AAAA' } satisfies VideoExport;
+    };
+    await handleExportVideo(dispatch, {
+      nodeId: '3:21',
+      format: 'WEBM',
+      fps: 30,
+      quality: 'HIGH',
+      constraint: { type: 'SCALE', value: 2 },
+      outPath: join(dir, 'frame.webm'),
+    });
+    expect(forwarded).toEqual({
+      nodeId: '3:21',
+      format: 'WEBM',
+      fps: 30,
+      quality: 'HIGH',
+      constraint: { type: 'SCALE', value: 2 },
+    });
+  });
+
+  it('rejects input missing outPath', async () => {
+    const dispatch: ToolDispatcher = async () =>
+      ({ nodeId: '0:1', format: 'MP4', base64: null }) satisfies VideoExport;
+    await expect(handleExportVideo(dispatch, { nodeId: '0:1', format: 'MP4' })).rejects.toThrow(
+      /outPath/,
+    );
+  });
+});

--- a/packages/mcp/test/tools/motion-schemas.test.ts
+++ b/packages/mcp/test/tools/motion-schemas.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  animationStyleConfigSchema,
+  keyframeFieldSchema,
+  keyframeValueSchema,
+  manualKeyframeTrackInputSchema,
+  motionEasingSchema,
+} from '../../src/tools/motion-schemas.js';
+
+describe('motionEasingSchema', () => {
+  it('accepts a named preset with no extra params', () => {
+    expect(motionEasingSchema.safeParse({ type: 'EASE_OUT' }).success).toBe(true);
+  });
+
+  it('accepts CUSTOM_CUBIC_BEZIER with control points and CUSTOM_SPRING with bounce', () => {
+    expect(
+      motionEasingSchema.safeParse({
+        type: 'CUSTOM_CUBIC_BEZIER',
+        easingFunctionCubicBezier: { x1: 0.4, y1: 0, x2: 0.2, y2: 1 },
+      }).success,
+    ).toBe(true);
+    expect(
+      motionEasingSchema.safeParse({ type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce: 0.5 } })
+        .success,
+    ).toBe(true);
+  });
+
+  it('rejects an unknown easing type and an out-of-range spring bounce', () => {
+    expect(motionEasingSchema.safeParse({ type: 'WOBBLE' }).success).toBe(false);
+    expect(
+      motionEasingSchema.safeParse({ type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce: 2 } })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('keyframeValueSchema', () => {
+  it('accepts a FLOAT and a COLOR value', () => {
+    expect(keyframeValueSchema.safeParse({ type: 'FLOAT', value: 120 }).success).toBe(true);
+    expect(
+      keyframeValueSchema.safeParse({ type: 'COLOR', value: { r: 1, g: 0, b: 0.5, a: 1 } }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a wrong-typed value, an unknown type, and an out-of-range color channel', () => {
+    expect(keyframeValueSchema.safeParse({ type: 'FLOAT', value: 'nope' }).success).toBe(false);
+    expect(keyframeValueSchema.safeParse({ type: 'MATRIX', value: 1 }).success).toBe(false);
+    expect(
+      keyframeValueSchema.safeParse({ type: 'COLOR', value: { r: 2, g: 0, b: 0, a: 1 } }).success,
+    ).toBe(false);
+  });
+});
+
+describe('manualKeyframeTrackInputSchema', () => {
+  it('accepts a track with a baseValue and ordered keyframes', () => {
+    expect(
+      manualKeyframeTrackInputSchema.safeParse({
+        baseValue: { type: 'FLOAT', value: 0 },
+        keyframes: [
+          { timelinePosition: 0, value: { type: 'FLOAT', value: 0 } },
+          {
+            timelinePosition: 0.3,
+            value: { type: 'FLOAT', value: 120 },
+            easing: { type: 'EASE_OUT' },
+          },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an empty keyframes array', () => {
+    expect(manualKeyframeTrackInputSchema.safeParse({ keyframes: [] }).success).toBe(false);
+  });
+});
+
+describe('keyframeFieldSchema', () => {
+  it('accepts a PROPERTY field and an effects INDEXED_ITEM with a sub-field', () => {
+    expect(keyframeFieldSchema.safeParse({ type: 'PROPERTY', name: 'TRANSLATION_X' }).success).toBe(
+      true,
+    );
+    expect(
+      keyframeFieldSchema.safeParse({
+        type: 'INDEXED_ITEM',
+        collection: 'effects',
+        index: 0,
+        field: 'RADIUS',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an unknown property name and an unknown discriminant', () => {
+    expect(keyframeFieldSchema.safeParse({ type: 'PROPERTY', name: 'WOBBLE' }).success).toBe(false);
+    expect(keyframeFieldSchema.safeParse({ type: 'GROUP', index: 0 }).success).toBe(false);
+  });
+});
+
+describe('animationStyleConfigSchema', () => {
+  it('accepts duration + timelineOffset (for stagger) + props', () => {
+    expect(
+      animationStyleConfigSchema.safeParse({
+        duration: 0.4,
+        timelineOffset: 0.1,
+        props: { direction: 'right', distance: 120 },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a non-positive duration', () => {
+    expect(animationStyleConfigSchema.safeParse({ duration: 0 }).success).toBe(false);
+  });
+});

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -17,7 +17,7 @@
     "vue": "^3.5.39"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "^1.130.0",
+    "@figma/plugin-typings": "^1.131.0",
     "@figwright/shared": "workspace:*",
     "@tailwindcss/vite": "^4.3.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugin/src/handlers/apply-animation-style.ts
+++ b/packages/plugin/src/handlers/apply-animation-style.ts
@@ -1,0 +1,37 @@
+import type { ApplyAnimationStyleResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor, isMotionNode } from './motion-shared.js';
+
+/**
+ * Apply a Motion animation-style preset to a node. Returns the appliedStyleId Figma hands back —
+ * the batch inverse removes exactly this instance on undo, so it must round-trip. `config` shape is
+ * validated MCP-side (animationStyleConfigSchema); here we pass it through to the plugin API.
+ */
+export const createApplyAnimationStyleHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; styleId?: unknown; config?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('apply_animation_style: nodeId must be a string');
+    }
+    if (typeof p.styleId !== 'string') {
+      throw new TypeError('apply_animation_style: styleId must be a string');
+    }
+    if (p.config !== undefined && (typeof p.config !== 'object' || p.config === null)) {
+      throw new TypeError('apply_animation_style: config must be an object');
+    }
+    assertFigmaEditor(figmaCtx, 'apply_animation_style');
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `apply_animation_style: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    const appliedStyleId = node.applyAnimationStyle(
+      p.styleId,
+      p.config as AnimationStyleConfiguration | undefined,
+    );
+    const result: ApplyAnimationStyleResult = { ok: true, nodeId: node.id, appliedStyleId };
+    return result;
+  };

--- a/packages/plugin/src/handlers/apply-manual-keyframe-track.ts
+++ b/packages/plugin/src/handlers/apply-manual-keyframe-track.ts
@@ -1,0 +1,33 @@
+import type { MutateResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor, assertKeyframeField, isMotionNode } from './motion-shared.js';
+
+/**
+ * Set a hand-authored keyframe track on a node for one field. `field` / `track` shapes are
+ * validated MCP-side (keyframeFieldSchema / manualKeyframeTrackInputSchema); here we add the
+ * field's effects semantic check and pass through to the plugin API, which replaces any existing
+ * track on that field.
+ */
+export const createApplyManualKeyframeTrackHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; field?: unknown; track?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('apply_manual_keyframe_track: nodeId must be a string');
+    }
+    assertKeyframeField(p.field, 'apply_manual_keyframe_track');
+    if (typeof p.track !== 'object' || p.track === null) {
+      throw new TypeError('apply_manual_keyframe_track: track must be an object');
+    }
+    assertFigmaEditor(figmaCtx, 'apply_manual_keyframe_track');
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `apply_manual_keyframe_track: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    node.applyManualKeyframeTrack(p.field as KeyframeField, p.track as ManualKeyframeTrackInput);
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/src/handlers/batch.ts
+++ b/packages/plugin/src/handlers/batch.ts
@@ -1,6 +1,7 @@
 import type { BatchResult } from '@figwright/shared';
 
 import type { SandboxHandlers, SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor, isMotionNode, toPlainJson } from './motion-shared.js';
 
 /**
  * Atomic batch: apply several invertible write ops as a unit. Two phases —
@@ -214,6 +215,113 @@ const setTextInverse: BatchInverse = {
   },
 };
 
+// ── Motion (beta) inverses ───────────────────────────────────────────────────
+// Motion authoring joins the batch only where the pre-op state snapshots faithfully — the stagger
+// hot-path. apply_animation_style undoes via the appliedStyleId the apply returns; a PROPERTY
+// keyframe track round-trips through a deep-cloned snapshot. Indexed fills/strokes/effects tracks
+// have no faithful snapshot yet, so they're rejected up front (same honesty stance as
+// create_component's fromNodeId) to keep all-or-nothing real. All three gate on the Figma editor.
+
+const applyAnimationStyleInverse: BatchInverse = {
+  async capture(figmaCtx, params) {
+    assertFigmaEditor(figmaCtx, 'batch/apply_animation_style');
+    const id = (params as { nodeId?: unknown } | null)?.nodeId;
+    if (typeof id !== 'string') {
+      throw new TypeError('batch/apply_animation_style: nodeId must be a string');
+    }
+    const node = await figmaCtx.getNodeByIdAsync(id);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `batch/apply_animation_style: node ${id} not found or does not support Motion`,
+      );
+    }
+    return null; // undo relies on the appliedStyleId in the apply result
+  },
+  async undo(figmaCtx, _params, _captured, result) {
+    const r = result as { nodeId?: unknown; appliedStyleId?: unknown } | null;
+    if (typeof r?.nodeId !== 'string' || typeof r.appliedStyleId !== 'string') return;
+    const node = await figmaCtx.getNodeByIdAsync(r.nodeId);
+    if (node !== null && isMotionNode(node)) node.removeAnimationStyle(r.appliedStyleId);
+  },
+};
+
+const applyManualKeyframeTrackInverse: BatchInverse = {
+  async capture(figmaCtx, params) {
+    assertFigmaEditor(figmaCtx, 'batch/apply_manual_keyframe_track');
+    const p = (params ?? {}) as { nodeId?: unknown; field?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('batch/apply_manual_keyframe_track: nodeId must be a string');
+    }
+    const field = p.field as { type?: unknown; name?: unknown } | null;
+    if (field?.type !== 'PROPERTY' || typeof field.name !== 'string') {
+      throw new Error(
+        'batch/apply_manual_keyframe_track: only PROPERTY fields are batchable — indexed fills/strokes/effects tracks have no faithful snapshot',
+      );
+    }
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `batch/apply_manual_keyframe_track: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    const tracks = node.manualKeyframeTracks as Record<string, unknown>;
+    const previous = tracks[field.name];
+    // Deep-clone so the snapshot can't be mutated by the apply that follows.
+    return {
+      id: p.nodeId,
+      field: p.field,
+      previous: previous === undefined ? null : toPlainJson(previous),
+    };
+  },
+  async undo(figmaCtx, _params, captured) {
+    const { id, field, previous } = captured as {
+      id: string;
+      field: KeyframeField;
+      previous: ManualKeyframeTrackInput | null;
+    };
+    const node = await figmaCtx.getNodeByIdAsync(id);
+    if (node === null || !isMotionNode(node)) return;
+    if (previous === null) node.removeManualKeyframeTrack(field);
+    else node.applyManualKeyframeTrack(field, previous);
+  },
+};
+
+const setTimelineDurationInverse: BatchInverse = {
+  async capture(figmaCtx, params) {
+    assertFigmaEditor(figmaCtx, 'batch/set_timeline_duration');
+    const p = (params ?? {}) as { nodeId?: unknown; timelineId?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('batch/set_timeline_duration: nodeId must be a string');
+    }
+    if (typeof p.timelineId !== 'string') {
+      throw new TypeError('batch/set_timeline_duration: timelineId must be a string');
+    }
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `batch/set_timeline_duration: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    const timeline = node.timelines.find(t => t.id === p.timelineId);
+    if (timeline === undefined) {
+      throw new Error(
+        `batch/set_timeline_duration: timeline ${p.timelineId} not found on node ${p.nodeId}`,
+      );
+    }
+    return { id: p.nodeId, timelineId: p.timelineId, duration: timeline.duration };
+  },
+  async undo(figmaCtx, _params, captured) {
+    const { id, timelineId, duration } = captured as {
+      id: string;
+      timelineId: string;
+      duration: number;
+    };
+    const node = await figmaCtx.getNodeByIdAsync(id);
+    if (node === null || !isMotionNode(node)) return;
+    node.setTimelineDuration(timelineId, duration);
+  },
+};
+
 /** Tool name → inverse. Membership here is the allowlist: only these ops may appear in a batch. */
 const INVERSES: Readonly<Record<string, BatchInverse>> = {
   // Single-node property mutations.
@@ -300,6 +408,10 @@ const INVERSES: Readonly<Record<string, BatchInverse>> = {
   import_svg: createInverse('import_svg'),
   create_instance: createInverse('create_instance'),
   clone_node: createInverse('clone_node', false),
+  // Motion (beta) — staggered authoring in one atomic, undoable call.
+  apply_animation_style: applyAnimationStyleInverse,
+  apply_manual_keyframe_track: applyManualKeyframeTrackInverse,
+  set_timeline_duration: setTimelineDurationInverse,
 };
 
 interface ParsedOp {

--- a/packages/plugin/src/handlers/export-video.ts
+++ b/packages/plugin/src/handlers/export-video.ts
@@ -1,0 +1,77 @@
+import type { VideoExport, VideoFormat } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+
+type VideoSettings = ExportSettingsMP4 | ExportSettingsGIF | ExportSettingsWEBM;
+
+/**
+ * Build the plugin-API video export settings from the validated tool params. fps is left loosely
+ * typed (the MCP schema doesn't pin it to the exact per-format literals) — Figma validates the
+ * value and rejects an unsupported one, which the handler surfaces as a `failed` reason.
+ */
+const buildVideoSettings = (
+  format: VideoFormat,
+  p: { fps?: unknown; quality?: unknown; loopCount?: unknown; constraint?: unknown },
+): VideoSettings => {
+  const settings: Record<string, unknown> = { format };
+  if (typeof p.fps === 'number') settings.fps = p.fps;
+  if (p.constraint !== undefined) settings.constraint = p.constraint;
+  if (format === 'GIF') {
+    if (typeof p.loopCount === 'number') settings.loopCount = p.loopCount;
+  } else if (p.quality === 'LOW' || p.quality === 'MEDIUM' || p.quality === 'HIGH') {
+    settings.quality = p.quality;
+  }
+  return settings as unknown as VideoSettings;
+};
+
+/**
+ * Export an animated top-level frame to MP4 / GIF / WebM bytes (base64). We resolve the node's
+ * enclosing top-level frame (video export rejects on any other node) and gate on the Figma Design
+ * editor. exportAsync rejects for several reasons — a static frame with no animation, an
+ * unsupported setting, or a render that raced another plugin call — so instead of collapsing them
+ * into one guessed label we surface Figma's own message in `error`. Read-only: exporting doesn't
+ * mutate the document.
+ */
+export const createExportVideoHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as {
+      nodeId?: unknown;
+      format?: unknown;
+      fps?: unknown;
+      quality?: unknown;
+      loopCount?: unknown;
+      constraint?: unknown;
+    };
+    if (typeof p.nodeId !== 'string') throw new TypeError('export_video: nodeId must be a string');
+    if (p.format !== 'MP4' && p.format !== 'GIF' && p.format !== 'WEBM') {
+      throw new TypeError('export_video: format must be MP4, GIF, or WEBM');
+    }
+    const format = p.format;
+    const miss = (nodeId: string, reason: VideoExport['reason'], error?: string): VideoExport => ({
+      nodeId,
+      format,
+      base64: null,
+      reason,
+      ...(error !== undefined ? { error } : {}),
+    });
+
+    // Video export only exists in the Figma Design editor (no animation engine in FigJam / Dev Mode).
+    if (figmaCtx.editorType !== 'figma') return miss(p.nodeId, 'wrong-editor');
+
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !('getTopLevelFrame' in node)) return miss(p.nodeId, 'not-found');
+    const frame = (node as SceneNode).getTopLevelFrame();
+    if (frame === undefined || !('exportAsync' in frame))
+      return miss(p.nodeId, 'no-top-level-frame');
+
+    try {
+      const bytes = await frame.exportAsync(buildVideoSettings(format, p));
+      return { nodeId: frame.id, format, base64: figmaCtx.base64Encode(bytes) };
+    } catch (err) {
+      // exportAsync rejects for a static (no-animation) frame, a bad setting, or a raced render —
+      // carry Figma's real message rather than guessing a single cause.
+      const message = err instanceof Error ? err.message : String(err);
+      return miss(frame.id, 'failed', message);
+    }
+  };

--- a/packages/plugin/src/handlers/get-design-context.ts
+++ b/packages/plugin/src/handlers/get-design-context.ts
@@ -8,6 +8,7 @@ import {
   type DetailLevel,
   type GetDesignContextResult,
   MIXED,
+  type MotionSummary,
   type ResolvedToken,
   type SerializedPaint,
   simplifyPaint,
@@ -441,6 +442,34 @@ const collectPropertyOverrides = (instance: InstanceNode): Record<string, unknow
   return out;
 };
 
+/**
+ * Compact Motion (beta) summary for a node that actually animates — applied preset names, the
+ * animated field names, and the containing timeline's duration. Read straight off the Motion mixin
+ * (sync); a node without the mixin, or a non-Figma editor where the read throws, yields undefined.
+ * Only produced when the node carries its own animation, so plain layers stay clean. Surfaced by
+ * buildNode (not project) at full detail — Motion is a Motion-API dimension, not a serializer one.
+ */
+export const motionSummary = (node: SceneNode): MotionSummary | undefined => {
+  if (!('animationStyles' in node)) return undefined;
+  const mn = node as SceneNode & MotionNodeMixin;
+  let styles: string[];
+  let props: string[];
+  let duration: number | undefined;
+  try {
+    styles = mn.animationStyles.map(s => s.name);
+    props = Object.keys(mn.animations);
+    duration = mn.timelines.length > 0 ? mn.timelines[0]!.duration : undefined;
+  } catch {
+    return undefined; // Motion unavailable in this editor — stay silent
+  }
+  if (styles.length === 0 && props.length === 0) return undefined;
+  const out: MotionSummary = {};
+  if (styles.length > 0) out.animationStyles = styles;
+  if (props.length > 0) out.animatedProperties = props;
+  if (duration !== undefined) out.timelineDuration = duration;
+  return out;
+};
+
 /** RemainingDepth: -1 = unlimited; otherwise levels of children still allowed below this node. */
 const buildNode = async (
   node: SceneNode,
@@ -448,6 +477,13 @@ const buildNode = async (
   ctx: BuildCtx,
 ): Promise<DesignContextNode> => {
   const out = project(node, ctx.detail);
+
+  // Motion is a Motion-API dimension (not a serializer field), so it's attached here rather than in
+  // project(). Full detail only — the compact hot path stays untouched.
+  if (ctx.detail === 'full') {
+    const motion = motionSummary(node);
+    if (motion !== undefined) out.motion = motion;
+  }
 
   let expandChildren = true;
   // Resolve the main component when deduping (needs the id) or at full detail (needs name/key for

--- a/packages/plugin/src/handlers/get-motion-styles.ts
+++ b/packages/plugin/src/handlers/get-motion-styles.ts
@@ -1,0 +1,19 @@
+import type { GetMotionStylesResult, MotionStyle } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor } from './motion-shared.js';
+
+/** List the file's Figma Motion animation-style presets (the templates apply_animation_style takes). */
+export const createGetMotionStylesHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async () => {
+    assertFigmaEditor(figmaCtx, 'get_motion_styles');
+    const styles: MotionStyle[] = figmaCtx.motion.figmaAnimationStyles().map(s => {
+      const style: MotionStyle = { styleId: s.styleId, name: s.name };
+      if (s.description !== undefined) style.description = s.description;
+      if (s.props !== undefined) style.props = { ...s.props };
+      return style;
+    });
+    const result: GetMotionStylesResult = { styles };
+    return result;
+  };

--- a/packages/plugin/src/handlers/get-node-motion.ts
+++ b/packages/plugin/src/handlers/get-node-motion.ts
@@ -1,0 +1,31 @@
+import type { GetNodeMotionResult, NodeMotion } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { isMotionNode, toPlainJson } from './motion-shared.js';
+
+/**
+ * Read a node's Motion state (applied styles, animations, manual keyframe tracks, timelines). Reads
+ * don't gate on editorType — a node with no Motion support just returns `motion: null`, which is
+ * honest in FigJam / Dev Mode. The deep keyframe structures are cloned to plain JSON.
+ */
+export const createGetNodeMotionHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const nodeId = (params as { nodeId?: unknown } | null)?.nodeId;
+    if (typeof nodeId !== 'string') {
+      throw new TypeError('get_node_motion: nodeId must be a string');
+    }
+    const node = await figmaCtx.getNodeByIdAsync(nodeId);
+    if (node === null || !isMotionNode(node)) {
+      const miss: GetNodeMotionResult = { nodeId, motion: null };
+      return miss;
+    }
+    const motion: NodeMotion = {
+      animationStyles: toPlainJson(node.animationStyles) as unknown[],
+      animations: toPlainJson(node.animations) as Record<string, unknown>,
+      manualKeyframeTracks: toPlainJson(node.manualKeyframeTracks) as Record<string, unknown>,
+      timelines: node.timelines.map(t => ({ id: t.id, duration: t.duration })),
+    };
+    const result: GetNodeMotionResult = { nodeId: node.id, motion };
+    return result;
+  };

--- a/packages/plugin/src/handlers/motion-shared.ts
+++ b/packages/plugin/src/handlers/motion-shared.ts
@@ -1,0 +1,53 @@
+// Shared helpers for the Motion (beta) handlers: the node-capability guard, the editor gate, a
+// light keyframe-field check, and a plain-JSON cloner for reads. The Motion API lives on every
+// SceneNode, but only in the Figma Design editor — FigJam / Dev Mode have no animation engine.
+
+/** A node that exposes the Motion API. Every SceneNode does; PAGE / DOCUMENT do not. */
+export type MotionNode = BaseNode & MotionNodeMixin;
+
+/** Runtime guard: the Motion mixin methods are present on scene nodes, absent on PAGE / DOCUMENT. */
+export const isMotionNode = (node: BaseNode): node is MotionNode => 'applyAnimationStyle' in node;
+
+/**
+ * Motion authoring and video export only work in the Figma Design editor. Throw a clear, actionable
+ * error rather than letting the plugin API reject opaquely (or silently no-op) in FigJam / Dev
+ * Mode.
+ */
+export const assertFigmaEditor = (figmaCtx: typeof figma, tool: string): void => {
+  if (figmaCtx.editorType !== 'figma') {
+    throw new Error(
+      `${tool}: Figma Motion is only available in the Figma Design editor (current editor: ${figmaCtx.editorType}).`,
+    );
+  }
+};
+
+/**
+ * Light semantic check the grounded MCP schema can't express: an effects INDEXED_ITEM must carry a
+ * `field` or a `propertyId`. Keeps the common PROPERTY / fills / strokes paths untouched.
+ */
+export const assertKeyframeField = (field: unknown, tool: string): void => {
+  if (typeof field !== 'object' || field === null) {
+    throw new TypeError(`${tool}: field must be an object`);
+  }
+  const f = field as {
+    type?: unknown;
+    collection?: unknown;
+    field?: unknown;
+    propertyId?: unknown;
+  };
+  if (
+    f.type === 'INDEXED_ITEM' &&
+    f.collection === 'effects' &&
+    f.field === undefined &&
+    f.propertyId === undefined
+  ) {
+    throw new TypeError(`${tool}: an effects INDEXED_ITEM field needs "field" or "propertyId"`);
+  }
+};
+
+/**
+ * Deep-clone a plugin-API structure to plain JSON. Motion's animation / keyframe objects are plain
+ * data keyed by field name; this shields the RPC envelope from any live proxy the API may hand
+ * back.
+ */
+export const toPlainJson = (value: unknown): unknown => JSON.parse(JSON.stringify(value));

--- a/packages/plugin/src/handlers/registry.ts
+++ b/packages/plugin/src/handlers/registry.ts
@@ -3,6 +3,8 @@ import { createIdempotencyCache, idempotent } from '../idempotency.js';
 import { createAddComponentPropertyHandler } from './add-component-property.js';
 import { createAddPageHandler } from './add-page.js';
 import { createAddVariableModeHandler } from './add-variable-mode.js';
+import { createApplyAnimationStyleHandler } from './apply-animation-style.js';
+import { createApplyManualKeyframeTrackHandler } from './apply-manual-keyframe-track.js';
 import { createApplyStyleToNodeHandler } from './apply-style-to-node.js';
 import { createBatchRenameNodesHandler } from './batch-rename-nodes.js';
 import { createBatchHandler } from './batch.js';
@@ -33,6 +35,7 @@ import { createDeleteVariableHandler } from './delete-variable.js';
 import { createDetachInstanceHandler } from './detach-instance.js';
 import { createEditComponentPropertyHandler } from './edit-component-property.js';
 import { createExportPdfHandler } from './export-pdf.js';
+import { createExportVideoHandler } from './export-video.js';
 import { createFindReplaceTextHandler } from './find-replace-text.js';
 import { createGetAnnotationsHandler } from './get-annotations.js';
 import { createGetComponentApiHandler } from './get-component-api.js';
@@ -41,6 +44,8 @@ import { createGetDocumentHandler } from './get-document.js';
 import { createGetFontsHandler } from './get-fonts.js';
 import { createGetLocalComponentsHandler } from './get-local-components.js';
 import { createGetMetadataHandler } from './get-metadata.js';
+import { createGetMotionStylesHandler } from './get-motion-styles.js';
+import { createGetNodeMotionHandler } from './get-node-motion.js';
 import { createGetNodeHandler } from './get-node.js';
 import { createGetNodesInfoHandler } from './get-nodes-info.js';
 import { createGetPagesHandler } from './get-pages.js';
@@ -58,6 +63,8 @@ import { createSetLockedHandler } from './lock-nodes.js';
 import { createMoveNodesHandler } from './move-nodes.js';
 import { createNavigateToPageHandler } from './navigate-to-page.js';
 import { createPingHandler } from './ping.js';
+import { createRemoveAnimationStyleHandler } from './remove-animation-style.js';
+import { createRemoveManualKeyframeTrackHandler } from './remove-manual-keyframe-track.js';
 import { createRemoveReactionsHandler } from './remove-reactions.js';
 import { createRenameNodeHandler } from './rename-node.js';
 import { createRenamePageHandler } from './rename-page.js';
@@ -88,6 +95,7 @@ import { createSetStrokesHandler } from './set-strokes.js';
 import { createSetTextPropertiesHandler } from './set-text-properties.js';
 import { createSetTextRangeHandler } from './set-text-range.js';
 import { createSetTextHandler } from './set-text.js';
+import { createSetTimelineDurationHandler } from './set-timeline-duration.js';
 import { createSetVariableCodeSyntaxHandler } from './set-variable-code-syntax.js';
 import { createSetVariableValueHandler } from './set-variable-value.js';
 import { createSetVisibleHandler } from './set-visible.js';
@@ -187,6 +195,12 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     create_section: createCreateSectionHandler(figmaCtx),
     create_instance: createCreateInstanceHandler(figmaCtx),
     combine_as_variants: createCombineAsVariantsHandler(figmaCtx),
+    // Motion (beta) — Figma Design only
+    apply_animation_style: createApplyAnimationStyleHandler(figmaCtx),
+    remove_animation_style: createRemoveAnimationStyleHandler(figmaCtx),
+    apply_manual_keyframe_track: createApplyManualKeyframeTrackHandler(figmaCtx),
+    remove_manual_keyframe_track: createRemoveManualKeyframeTrackHandler(figmaCtx),
+    set_timeline_duration: createSetTimelineDurationHandler(figmaCtx),
   };
 
   const handlers: SandboxHandlers = {
@@ -208,11 +222,14 @@ export const createSandboxHandlers = (figmaCtx: typeof figma): SandboxHandlers =
     get_fonts: createGetFontsHandler(figmaCtx),
     get_annotations: createGetAnnotationsHandler(figmaCtx),
     get_reactions: createGetReactionsHandler(figmaCtx),
+    get_motion_styles: createGetMotionStylesHandler(figmaCtx),
+    get_node_motion: createGetNodeMotionHandler(figmaCtx),
     list_files: createListFilesHandler(figmaCtx),
     get_design_context: createGetDesignContextHandler(figmaCtx),
     get_screenshot: createGetScreenshotHandler(figmaCtx),
     save_image_fills: createSaveImageFillsHandler(figmaCtx),
     export_pdf: createExportPdfHandler(figmaCtx),
+    export_video: createExportVideoHandler(figmaCtx),
   };
 
   for (const name of Object.keys(rawWrites)) {

--- a/packages/plugin/src/handlers/remove-animation-style.ts
+++ b/packages/plugin/src/handlers/remove-animation-style.ts
@@ -1,0 +1,36 @@
+import type { MutateResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor, isMotionNode } from './motion-shared.js';
+
+/**
+ * Remove one applied Motion animation style (by its appliedStyleId), or all of them when no id is
+ * given. Destructive: severing an applied style can't be reconstructed without re-applying.
+ */
+export const createRemoveAnimationStyleHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; animationStyleId?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('remove_animation_style: nodeId must be a string');
+    }
+    if (p.animationStyleId !== undefined && typeof p.animationStyleId !== 'string') {
+      throw new TypeError('remove_animation_style: animationStyleId must be a string');
+    }
+    assertFigmaEditor(figmaCtx, 'remove_animation_style');
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `remove_animation_style: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    if (typeof p.animationStyleId === 'string') {
+      node.removeAnimationStyle(p.animationStyleId);
+    } else {
+      // Snapshot ids first — removing mutates the live animationStyles list.
+      const appliedIds = node.animationStyles.map(applied => applied.id);
+      for (const id of appliedIds) node.removeAnimationStyle(id);
+    }
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/src/handlers/remove-manual-keyframe-track.ts
+++ b/packages/plugin/src/handlers/remove-manual-keyframe-track.ts
@@ -1,0 +1,25 @@
+import type { MutateResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor, assertKeyframeField, isMotionNode } from './motion-shared.js';
+
+/** Remove the manual keyframe track for a field on a node. Destructive: the track is discarded. */
+export const createRemoveManualKeyframeTrackHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; field?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('remove_manual_keyframe_track: nodeId must be a string');
+    }
+    assertKeyframeField(p.field, 'remove_manual_keyframe_track');
+    assertFigmaEditor(figmaCtx, 'remove_manual_keyframe_track');
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `remove_manual_keyframe_track: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    node.removeManualKeyframeTrack(p.field as KeyframeField);
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/src/handlers/set-timeline-duration.ts
+++ b/packages/plugin/src/handlers/set-timeline-duration.ts
@@ -1,0 +1,30 @@
+import type { MutateResult } from '@figwright/shared';
+
+import type { SandboxToolHandler } from '../dispatcher.js';
+import { assertFigmaEditor, isMotionNode } from './motion-shared.js';
+
+/** Set a Motion timeline's duration (seconds, > 0). timelineId comes from get_node_motion. */
+export const createSetTimelineDurationHandler =
+  (figmaCtx: typeof figma): SandboxToolHandler =>
+  async params => {
+    const p = (params ?? {}) as { nodeId?: unknown; timelineId?: unknown; duration?: unknown };
+    if (typeof p.nodeId !== 'string') {
+      throw new TypeError('set_timeline_duration: nodeId must be a string');
+    }
+    if (typeof p.timelineId !== 'string') {
+      throw new TypeError('set_timeline_duration: timelineId must be a string');
+    }
+    if (typeof p.duration !== 'number' || !(p.duration > 0)) {
+      throw new TypeError('set_timeline_duration: duration must be a positive number (seconds)');
+    }
+    assertFigmaEditor(figmaCtx, 'set_timeline_duration');
+    const node = await figmaCtx.getNodeByIdAsync(p.nodeId);
+    if (node === null || !isMotionNode(node)) {
+      throw new Error(
+        `set_timeline_duration: node ${p.nodeId} not found or does not support Motion`,
+      );
+    }
+    node.setTimelineDuration(p.timelineId, p.duration);
+    const result: MutateResult = { ok: true, nodeId: node.id };
+    return result;
+  };

--- a/packages/plugin/test/handlers/batch.test.ts
+++ b/packages/plugin/test/handlers/batch.test.ts
@@ -2,6 +2,8 @@ import type { BatchResult } from '@figwright/shared';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { SandboxHandlers } from '../../src/dispatcher.js';
+import { createApplyAnimationStyleHandler } from '../../src/handlers/apply-animation-style.js';
+import { createApplyManualKeyframeTrackHandler } from '../../src/handlers/apply-manual-keyframe-track.js';
 import { createBatchHandler } from '../../src/handlers/batch.js';
 import { createCreateComponentHandler } from '../../src/handlers/create-component.js';
 import { createCreateFrameHandler } from '../../src/handlers/create-frame.js';
@@ -13,6 +15,7 @@ import { createSetFillsHandler } from '../../src/handlers/set-fills.js';
 import { createSetOpacityHandler } from '../../src/handlers/set-opacity.js';
 import { createSetStrokesHandler } from '../../src/handlers/set-strokes.js';
 import { createSetTextPropertiesHandler } from '../../src/handlers/set-text-properties.js';
+import { createSetTimelineDurationHandler } from '../../src/handlers/set-timeline-duration.js';
 import { createIdempotencyCache, idempotent } from '../../src/idempotency.js';
 
 /** A mutable node store backing a fake figma whose getNodeByIdAsync / createFrame share one map. */
@@ -373,5 +376,210 @@ describe('batch handler', () => {
     await expect(handler({})).rejects.toThrow(/ops must be an array/);
     await expect(handler({ ops: [] })).rejects.toThrow(/must not be empty/);
     await expect(handler({ ops: [{ params: {} }] })).rejects.toThrow(/tool must be a string/);
+  });
+});
+
+// ── Motion (beta) batch inverses ─────────────────────────────────────────────
+
+const makeMotionFigma = (editorType = 'figma') => {
+  const store = new Map<string, Record<string, unknown>>();
+
+  const addMotionNode = (
+    id: string,
+    init: { tracks?: Record<string, unknown>; timelines?: { id: string; duration: number }[] } = {},
+  ) => {
+    const applied: { id: string; styleId: string }[] = [];
+    const tracks: Record<string, unknown> = { ...init.tracks };
+    const timelines = init.timelines ?? [];
+    let seq = 0;
+    const node = {
+      id,
+      get animationStyles() {
+        return applied.slice();
+      },
+      get manualKeyframeTracks() {
+        return tracks;
+      },
+      get timelines() {
+        return timelines;
+      },
+      applyAnimationStyle: vi.fn<(styleId: string) => string>((styleId: string) => {
+        const appliedId = `${id}:as:${(seq += 1)}`;
+        applied.push({ id: appliedId, styleId });
+        return appliedId;
+      }),
+      removeAnimationStyle: vi.fn<(appliedId: string) => void>((appliedId: string) => {
+        const i = applied.findIndex(a => a.id === appliedId);
+        if (i >= 0) applied.splice(i, 1);
+      }),
+      applyManualKeyframeTrack: vi.fn<
+        (field: { type: string; name?: string }, track: unknown) => void
+      >((field: { type: string; name?: string }, track: unknown) => {
+        if (field.type === 'PROPERTY' && field.name !== undefined) tracks[field.name] = track;
+      }),
+      removeManualKeyframeTrack: vi.fn<(field: { type: string; name?: string }) => void>(
+        (field: { type: string; name?: string }) => {
+          if (field.type === 'PROPERTY' && field.name !== undefined) delete tracks[field.name];
+        },
+      ),
+      setTimelineDuration: vi.fn<(tid: string, d: number) => void>((tid: string, d: number) => {
+        const t = timelines.find(x => x.id === tid);
+        if (t !== undefined) t.duration = d;
+      }),
+    };
+    store.set(id, node as unknown as Record<string, unknown>);
+    return node;
+  };
+
+  const figmaCtx = {
+    editorType,
+    getNodeByIdAsync: async (id: string) => store.get(id) ?? null,
+  } as unknown as typeof figma;
+
+  return { figmaCtx, store, addMotionNode };
+};
+
+const motionWrites = (figmaCtx: typeof figma): SandboxHandlers => ({
+  apply_animation_style: createApplyAnimationStyleHandler(figmaCtx),
+  apply_manual_keyframe_track: createApplyManualKeyframeTrackHandler(figmaCtx),
+  set_timeline_duration: createSetTimelineDurationHandler(figmaCtx),
+  set_fills: createSetFillsHandler(figmaCtx),
+});
+
+/** A trailing op that always fails at apply time, forcing rollback of the preceding Motion op. */
+const FAILING_FILL = {
+  tool: 'set_fills',
+  params: { nodeId: 'F', fills: [{ type: 'GRADIENT_LINEAR' }] },
+};
+
+describe('batch Motion inverses', () => {
+  it('rolls back apply_animation_style by removing the applied style instance', async () => {
+    const { figmaCtx, store, addMotionNode } = makeMotionFigma();
+    const a = addMotionNode('1:1');
+    store.set('F', { id: 'F', fills: [] });
+    const handler = createBatchHandler(figmaCtx, motionWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          { tool: 'apply_animation_style', params: { nodeId: '1:1', styleId: 's1' } },
+          FAILING_FILL,
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(a.removeAnimationStyle).toHaveBeenCalledWith('1:1:as:1');
+    expect(a.animationStyles).toHaveLength(0);
+  });
+
+  it('restores a prior PROPERTY keyframe track on rollback', async () => {
+    const OLD = {
+      baseValue: { type: 'FLOAT', value: 0 },
+      keyframes: [{ timelinePosition: 0, value: { type: 'FLOAT', value: 0 } }],
+    };
+    const { figmaCtx, store, addMotionNode } = makeMotionFigma();
+    const a = addMotionNode('1:1', { tracks: { TRANSLATION_X: OLD } });
+    store.set('F', { id: 'F', fills: [] });
+    const handler = createBatchHandler(figmaCtx, motionWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          {
+            tool: 'apply_manual_keyframe_track',
+            params: {
+              nodeId: '1:1',
+              field: { type: 'PROPERTY', name: 'TRANSLATION_X' },
+              track: {
+                keyframes: [{ timelinePosition: 0.3, value: { type: 'FLOAT', value: 120 } }],
+              },
+            },
+          },
+          FAILING_FILL,
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(a.manualKeyframeTracks.TRANSLATION_X).toEqual(OLD); // deep-equal, from the cloned snapshot
+  });
+
+  it('removes a PROPERTY keyframe track on rollback when there was none before', async () => {
+    const { figmaCtx, store, addMotionNode } = makeMotionFigma();
+    const a = addMotionNode('1:1');
+    store.set('F', { id: 'F', fills: [] });
+    const handler = createBatchHandler(figmaCtx, motionWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          {
+            tool: 'apply_manual_keyframe_track',
+            params: {
+              nodeId: '1:1',
+              field: { type: 'PROPERTY', name: 'OPACITY' },
+              track: { keyframes: [{ timelinePosition: 0, value: { type: 'FLOAT', value: 1 } }] },
+            },
+          },
+          FAILING_FILL,
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(a.removeManualKeyframeTrack).toHaveBeenCalledWith({ type: 'PROPERTY', name: 'OPACITY' });
+    expect(a.manualKeyframeTracks.OPACITY).toBeUndefined();
+  });
+
+  it('rejects an indexed (effects) keyframe track as not batchable, before any op runs', async () => {
+    const { figmaCtx, addMotionNode } = makeMotionFigma();
+    addMotionNode('1:1');
+    const handler = createBatchHandler(figmaCtx, motionWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          {
+            tool: 'apply_manual_keyframe_track',
+            params: {
+              nodeId: '1:1',
+              field: { type: 'INDEXED_ITEM', collection: 'effects', index: 0, field: 'RADIUS' },
+              track: { keyframes: [{ timelinePosition: 0, value: { type: 'FLOAT', value: 1 } }] },
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/only PROPERTY fields are batchable/);
+  });
+
+  it('restores a timeline duration on rollback', async () => {
+    const { figmaCtx, store, addMotionNode } = makeMotionFigma();
+    const a = addMotionNode('1:1', { timelines: [{ id: 't1', duration: 1 }] });
+    store.set('F', { id: 'F', fills: [] });
+    const handler = createBatchHandler(figmaCtx, motionWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [
+          {
+            tool: 'set_timeline_duration',
+            params: { nodeId: '1:1', timelineId: 't1', duration: 5 },
+          },
+          FAILING_FILL,
+        ],
+      }),
+    ).rejects.toThrow(/rolled back 1/);
+
+    expect(a.timelines[0]!.duration).toBe(1);
+  });
+
+  it('rejects Motion ops outside the Figma Design editor at capture time', async () => {
+    const { figmaCtx, addMotionNode } = makeMotionFigma('figjam');
+    addMotionNode('1:1');
+    const handler = createBatchHandler(figmaCtx, motionWrites(figmaCtx));
+
+    await expect(
+      handler({
+        ops: [{ tool: 'apply_animation_style', params: { nodeId: '1:1', styleId: 's1' } }],
+      }),
+    ).rejects.toThrow(/Figma Design editor/);
   });
 });

--- a/packages/plugin/test/handlers/get-design-context.test.ts
+++ b/packages/plugin/test/handlers/get-design-context.test.ts
@@ -844,3 +844,45 @@ describe('get_design_context node-count bail (budget)', () => {
     expect(r.sectionPlan?.sections[0]?.nodeId).toBe('w0');
   });
 });
+
+describe('get_design_context — Motion (beta) summary', () => {
+  const animated = (over: Record<string, unknown> = {}): SceneNode =>
+    node({
+      id: 'anim',
+      name: 'Card',
+      animationStyles: [{ id: 'as1', name: 'Slide In' }],
+      animations: { TRANSLATION_X: {}, OPACITY: {} },
+      timelines: [{ id: 't1', duration: 1.2 }],
+      ...over,
+    });
+
+  it('attaches a compact motion summary at full detail for an animated node', async () => {
+    const handler = createGetDesignContextHandler(fakeFigma({ selection: [animated()] }));
+    const r = (await handler({ detail: 'full' })) as GetDesignContextResult;
+    expect(r.nodes[0]?.motion).toEqual({
+      animationStyles: ['Slide In'],
+      animatedProperties: ['TRANSLATION_X', 'OPACITY'],
+      timelineDuration: 1.2,
+    });
+  });
+
+  it('omits motion at compact detail — the hot path stays untouched', async () => {
+    const handler = createGetDesignContextHandler(fakeFigma({ selection: [animated()] }));
+    const r = (await handler({ detail: 'compact' })) as GetDesignContextResult;
+    expect(r.nodes[0]?.motion).toBeUndefined();
+  });
+
+  it('omits motion for a node that carries no animation', async () => {
+    const still = animated({ animationStyles: [], animations: {}, timelines: [] });
+    const handler = createGetDesignContextHandler(fakeFigma({ selection: [still] }));
+    const r = (await handler({ detail: 'full' })) as GetDesignContextResult;
+    expect(r.nodes[0]?.motion).toBeUndefined();
+  });
+
+  it('omits motion for a node lacking the Motion mixin entirely', async () => {
+    const plain = node({ id: 'p', name: 'Plain' }); // no animationStyles property at all
+    const handler = createGetDesignContextHandler(fakeFigma({ selection: [plain] }));
+    const r = (await handler({ detail: 'full' })) as GetDesignContextResult;
+    expect(r.nodes[0]?.motion).toBeUndefined();
+  });
+});

--- a/packages/shared/src/design-context.ts
+++ b/packages/shared/src/design-context.ts
@@ -222,6 +222,13 @@ export interface DesignContextNode {
   styleIds?: SerializedStyleIds;
   boundVariables?: Readonly<Record<string, readonly string[]>>;
   componentProperties?: Readonly<Record<string, SerializedComponentProperty>>;
+  /**
+   * Motion (beta) summary — attached at full detail to nodes that carry animation, so codegen sees
+   * that a layer animates (and how) without a separate get_node_motion call. Compact by design: the
+   * applied preset names, the animated property fields, and the containing timeline's duration —
+   * never the full keyframe data (get_node_motion has that).
+   */
+  motion?: MotionSummary;
   mainComponent?: SerializedMainComponent;
   mainComponentId?: string;
   /**
@@ -268,6 +275,19 @@ export interface DesignContextNode {
   }[];
   truncated?: boolean;
   children?: readonly DesignContextNode[];
+}
+
+/** Compact Motion (beta) summary for a node — see {@link DesignContextNode.motion}. */
+export interface MotionSummary {
+  /** Applied animation-style preset names. */
+  animationStyles?: readonly string[];
+  /**
+   * Field names that carry keyframes (PROPERTY names like TRANSLATION_X, plus
+   * fills/strokes/effects).
+   */
+  animatedProperties?: readonly string[];
+  /** Duration in seconds of the timeline this node participates in. */
+  timelineDuration?: number;
 }
 
 // Cast through unknown: zod's .optional() outputs `T | undefined`, while DesignContextNode uses
@@ -372,6 +392,13 @@ export const DesignContextNodeSchema = z.lazy(() =>
     styleIds: SerializedStyleIdsSchema.optional(),
     boundVariables: z.record(z.string(), z.array(z.string())).optional(),
     componentProperties: z.record(z.string(), SerializedComponentPropertySchema).optional(),
+    motion: z
+      .object({
+        animationStyles: z.array(z.string()).optional(),
+        animatedProperties: z.array(z.string()).optional(),
+        timelineDuration: z.number().optional(),
+      })
+      .optional(),
     mainComponent: SerializedMainComponentSchema.optional(),
     mainComponentId: z.string().optional(),
     fill: z.string().optional(),

--- a/packages/shared/src/queries.ts
+++ b/packages/shared/src/queries.ts
@@ -97,6 +97,46 @@ export const ExportPdfResultSchema = z.object({
 });
 export type ExportPdfResult = z.infer<typeof ExportPdfResultSchema>;
 
+// ── export_video (an animated top-level frame → MP4 / GIF / WebM) ────────────
+export const VIDEO_FORMATS = ['MP4', 'GIF', 'WEBM'] as const;
+export type VideoFormat = (typeof VIDEO_FORMATS)[number];
+
+/**
+ * Why a video export produced no bytes. The first three are cheap pre-checks: `wrong-editor` (not
+ * the Figma Design editor), `not-found` (missing node), `no-top-level-frame` (nothing resolves to a
+ * top-level frame). `failed` is any exportAsync rejection — Figma's own message rides in `error`,
+ * so the caller sees the real cause (a static frame with no animation, an unsupported setting, or
+ * an export that raced another plugin call) instead of a single guessed label.
+ */
+export const VIDEO_EXPORT_MISS_REASONS = [
+  'not-found',
+  'no-top-level-frame',
+  'wrong-editor',
+  'failed',
+] as const;
+export type VideoExportMissReason = (typeof VIDEO_EXPORT_MISS_REASONS)[number];
+
+/** Plugin-side video export: base64 bytes of the encoded frame, or null + a reason when it couldn't. */
+export const VideoExportSchema = z.object({
+  nodeId: z.string(),
+  format: z.enum(VIDEO_FORMATS),
+  base64: z.string().nullable(),
+  reason: z.enum(VIDEO_EXPORT_MISS_REASONS).optional(),
+  /** Figma's own rejection message, present when reason is `failed`. */
+  error: z.string().optional(),
+});
+export type VideoExport = z.infer<typeof VideoExportSchema>;
+
+/** Result of export_video: the written file path (null + reason when nothing was exported). */
+export const ExportVideoResultSchema = z.object({
+  nodeId: z.string(),
+  format: z.enum(VIDEO_FORMATS),
+  path: z.string().nullable(),
+  reason: z.enum(VIDEO_EXPORT_MISS_REASONS).optional(),
+  error: z.string().optional(),
+});
+export type ExportVideoResult = z.infer<typeof ExportVideoResultSchema>;
+
 // ── save_image_fills ─────────────────────────────────────────────────────────
 /**
  * One IMAGE fill's ORIGINAL bytes, as uploaded — no mask, clip, crop, scale, or effects applied
@@ -222,3 +262,38 @@ export const GetReactionsResultSchema = z.object({
   reactions: z.array(SerializedReactionSchema),
 });
 export type GetReactionsResult = z.infer<typeof GetReactionsResultSchema>;
+
+// ── Motion (beta): get_motion_styles / get_node_motion ───────────────────────
+export const MotionStyleSchema = z.object({
+  styleId: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  props: z.record(z.string(), z.string()).optional(),
+});
+export type MotionStyle = z.infer<typeof MotionStyleSchema>;
+
+export const GetMotionStylesResultSchema = z.object({ styles: z.array(MotionStyleSchema) });
+export type GetMotionStylesResult = z.infer<typeof GetMotionStylesResultSchema>;
+
+export const TimelineSchema = z.object({ id: z.string(), duration: z.number() });
+export type Timeline = z.infer<typeof TimelineSchema>;
+
+/**
+ * A node's Motion state, mirrored from the plugin API. The keyframe structures (`animations`,
+ * `manualKeyframeTracks`) are deep but plain JSON keyed by field name, so they pass through as
+ * `unknown` rather than re-modeling every KeyframeBinding — the grounded write schema
+ * (motion-schemas) is where authoring shape is enforced. `null` when the node supports no Motion.
+ */
+export const NodeMotionSchema = z.object({
+  animationStyles: z.array(z.unknown()),
+  animations: z.record(z.string(), z.unknown()),
+  manualKeyframeTracks: z.record(z.string(), z.unknown()),
+  timelines: z.array(TimelineSchema),
+});
+export type NodeMotion = z.infer<typeof NodeMotionSchema>;
+
+export const GetNodeMotionResultSchema = z.object({
+  nodeId: z.string(),
+  motion: NodeMotionSchema.nullable(),
+});
+export type GetNodeMotionResult = z.infer<typeof GetNodeMotionResultSchema>;

--- a/packages/shared/src/writes.ts
+++ b/packages/shared/src/writes.ts
@@ -10,6 +10,18 @@ export const MutateResultSchema = z.object({
 });
 export type MutateResult = z.infer<typeof MutateResultSchema>;
 
+/**
+ * Result of apply_animation_style: echoes the applied-style instance id Figma returns from
+ * applyAnimationStyle. batch's inverse uses it to removeAnimationStyle on undo, so it must
+ * round-trip.
+ */
+export const ApplyAnimationStyleResultSchema = z.object({
+  ok: z.literal(true),
+  nodeId: z.string(),
+  appliedStyleId: z.string(),
+});
+export type ApplyAnimationStyleResult = z.infer<typeof ApplyAnimationStyleResultSchema>;
+
 /** Result of a node-creation write (create_frame / …): the new node's id + identity. */
 export const CreateResultSchema = z.object({
   ok: z.literal(true),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         version: 3.5.39(typescript@6.0.3)
     devDependencies:
       '@figma/plugin-typings':
-        specifier: ^1.130.0
-        version: 1.130.0
+        specifier: ^1.131.0
+        version: 1.131.0
       '@figwright/shared':
         specifier: workspace:*
         version: link:../shared
@@ -157,8 +157,8 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@figma/plugin-typings@1.130.0':
-    resolution: {integrity: sha512-kz+eU4TXBr99YrMyF2/WtcsdS6K4Ksy3datZZtuCUUSDPRknJAVLZpjhBESCd0tCtHRWKeo4l/I7Aze6lHB52A==}
+  '@figma/plugin-typings@1.131.0':
+    resolution: {integrity: sha512-XBTPNGc65myupitMaeemyiF/ir1jn/EXXTdoGUCEVCfVB6KPQUy+gbfHbnC+QQiHxdw/Naikdx+9v/u4d49gfA==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1092,8 +1092,14 @@ packages:
   '@vue/compiler-core@3.5.39':
     resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
   '@vue/compiler-dom@3.5.39':
     resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
 
   '@vue/compiler-sfc@3.5.39':
     resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
@@ -1120,6 +1126,9 @@ packages:
 
   '@vue/shared@3.5.39':
     resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
   '@vueuse/core@14.3.0':
     resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
@@ -2416,7 +2425,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@figma/plugin-typings@1.130.0': {}
+  '@figma/plugin-typings@1.131.0': {}
 
   '@hono/node-server@1.19.14(hono@4.12.26)':
     dependencies:
@@ -3029,10 +3038,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.39':
     dependencies:
       '@vue/compiler-core': 3.5.39
       '@vue/shared': 3.5.39
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/compiler-sfc@3.5.39':
     dependencies:
@@ -3054,8 +3076,8 @@ snapshots:
   '@vue/language-core@3.3.7':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.39
-      '@vue/shared': 3.5.39
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -3084,6 +3106,8 @@ snapshots:
       vue: 3.5.39(typescript@6.0.3)
 
   '@vue/shared@3.5.39': {}
+
+  '@vue/shared@3.5.40': {}
 
   '@vueuse/core@14.3.0(vue@3.5.39(typescript@6.0.3))':
     dependencies:

--- a/skills/figma-build/SKILL.md
+++ b/skills/figma-build/SKILL.md
@@ -60,6 +60,16 @@ hardcode width/height), and real fonts (a new TEXT node defaults to Inter). →
   variables/collections, paint/text styles, or components + variant sets, then switch back to the
   reuse path. → **[`references/author-design-system.md`](./references/author-design-system.md).**
 
+## Motion (animation)
+
+When the source carries animation — CSS `@keyframes` / `transition`, Framer Motion, GSAP, a Vue/Svelte
+transition — author it as Figma **Motion (beta)** on the frame you built rather than dropping it:
+`apply_animation_style` (presets from `get_motion_styles`) or `apply_manual_keyframe_track` per
+property, `set_timeline_duration` for length. A staggered row is **one atomic `batch`** of
+`apply_animation_style` ops with increasing `config.timelineOffset` — not N calls. Motion is
+Figma-Design-only and keyframes attach to a top-level frame's layers, so build the frame first.
+→ **[`references/motion.md`](./references/motion.md).**
+
 ## Verify visually (close the loop)
 
 `get_screenshot` the built node, fix discrepancies, and re-screenshot — the same render-and-diff

--- a/skills/figma-build/references/motion.md
+++ b/skills/figma-build/references/motion.md
@@ -1,0 +1,86 @@
+# Code → Motion (author animation in Figma)
+
+The reverse of `figma-codegen`'s `references/motion.md`: when the source you're building from carries
+animation — CSS `@keyframes` / `transition`, Framer Motion props, GSAP, a Vue/Svelte transition — author
+it as Figma **Motion (beta)** on the frame you built, instead of dropping it to a static layout.
+
+**Preconditions (check first, fail friendly):** Motion authoring only works in the **Figma Design**
+editor, and keyframes attach to the layers of a **top-level frame** (a frame directly on the page).
+Build the frame + its layers first, then animate them. FigJam / Dev Mode can't.
+
+## Recognise the animation in the source
+
+- **CSS** — `@keyframes name { … }` + `animation`, or a `transition` on enter/hover.
+- **Framer Motion** — `initial` / `animate` / `variants`, `transition`, `whileHover`, `staggerChildren`.
+- **GSAP** — `gsap.to/from/timeline`, `stagger`.
+- **Vue / Svelte** — `<transition>` / `transition:` directives.
+
+Read the real values from the source (the keyframe stops, the duration, the easing) — don't eyeball.
+
+## Author it with the Motion tools
+
+1. **`get_motion_styles`** first. If the animation is a common entrance (fade in, slide in from a
+   direction), a preset likely matches → **`apply_animation_style`** with `config` tuning
+   `duration` (seconds) and preset props (direction, distance). Prefer a preset over hand-keyframing
+   when it fits — it's what a designer would reach for.
+2. Otherwise **`apply_manual_keyframe_track`** per animated property. Map source → Figma field:
+
+   | Source                                                      | Figma `field` (`{ type:'PROPERTY', name }`)     | `value` type       |
+   | ----------------------------------------------------------- | ----------------------------------------------- | ------------------ |
+   | `translateX/Y`, Framer `x`/`y`                              | `TRANSLATION_X` / `TRANSLATION_Y`               | `FLOAT`            |
+   | `scale`, `scaleX/Y`                                         | `SCALE_XY` / `SCALE_X` / `SCALE_Y`              | `FLOAT`            |
+   | `rotate` (deg)                                              | `ROTATION` (**radians** — `rad = deg * π/180`)  | `FLOAT`            |
+   | `opacity`                                                   | `OPACITY`                                       | `FLOAT`            |
+   | `border-radius`, `border-width`, width/height, gap, padding | `CORNER_RADIUS` / `STROKE_WEIGHT` / `WIDTH` / … | `FLOAT`            |
+   | colour                                                      | an indexed `fills` item                         | `COLOR` (RGBA 0–1) |
+
+   Each `track` = `{ baseValue, keyframes: [{ timelinePosition (s), value, easing? }] }`. A CSS
+   `@keyframes` `%` stop → `timelinePosition = pct/100 * duration`.
+
+3. **`set_timeline_duration`** to match the source's total duration.
+
+### Easing (reverse map)
+
+- `linear` → `{ type: 'LINEAR' }`; `ease-in/out/in-out` → `EASE_IN` / `EASE_OUT` / `EASE_IN_AND_OUT`.
+- `cubic-bezier(x1,y1,x2,y2)` → `{ type: 'CUSTOM_CUBIC_BEZIER', easingFunctionCubicBezier: {x1,y1,x2,y2} }`.
+- A **spring** (Framer `type:'spring'`, GSAP elastic) → `{ type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce } }`
+  (normalized 0–1), or a named preset (`GENTLE`/`QUICK`/`BOUNCY`/`SLOW`) when it's close.
+
+## Stagger → one atomic `batch` (the efficiency win)
+
+A `staggerChildren`, a GSAP `stagger`, or per-index `animation-delay` over a row of N nodes → **one
+`batch`** of N `apply_animation_style` ops, each with `config.timelineOffset = index * step`. That's a
+single round-trip that's undoable as a unit (Cmd-Z once reverts the whole stagger) — don't fire N
+sequential calls.
+
+```jsonc
+// batch ops for a 3-item staggered fade-in, step 0.1s
+[
+  {
+    "tool": "apply_animation_style",
+    "params": { "nodeId": "…A", "styleId": "…", "config": { "timelineOffset": 0 } },
+  },
+  {
+    "tool": "apply_animation_style",
+    "params": { "nodeId": "…B", "styleId": "…", "config": { "timelineOffset": 0.1 } },
+  },
+  {
+    "tool": "apply_animation_style",
+    "params": { "nodeId": "…C", "styleId": "…", "config": { "timelineOffset": 0.2 } },
+  },
+]
+```
+
+Manual keyframe tracks are also batchable (PROPERTY fields only). `set_timeline_duration` too.
+
+## Verify
+
+`export_video` the top-level frame to an MP4/GIF and check the motion reads right, or scrub the
+timeline in Figma. Then it's the same render-and-diff loop as a static build.
+
+## Limits (be honest)
+
+- **Motion is beta** and Figma-Design-only; if `apply_*` reports it's unavailable, say so — don't fake
+  a static approximation and call it animated.
+- **Rotation/units**: degrees → radians; colours → RGBA 0–1.
+- Author only what the source actually animates; don't invent motion the code didn't specify.

--- a/skills/figma-codegen/SKILL.md
+++ b/skills/figma-codegen/SKILL.md
@@ -147,6 +147,15 @@ back by its join as highest authority:
   design's viewport, diff against the Figma node, fix at the source.
   → [`references/verify.md`](./references/verify.md).
 
+## Motion (animation)
+
+When `get_design_context` (full detail) tags a node with a `motion` summary — applied
+animation-style presets, animated property fields, a timeline duration — carry it into the project's
+animation mechanism (CSS `@keyframes` / `transition`, Framer Motion, GSAP, Vue `<transition>`) instead
+of emitting a static component. `get_node_motion` returns the full keyframe detail when the summary
+isn't enough. Dropping a frame's animation is a fidelity miss, the same class as dropping a shadow.
+→ [`references/motion.md`](./references/motion.md).
+
 ## Rules
 
 - **Ground every section — never eyeball a value off the screenshot.** Every px size, colour,

--- a/skills/figma-codegen/references/motion.md
+++ b/skills/figma-codegen/references/motion.md
@@ -1,0 +1,69 @@
+# Motion → code (animation)
+
+Figma Motion (beta) lets a frame's layers animate — applied **animation-style presets** (fade / slide
+in), **manual keyframe tracks** on properties (translate, scale, rotate, opacity, …), and a **timeline**
+with a duration. Carry that into the project's animation mechanism instead of dropping it (a static
+component from an animated frame is a fidelity miss, the same class as dropping a shadow).
+
+## Read the animation
+
+1. **`get_design_context`** (detail `full`) tags any animated node with a compact `motion` summary:
+   - `animationStyles` — applied preset names (e.g. `"Slide In"`).
+   - `animatedProperties` — the fields that carry keyframes (`TRANSLATION_X`, `OPACITY`, `SCALE_XY`, …).
+   - `timelineDuration` — the containing timeline's length in seconds.
+2. When the summary isn't enough, **`get_node_motion`** on that node returns the full detail:
+   `animationStyles` (with configured props), `animations` / `manualKeyframeTracks` (every keyframe:
+   `timelinePosition` in seconds, typed `value`, `easing`), and `timelines`.
+
+If neither reports motion, there's no animation to carry — don't invent one.
+
+## Map to the detected stack
+
+Emit animation in the project's existing mechanism (check what's already used before adding a dep):
+CSS `@keyframes` / `transition`, Framer Motion, GSAP, Vue `<transition>`, Svelte transitions.
+
+### Property fields → transforms
+
+| Figma field                                                                       | CSS / transform                                        | Framer Motion                 |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------ | ----------------------------- |
+| `TRANSLATION_X` / `TRANSLATION_Y` / `TRANSLATION_XY`                              | `translateX/Y` (`transform`)                           | `x` / `y`                     |
+| `SCALE_X` / `SCALE_Y` / `SCALE_XY`                                                | `scaleX/Y`                                             | `scaleX` / `scaleY` / `scale` |
+| `ROTATION`                                                                        | `rotate` (deg; Figma is radians → `deg = rad * 180/π`) | `rotate` (deg)                |
+| `OPACITY`                                                                         | `opacity`                                              | `opacity`                     |
+| `CORNER_RADIUS`, `STROKE_WEIGHT`, `WIDTH`/`HEIGHT`, `STACK_SPACING`, padding, gap | the matching CSS prop                                  | style value                   |
+| effect fields (shadow `OFFSET_X`/`RADIUS`/`COLOR`, …)                             | animate `box-shadow` / `filter`                        | `boxShadow` etc.              |
+
+A `FLOAT` keyframe value is the raw number; `COLOR` is RGBA 0–1 (→ hex/rgb); `VECTOR` is `{x,y}`.
+
+### Keyframes → the mechanism
+
+- **Two-keyframe track** (base → target) is a **transition/entrance**: emit a `transition` or a
+  Framer `initial`/`animate` pair, not a full `@keyframes`.
+- **Multi-keyframe track** → CSS `@keyframes` with each `timelinePosition/duration` as a `%` stop, or a
+  Framer keyframe array (`animate={{ x: [0, 120, 100] }}`).
+- **`timelineDuration`** → `animation-duration` / `transition` duration / Framer `transition.duration`.
+
+### Easing
+
+| Figma `MotionEasing.type`                                | CSS                                                                     | Framer                                                            |
+| -------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `LINEAR`                                                 | `linear`                                                                | `"linear"`                                                        |
+| `EASE_IN` / `EASE_OUT` / `EASE_IN_AND_OUT`               | `ease-in` / `ease-out` / `ease-in-out`                                  | `"easeIn"` / `"easeOut"` / `"easeInOut"`                          |
+| `EASE_*_BACK`                                            | `cubic-bezier` overshoot (e.g. back-out `cubic-bezier(.34,1.56,.64,1)`) | `[.34,1.56,.64,1]`                                                |
+| `CUSTOM_CUBIC_BEZIER`                                    | `cubic-bezier(x1,y1,x2,y2)` from `easingFunctionCubicBezier`            | that array                                                        |
+| `GENTLE` / `QUICK` / `BOUNCY` / `SLOW` / `CUSTOM_SPRING` | **spring — no native CSS**; approximate with a bezier and note the gap  | `{ type: "spring", bounce }` (from `easingFunctionSpring.bounce`) |
+| `HOLD`                                                   | `steps(1, jump-end)`                                                    | `steps`                                                           |
+
+### Stagger
+
+A row/list whose siblings share a preset but differ in `timelineOffset` (0, 0.1, 0.2, …) is a
+**staggered entrance**. Emit it as stagger, not N hardcoded delays: Framer `staggerChildren`, CSS
+`animation-delay: calc(var(--i) * 100ms)`, GSAP `stagger`.
+
+## Fidelity limits (be honest)
+
+- **Spring is lossy to CSS.** Figma's `GENTLE`/`BOUNCY`/`CUSTOM_SPRING` have no native CSS equivalent.
+  Use a spring-capable lib (Framer/GSAP) when the project has one; otherwise approximate with a bezier
+  and flag it rather than pretending it's exact.
+- **Rotation is radians in Figma, degrees in CSS/Framer** — always convert.
+- Carry only what's animated; don't add motion a static node didn't have.


### PR DESCRIPTION
## What

Wires the Figma **Motion (beta)** API and **video export** into Figwright, taking the tool count **104 → 112**. Rather than a raw port, Motion is exposed through grounded Zod schemas (reliable authoring) and batch atomicity (efficient stagger), and read/written on both sides of the bidirectional skills.

## Tools

**Motion authoring (7)** — `get_motion_styles`, `get_node_motion`, `apply_animation_style`, `remove_animation_style`, `apply_manual_keyframe_track`, `remove_manual_keyframe_track`, `set_timeline_duration`. Shared grounded schemas (`motion-schemas.ts`: easing presets, 9 keyframe value types, the property/effect field enums); handlers gate on `editorType === 'figma'` and guard the Motion mixin.

**Video export (1)** — `export_video` encodes an animated top-level frame to MP4 / GIF / WebM. Follows the `export_pdf` local-tool pattern (plugin base64 → server writes the file), resolves any node to its top-level frame via `getTopLevelFrame()`, and returns Figma's own rejection message in `error` rather than guessing a single cause.

## Highlights

- **Batch stagger** — `apply_animation_style`, `apply_manual_keyframe_track` (PROPERTY fields only), and `set_timeline_duration` get inverses, so a staggered row is one atomic, undoable call. `apply_animation_style` undoes via the `appliedStyleId` it returns; indexed keyframe tracks are rejected up front to keep all-or-nothing honest.
- **Read grounding** — `get_design_context` (full detail) attaches a compact motion summary (preset names, animated fields, timeline duration) to animated nodes, in `buildNode` rather than `project()` since Motion is not a serializer dimension.
- **Bidirectional skills** — `figma-codegen/references/motion.md` maps Motion → CSS/Framer/GSAP/Vue; `figma-build/references/motion.md` maps code animation back to Motion keyframes.
- Bumps `@figma/plugin-typings` to **1.131** (Motion typed since 1.129, the MP4/GIF/WebM `exportAsync` overload since 1.131). Docs tool counts synced to 112.

## Verification

- Six local gates green: `typecheck / lint / format:check / knip / build / test`.
- **Live-verified end-to-end** in the Figma Design editor: preset apply, manual keyframe author/read/remove, `set_timeline_duration`, batch stagger, and **batch rollback fidelity on both undo branches** — restoring a prior PROPERTY track (read-shape binding fed back into the write API, restored identically) and removing a newly-added track (previous === null). `export_video` produces valid MP4 (H.264) + GIF (with `SCALE` constraint), resolves a child node to its frame, and returns `failed` + Figma's message on a static frame.