### PR TITLE
test(relay): de-flake heartbeat close test, add deterministic ping coverage

### DIFF
--- a/packages/mcp/test/relay/relay.test.ts
+++ b/packages/mcp/test/relay/relay.test.ts
@@ -180,21 +180,47 @@ describe('Relay hello loop', () => {
     );
     await nextMessage(ws);
 
-    const pings: Envelope[] = [];
-    ws.on('message', d => {
-      try {
-        const env = decodeEnvelope(d as ArrayBuffer);
-        if (env.kind === 'req' && env.method === SystemMethod.Ping) pings.push(env);
-      } catch {
-        /* ignore */
-      }
-    });
-
+    // Assert only the contract: a plugin that misses maxMisses heartbeats gets closed with 1001.
+    // We deliberately do NOT assert "a ping was sent first" — HeartbeatMonitor.tick() closes
+    // straight away when the first timer callback already spans >= maxMisses intervals (real under
+    // CI timer jitter), so a preceding ping is not a guarantee the implementation makes. Asserting
+    // it made this test flaky; the ping-is-sent behaviour is covered deterministically below.
     const closeCode = await new Promise<number>(resolve => {
       ws.once('close', code => resolve(code));
     });
     expect(closeCode).toBe(1001);
-    expect(pings.length).toBeGreaterThan(0);
+  });
+
+  it('sends heartbeat pings to an idle plugin', async () => {
+    // maxMisses is high so the socket never closes during the test — this isolates "the server pings
+    // an idle plugin" from the close-timing race above. The collector is registered before the first
+    // await after hello, so no ping can slip through an unlistened gap.
+    const { port } = await startRelay({ heartbeatIntervalMs: 20, heartbeatMaxMisses: 1000 });
+    const ws = await connect(port);
+    const sessionId = newId();
+    ws.send(
+      encodeEnvelope(
+        createRequest({ id: 'h', sessionId, method: SystemMethod.Hello, params: helloParams() }),
+      ),
+    );
+    await nextMessage(ws);
+
+    const firstPing = await new Promise<Envelope>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('no heartbeat ping within 2s')), 2000);
+      ws.on('message', d => {
+        try {
+          const env = decodeEnvelope(d as ArrayBuffer);
+          if (env.kind === 'req' && env.method === SystemMethod.Ping) {
+            clearTimeout(timer);
+            resolve(env);
+          }
+        } catch {
+          /* ignore non-ping frames */
+        }
+      });
+    });
+    expect(firstPing).toMatchObject({ kind: 'req', method: SystemMethod.Ping });
+    ws.close();
   });
 
   it('plugin responding to $ping keeps connection alive past timeout window', async () => {


### PR DESCRIPTION
## Problem

The `closes socket when plugin misses heartbeat` test (present since the initial commit) is intermittently red in CI:

```
AssertionError: expected 0 to be greater than 0
  packages/mcp/test/relay/relay.test.ts:197  expect(pings.length).toBeGreaterThan(0)
```

## Root cause — a bad assertion, not a relay bug

`HeartbeatMonitor.tick()` closes the socket **immediately** when the first timer callback already spans `>= maxMisses` intervals — a real possibility under CI timer jitter with the test's 30ms interval / 2 misses — so **no ping is sent before the close**. The implementation makes no "a ping precedes the close" guarantee (correctly — there's no point pinging a plugin already past its deadline), so `pings.length > 0` asserts a property the code doesn't promise. That's the definition of flaky.

A secondary contributor: the ping collector was registered only *after* `await nextMessage(ws)`, so an early ping could arrive before any listener existed.

## Fix — test-only (relay/heartbeat implementation is correct and untouched)

- Drop the flaky `pings.length` assertion; keep the real contract `closeCode === 1001` (miss heartbeat → socket closed).
- Add a deterministic `sends heartbeat pings to an idle plugin` test with `maxMisses` high (socket never closes), asserting the server pings an idle plugin — isolated from the close-timing race, collector registered before the await. Preserves ping coverage without the flakiness.

## Verification

Relay suite green **10/10 consecutive runs**; full `pnpm test`, `typecheck`, `lint`, `format:check`, `knip` all pass.