### PR TITLE
chore: switch renovate to recommended + rangeStrategy bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "group:allNonMajor", ":maintainLockFilesWeekly"],
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "group:allNonMajor",
+    ":maintainLockFilesWeekly",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "rangeStrategy": "bump",
   "minimumReleaseAge": "1 day",
   "postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## Description

Aligns our Renovate config with the shape used across the unjs / nuxt / astro ecosystem, and stops Renovate from pinning `package.json` versions.

**Why:** we were on `config:best-practices`, which silently bundles `:pinDevDependencies` — that's what produced the "pin dependencies" PR (#86). None of the reference configs I checked use best-practices; unjs, `renovate-config-nuxt`, and astro all use **`config:recommended` + `rangeStrategy: "bump"`** (keep caret ranges, bump the floor, don't pin). Our committed `pnpm-lock.yaml` already guarantees reproducible installs, so pinning `package.json` was churn for little gain.

**Changes:**
- `config:best-practices` → `config:recommended` + `rangeStrategy: "bump"` — npm deps stay `^x.y.z`, Renovate bumps the floor instead of pinning.
- Add `helpers:pinGitHubActionDigests` explicitly — keeps GitHub Action SHAs pinned (the one best-practices piece worth keeping; our `zizmor` workflow wants it). unjs + astro both do this too.
- Add `:semanticCommitTypeAll(chore)` — every dependency PR lands as `chore(deps): …`, keeping deps out of the changelog's feat/fix sections and matching how we bump by hand. unjs + `renovate-config-nuxt` both use it.
- Unchanged: `group:allNonMajor` (one bundled non-major PR — correct for a 3-package repo), `:maintainLockFilesWeekly`, `minimumReleaseAge: "1 day"`, `pnpmDedupe`.

**Follow-up:** the stale "pin dependencies" PR (#86) is closed as obsolete; the "update all non-major" PR (#87) stays.

## Checklist

- [x] Config-only change, no code touched
- [x] Tests n/a (Renovate config)
- [x] Docs n/a