### PR TITLE
docs: add security policy with private reporting channel and security model

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/awdr74100/figwright/security/advisories/new
+    about: Never report security vulnerabilities in public issues — use private reporting instead. See SECURITY.md.
   - name: 💬 Questions & setup help
     url: https://github.com/awdr74100/figwright#readme
     about: Check the README first — it covers installation, quick start, and supported MCP clients.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,7 @@ What to expect:
 
 - **Acknowledgement within 3 days.** Figwright is maintained by one person, so please allow a little slack across time zones and weekends.
 - An assessment of impact and affected versions, and a fix timeline proportional to severity.
+- **Coordinated disclosure.** Please keep the report private until a fix is released. We will agree on a publication date with you and aim to publish an advisory within 90 days of triage, sooner for severe issues.
 - Credit in the published advisory and release notes, unless you prefer to stay anonymous.
 
 Please include reproduction steps, the affected tool or component, and your Figwright version (the `@figwright/mcp` version from your MCP client config, plus the plugin build if relevant).
@@ -27,6 +28,16 @@ Figwright runs **entirely on your machine**; there is no Figwright cloud service
 - **What leaves your machine.** Nothing. Figwright sends no telemetry and phones home to no one. Design data flows only between the plugin, the local relay, and your MCP client.
 - **File writes.** Export tools (screenshots, PDF, video, image fills) write only to the paths your agent explicitly passes in the tool call — the server never writes anywhere it wasn't asked to.
 
-Reports are in scope even when the trigger is a malicious Figma document or prompt-injected tool input: if Figwright's handling of untrusted input lets an attacker escalate beyond the boundaries above, we want to know.
+## Scope
+
+**In scope:** anything that lets an attacker cross the boundaries above — including when the trigger is a malicious Figma document or prompt-injected tool input. If Figwright's handling of untrusted input lets an attacker escalate beyond what this document describes, we want to know.
+
+**Out of scope — please report these where they belong:**
+
+- **Vulnerabilities in dependencies.** Report them to the upstream maintainers (or via the [npm contact form](https://www.npmjs.com/support)); open a regular issue here if Figwright needs to bump a patched release.
+- **Bugs in Figma itself** (the desktop app, the Plugin API sandbox) — report to [Figma](https://www.figma.com/security/).
+- **Bugs in your MCP client** (Claude Code, Cursor, etc.) — report to that project.
+- **Prompt injection against the AI agent itself.** An agent following bad instructions embedded in a design file is a limitation of LLM-based tooling, not a Figwright vulnerability — unless Figwright's handling of that input breaks the boundaries above, which _is_ in scope.
+- **An already-compromised machine.** Malware running with your user privileges can do everything Figwright can and more; that is not a boundary Figwright can defend.
 
 Thanks for helping keep Figwright and its users safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use [GitHub private vulnerability reporting](https://github.com/awdr74100/figwright/security/advisories/new): go to the [Security tab](https://github.com/awdr74100/figwright/security) and click **Report a vulnerability**. The report stays private between you and the maintainer until a fix is released.
+
+What to expect:
+
+- **Acknowledgement within 3 days.** Figwright is maintained by one person, so please allow a little slack across time zones and weekends.
+- An assessment of impact and affected versions, and a fix timeline proportional to severity.
+- Credit in the published advisory and release notes, unless you prefer to stay anonymous.
+
+Please include reproduction steps, the affected tool or component, and your Figwright version (the `@figwright/mcp` version from your MCP client config, plus the plugin build if relevant).
+
+## Supported versions
+
+Only the **latest release** of `@figwright/mcp` and the bundled Figma plugin receives security fixes. If you are on an older version, update before reporting — the issue may already be fixed.
+
+## Security model
+
+Figwright runs **entirely on your machine**; there is no Figwright cloud service.
+
+- **Where it runs.** Your MCP client launches the `@figwright/mcp` server locally and talks to it over stdio. The server relays to the Figma plugin over a WebSocket bound to `127.0.0.1` (port 3055) — it is never exposed to the network.
+- **What it can access.** The plugin runs in Figma's plugin sandbox and uses the official public Plugin API — the same API every Community plugin uses. It can only touch the Figma file you have open; it cannot reach your other files, your account, or your org's data, because the Plugin API doesn't expose them.
+- **What leaves your machine.** Nothing. Figwright sends no telemetry and phones home to no one. Design data flows only between the plugin, the local relay, and your MCP client.
+- **File writes.** Export tools (screenshots, PDF, video, image fills) write only to the paths your agent explicitly passes in the tool call — the server never writes anywhere it wasn't asked to.
+
+Reports are in scope even when the trigger is a malicious Figma document or prompt-injected tool input: if Figwright's handling of untrusted input lets an attacker escalate beyond the boundaries above, we want to know.
+
+Thanks for helping keep Figwright and its users safe.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` at the repo root: private-only vulnerability reporting via GitHub private vulnerability reporting (now enabled on the repo — the **Report a vulnerability** button is live on the Security tab), realistic response expectations for a solo-maintained project, and a supported-versions statement (latest release only).
- Document the **security model** as explicit, verifiable boundaries: stdio-launched local server, relay bound to `127.0.0.1:3055`, plugin sandboxed to the open file via the official Plugin API, no telemetry, file writes only at explicitly requested paths.

## Why

A researcher who finds an issue in Figwright currently has no private channel, so the likely outcome is a public 0-day issue. Trust questions about data boundaries have also come up from users; this writes the answer down where GitHub surfaces it (Security tab, new-issue flow).

Docs-only change; no code affected.