### PR TITLE
chore: drop renovate schedule, lower minimumReleaseAge to 1 day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", "group:allNonMajor", ":maintainLockFilesWeekly"],
-  "schedule": ["before 9am on Monday"],
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "1 day",
   "postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## Description

Renovate had detected every pending update but never opened a single PR — all of them were parked under **Awaiting Schedule** on Dependency Dashboard #77.

Root cause: the `schedule: ["before 9am on Monday"]` config is a single narrow weekly window, and with no `timezone` set it is interpreted in **UTC** (= Mon 08:00–17:00 Asia/Taipei, not what it looks like). The hosted Renovate app didn't perform a run inside that narrow window, so it deferred everything until the next Monday — a recurring missed-window failure mode.

This PR:
- **Removes `schedule` entirely.** `group:allNonMajor` + the default `prHourlyLimit` (2) / `prConcurrentLimit` (10) already keep PR volume low, so a schedule buys little here while adding the missed-window risk and delaying security-relevant updates by up to a week.
- **Lowers `minimumReleaseAge` from 3 days to 1 day** for fresher updates, while still skipping same-day yanked releases.

After merge, tick the *"Check this box to trigger a request for Renovate to run again"* box on #77 to open the backlog of pending PRs immediately.

## Checklist

- [ ] The canonical checks pass locally (config-only change, no code touched)
- [x] Tests are added or updated for any behavior change (n/a — Renovate config only)
- [x] Read-path / serializer changes are verified with a live round-trip (n/a)
- [x] Documentation is updated if needed (n/a)