### PR TITLE
feat: add Homebrew install path and tap auto-bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 # Triggered by the tag that `pnpm release` (changelogen --release) creates and
 # you push. Builds, gates, publishes @figwright/mcp to npm with provenance via
-# OIDC trusted publishing, creates the GitHub Release from the changelog, and
-# attaches the Figma plugin as a downloadable asset.
+# OIDC trusted publishing, creates the GitHub Release from the changelog,
+# attaches the Figma plugin as a downloadable asset, and bumps the Homebrew
+# tap formula to the released version.
 on:
   push:
     tags: ['v*']
@@ -63,3 +64,33 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" "$RUNNER_TEMP/figwright-plugin-${GITHUB_REF_NAME}.zip" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Point the Homebrew tap (awdr74100/homebrew-tap) at the version npm just
+  # accepted. Needs TAP_GITHUB_TOKEN — a fine-grained PAT with contents:write
+  # on homebrew-tap only — and skips quietly when it isn't configured (forks).
+  homebrew-tap:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+    steps:
+      - name: Bump formula version and sha256
+        if: env.TAP_TOKEN != ''
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          url="https://registry.npmjs.org/@figwright/mcp/-/mcp-${version}.tgz"
+          # The registry can lag a few seconds behind a successful publish.
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
+            curl -fsSL "$url" -o mcp.tgz && break
+            sleep 15
+          done
+          sha="$(sha256sum mcp.tgz | cut -d' ' -f1)"
+          git clone --depth 1 "https://x-access-token:${TAP_TOKEN}@github.com/awdr74100/homebrew-tap.git" tap
+          cd tap
+          sed -i -E "s|mcp-[0-9][0-9A-Za-z.+-]*\.tgz|mcp-${version}.tgz|" Formula/figwright.rb
+          sed -i -E "s|sha256 \"[0-9a-f]{64}\"|sha256 \"${sha}\"|" Formula/figwright.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "figwright ${version}"
+          git push

--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ For Claude Code, add this to your `.mcp.json` (other clients use the same shape)
 
 `npx` fetches and runs the published server — no global install needed.
 
+Prefer Homebrew? Install once and point `command` at a fixed binary — no Node setup, no per-launch registry fetch, immune to version-manager `PATH` surprises:
+
+```bash
+brew install awdr74100/tap/figwright
+```
+
+```json
+{
+  "mcpServers": {
+    "figwright": {
+      "command": "/opt/homebrew/bin/figwright-mcp"
+    }
+  }
+}
+```
+
+(`/opt/homebrew/bin` on Apple Silicon — `which figwright-mcp` prints the exact path on any machine.)
+
+> ⭐ **Like it? [Star the repo](https://github.com/awdr74100/figwright/stargazers)** — stars are Homebrew's notability bar, and enough of them turn this into an official `brew install figwright`.
+
 ### 2. Install the Figma plugin
 
 The plugin isn't on the Figma Community marketplace yet, so install it from the latest release:
@@ -194,7 +214,7 @@ Figwright exposes **112 MCP tools** in three groups:
 ## Requirements
 
 - An **MCP client** (Claude Code, Cursor, …).
-- **Node.js 20.19+ or 22.12+** — the server runs via `npx`, as its own process, so this is independent of the Node version your project builds with. (This is the modern-Node baseline; Node 18/21 and 22.0–22.11 aren't supported.)
+- **Node.js 20.19+ or 22.12+** — the server runs via `npx`, as its own process, so this is independent of the Node version your project builds with. (This is the modern-Node baseline; Node 18/21 and 22.0–22.11 aren't supported. The Homebrew install brings its own Node — skip this entirely.)
 - **Figma** — the free tier is enough; the desktop app is needed to import the plugin in development.
 
 ## FAQ
@@ -202,7 +222,7 @@ Figwright exposes **112 MCP tools** in three groups:
 <details>
 <summary><strong>The server won't start — <code>command not found</code>, or it fails / disconnects with <code>-32000</code> ("Connection closed").</strong></summary>
 
-Both come down to how your MCP client launches the server: it spawns the `command` directly, **not** through your interactive shell, so it inherits none of what your shell sets up. That bites hardest when Node is managed by a version manager (**fnm, nvm, asdf, volta, mise**), since those configure `PATH` and npm from shell hooks that only run in a real terminal. It isn't specific to Figwright — it affects any `npx`-launched MCP server. There are two symptoms, with two different fixes.
+Both come down to how your MCP client launches the server: it spawns the `command` directly, **not** through your interactive shell, so it inherits none of what your shell sets up. That bites hardest when Node is managed by a version manager (**fnm, nvm, asdf, volta, mise**), since those configure `PATH` and npm from shell hooks that only run in a real terminal. It isn't specific to Figwright — it affects any `npx`-launched MCP server. The [Homebrew install](#1-add-the-server-to-your-mcp-client) sidesteps this whole class of problem (fixed absolute path, its own Node pinned); otherwise there are two symptoms, with two different fixes.
 
 **`command not found` — the client can't find `npx` / `node` on its `PATH`.**
 


### PR DESCRIPTION
## What

- **README — Quick start**: adds a Homebrew install option next to `npx`: `brew install awdr74100/tap/figwright`, with an absolute-path MCP config (`/opt/homebrew/bin/figwright-mcp`). A star CTA sits directly beneath the brew block — stars are homebrew-core's notability bar (225 needed for self-submission).
- **README — FAQ/Requirements**: the `-32000`/`command not found` FAQ now points at the Homebrew install as the fix that sidesteps the whole GUI-spawn/PATH class of failure; Requirements notes the brew install brings its own Node.
- **release.yml — new `homebrew-tap` job**: after a successful npm publish, bumps [`awdr74100/homebrew-tap`](https://github.com/awdr74100/homebrew-tap)'s formula to the released version (URL + sha256). Zero actions, `permissions: {}`; skips quietly when `TAP_GITHUB_TOKEN` isn't configured.

## Formula (lives in the tap repo)

Node formula, same shape as firebase-cli / gemini-cli / playwright-mcp in homebrew-core: `depends_on "node"` + npm registry tarball + `std_npm_args`, **plus a shebang rewrite** pinning the entry point to Homebrew's node — GUI MCP clients and fnm/nvm/mise users can no longer end up on the wrong (or no) Node.

## Verified locally (brew 6.0.11)

- `brew install` from the tap: node 26.5.0 pulled automatically, shebang rewritten to `#!/opt/homebrew/opt/node/bin/node`
- MCP `initialize` handshake against the installed binary: full round trip, clean exit on stdin EOF
- `brew test` ✅ · `brew audit --strict` ✅ · zizmor on release.yml: no findings
- Tap Trust (brew 6): currently opt-in via `HOMEBREW_REQUIRE_TAP_TRUST`; default installs have zero extra friction

## Setup needed after merge (one-time)

1. Create the public tap repo `awdr74100/homebrew-tap` (contents ready and committed locally).
2. Add a fine-grained PAT with `contents:write` on `homebrew-tap` as the `TAP_GITHUB_TOKEN` repo secret.