### PR TITLE
docs: sync glama.json to canonical description, refresh AGENTS.md facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is the canonical guide for AI agents and contributors working in this 
 
 Two halves talk over a local WebSocket relay:
 
-- **MCP server** (`packages/mcp`, published as `@figwright/mcp`) — the Node process an MCP client launches. It exposes 80+ read/write tools, plus higher-level **grounding** tools that join Figma data with the user's codebase (component / token / icon maps) and a codegen prompt. It owns the relay, leader/follower **election** (multiple MCP servers can share one plugin; **newest build wins** — a leader on an older build abdicates to a newer one at the next idle moment), and request **idempotency**.
+- **MCP server** (`packages/mcp`, published as `@figwright/mcp`) — the Node process an MCP client launches. It exposes 112 tools — reads, writes, and higher-level **grounding** tools that join Figma data with the user's codebase (component / token / icon maps) — plus a codegen prompt. It owns the relay, leader/follower **election** (multiple MCP servers can share one plugin; **newest build wins** — a leader on an older build abdicates to a newer one at the next idle moment), and request **idempotency**.
 - **Figma plugin** (`packages/plugin`) — a Vue 3 + Vite UI plus a sandbox that runs inside Figma and performs the actual Figma API calls. It connects out to the server's WebSocket.
 - **Shared** (`packages/shared`) — types, Zod schemas, the msgpack wire codec, and the plugin↔server protocol. It is **bundled into the server at build time** (not published on its own).
 
@@ -21,11 +21,11 @@ packages/
   shared/   # types, Zod schemas, msgpack codec, plugin↔server protocol (bundled into mcp)
   mcp/      # the MCP server — @figwright/mcp (Node, ESM): relay, election, tools, joins
   plugin/   # Figma plugin — Vue 3 + Vite + Tailwind v4 (UI) + sandbox (Figma API)
-skills/     # agent skills that orchestrate the tools (figma-codegen) — installable via `npx skills add`
+skills/     # agent skills that orchestrate the tools (figma-codegen, figma-build) — installable via `npx skills add`
 test/       # cross-package integration tests (e.g. server tool registry ↔ plugin handlers)
 ```
 
-`packages/mcp/src` is organized by concern: `tools/`, `relay/`, `election/`, `join/` (component/token/icon maps), `tokens/`, `profile/` (stack detection), `scan/`, `icons/`, `prompts/`.
+`packages/mcp/src` is organized by concern: `tools/`, `relay/`, `election/`, `join/` (component/token/icon maps), `tokens/`, `profile/` (stack detection), `scan/`, `icons/`, `diff/` (design_diff baselines), `prompts/`.
 
 ## Tech stack
 

--- a/glama.json
+++ b/glama.json
@@ -2,6 +2,6 @@
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": ["awdr74100"],
   "name": "figwright",
-  "description": "Open-source, bidirectional Figma agent for MCP clients — a free alternative to Figma's Dev Mode MCP. Reads designs with high-fidelity grounding and writes back to the canvas: frames, text, auto-layout, styles, variables, and components. 92 tools, no API token, no paid Figma seat.",
+  "description": "Free, two-way Figma MCP server. Turn designs into framework-aware code, and push code back to the canvas. Works with Claude Code, Cursor, Codex, and any MCP client. No API token, no paid Figma seat.",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Storefront/metadata sync pass — aligning hand-written prose with the actual state of the repo.

- **glama.json** — adopt the canonical server description introduced in #68 ("Free, two-way Figma MCP server…"), which was applied to both READMEs and both package.json files but never carried over here. Also drops the hand-written tool count, which had gone stale (said 92; actual is 112 per `ALL_TOOL_SPECS`) — the README carries the maintained number, and the listing keeps only claims that can't rot ("No API token, no paid Figma seat").
- **AGENTS.md** — three factual refreshes: tool count 80+ → 112, the `skills/` layout note now lists both skills (figma-codegen, figma-build), and the `packages/mcp/src` concern list gains the missing `diff/` directory.

No code changes.

## Verification

- `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` — all green (977 tests)
- Tool count verified against `ALL_TOOL_SPECS` in `packages/mcp/src/tools/registry.ts` (112 entries)