### PR TITLE
chore: pin node in renovate, drop redundant engines.pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "vitest": "^4.1.10"
   },
   "engines": {
-    "node": ">=24.0.0",
-    "pnpm": ">=11.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "pnpm@11.8.0"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
   ],
   "rangeStrategy": "bump",
   "minimumReleaseAge": "1 day",
-  "postUpdateOptions": ["pnpmDedupe"]
+  "postUpdateOptions": ["pnpmDedupe"],
+  "ignoreDeps": ["node"]
 }


### PR DESCRIPTION
## Description

Follow-up to #88, consolidating how node and pnpm versions are managed. Two related changes:

### 1. `renovate.json` — freeze node, keep pnpm updating

With `rangeStrategy: "bump"`, Renovate raised both engine floors on every toolchain release (in #87: `node >=24.0.0 → >=24.18.0`, `pnpm >=11.0.0 → >=11.15.1`). We want node pinned (bumped by hand) but pnpm current:

```json
"ignoreDeps": ["node"]
```

- **node — frozen everywhere**: every dep named `node` is ignored across managers, so both `.node-version` (nodenv) and `engines.node` (npm) stop auto-updating. Bumped by hand.
- **pnpm — stays automatic**: `packageManager` keeps updating (see below).

Matches how **vue, vite, and unjs** manage node (all three use `ignoreDeps: ["node"]`).

### 2. `package.json` — drop redundant `engines.pnpm`

```diff
  "engines": {
-   "node": ">=24.0.0",
-   "pnpm": ">=11.0.0"
+   "node": ">=24.0.0"
  },
  "packageManager": "pnpm@11.8.0"
```

The pnpm version is already pinned exactly via `packageManager` (Corepack-enforced), so `engines.pnpm` was a redundant soft assertion doing nothing. **None of vue/vite/nuxt/astro declare `engines.pnpm`** — they manage pnpm through `packageManager` alone, which Renovate keeps current (`pnpm@11.8.0 → …`). `engines.node` stays as the node version assertion.

Net result: node is fully manual; the pnpm version lives in one place (`packageManager`) and updates automatically.

## Checklist

- [x] Config + manifest change, no code touched
- [x] Tests n/a
- [x] Docs n/a