### PR TITLE
fix: gate the local relay against cross-site and DNS-rebinding access

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ Figwright exposes **112 MCP tools** in three groups:
 - **Node.js 20.19+ or 22.12+** — the server runs via `npx`, as its own process, so this is independent of the Node version your project builds with. (This is the modern-Node baseline; Node 18/21 and 22.0–22.11 aren't supported.)
 - **Figma** — the free tier is enough; the desktop app is needed to import the plugin in development.
 
+## Security
+
+Figwright runs entirely on your machine: your client launches the server over stdio, the server relays to the plugin over a WebSocket on `127.0.0.1:3055`, and nothing is sent anywhere else. The plugin uses only Figma's public Plugin API, so it reaches the file you have open and nothing beyond it.
+
+Loopback is not on its own a boundary — a web page you visit can still reach a local port — so the relay gates every request on two headers a page cannot forge: **`Host`**, which must name loopback (this is what stops DNS rebinding), and **`Origin`**, which admits the plugin's sandboxed handshake and refuses browsers everywhere else. The leader's HTTP endpoints additionally require a media type that cannot be sent without a CORS preflight. See [MCP Security Best Practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices) for the wider picture, and [SECURITY.md](./SECURITY.md) for Figwright's threat model, what is in and out of scope, and how to report a vulnerability privately.
+
+**Figwright is not a substitute for reviewing what your agent does.** Its write tools change your Figma file and its export tools write files to paths the agent chooses; an agent acting on a malicious design or a prompt-injected instruction can misuse both. Your MCP client's tool-approval controls are the boundary that matters.
+
 ## FAQ
 
 <details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,13 @@ Only the **latest release** of `@figwright/mcp` and the bundled Figma plugin rec
 
 Figwright runs **entirely on your machine**; there is no Figwright cloud service.
 
-- **Where it runs.** Your MCP client launches the `@figwright/mcp` server locally and talks to it over stdio. The server relays to the Figma plugin over a WebSocket bound to `127.0.0.1` (port 3055) — it is never exposed to the network.
+- **Where it runs.** Your MCP client launches the `@figwright/mcp` server locally and talks to it over stdio. The server relays to the Figma plugin over a WebSocket bound to `127.0.0.1` (port 3055), so it is not reachable from your network.
+- **Who can talk to it.** Binding to loopback is not by itself a boundary: a web page you visit can open a WebSocket to a local port or send it a form-style POST without any same-origin check, and DNS rebinding can make a page's own domain resolve to `127.0.0.1`. Figwright gates every request — WebSocket upgrades included — on the two headers a page cannot forge:
+  - **`Host`** must name loopback (`localhost`, `127.0.0.1`, `[::1]`). A rebound request still carries the attacker's domain here, which is what makes this the check that stops rebinding — including on `GET`, where the browser considers itself same-origin, sends no `Origin`, and would otherwise be able to read the reply.
+  - **`Origin`** must be absent (a follower process or the plugin host, neither of which is a browser) or the plugin's sandboxed origin. The leader's HTTP endpoints (`/rpc`, `/ping`, `/abdicate`) are stricter still — they refuse **any** request carrying an `Origin` — and require a media type outside the set a page can send without a CORS preflight.
+
+  If some environment's plugin host is ever refused, `FIGWRIGHT_ALLOW_ANY_ORIGIN=1` lifts the origin gate — please report it rather than leaving it set. It deliberately does not lift the host gate. What none of this defends against is another program already running as you on the same machine; see the note on a compromised machine below.
+
 - **What it can access.** The plugin runs in Figma's plugin sandbox and uses the official public Plugin API — the same API every Community plugin uses. It can only touch the Figma file you have open; it cannot reach your other files, your account, or your org's data, because the Plugin API doesn't expose them.
 - **What leaves your machine.** Nothing. Figwright sends no telemetry and phones home to no one. Design data flows only between the plugin, the local relay, and your MCP client.
 - **File writes.** Export tools (screenshots, PDF, video, image fills) write only to the paths your agent explicitly passes in the tool call — the server never writes anywhere it wasn't asked to.

--- a/packages/mcp/src/election/leader-endpoints.ts
+++ b/packages/mcp/src/election/leader-endpoints.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, Server as HttpServer, ServerResponse } from 'node
 import { ErrorCode, getRelayBudget, RpcRequestSchema, type RpcResponse } from '@figwright/shared';
 import { decode, encode } from '@msgpack/msgpack';
 
+import { hasContentType, isAllowedHost, isAllowedHttpOrigin } from '../local-access.js';
 import type { Relay } from '../relay/relay.js';
 
 export const PING_PATH = '/ping';
@@ -66,6 +67,26 @@ export const attachLeaderEndpoints = (http: HttpServer, deps: LeaderEndpointDeps
   const log = deps.log ?? ((): void => {});
 
   const handler = (req: IncomingMessage, res: ServerResponse): void => {
+    // Addressed by a name that isn't ours: DNS rebinding, where the browser thinks it is talking to
+    // the attacker's domain and so both omits Origin and gets to read the reply.
+    if (!isAllowedHost(req.headers.host)) {
+      log(
+        `[leader] refused ${req.method ?? '?'} ${req.url ?? '?'} for host ${req.headers.host ?? ''}`,
+      );
+      writeJson(res, 403, { error: 'forbidden host' });
+      return;
+    }
+
+    // Followers reach these endpoints over Node's fetch, which sets no Origin. A request that does
+    // carry one came from a page in the user's browser, which has no legitimate reason to be here.
+    if (!isAllowedHttpOrigin(req.headers.origin)) {
+      log(
+        `[leader] refused ${req.method ?? '?'} ${req.url ?? '?'} from origin ${req.headers.origin ?? ''}`,
+      );
+      writeJson(res, 403, { error: 'forbidden origin' });
+      return;
+    }
+
     if (req.method === 'GET' && req.url === PING_PATH) {
       writeJson(res, 200, {
         ok: true,
@@ -82,6 +103,10 @@ export const attachLeaderEndpoints = (http: HttpServer, deps: LeaderEndpointDeps
     }
 
     if (req.method === 'POST' && req.url === ABDICATE_PATH) {
+      if (!hasContentType(req.headers['content-type'], 'application/json')) {
+        writeJson(res, 415, { ok: false, reason: 'unsupported media type' });
+        return;
+      }
       void (async (): Promise<void> => {
         let requesterBuildId: unknown;
         try {
@@ -132,6 +157,17 @@ export const attachLeaderEndpoints = (http: HttpServer, deps: LeaderEndpointDeps
     }
 
     if (req.method === 'POST' && req.url === RPC_PATH) {
+      // A media type outside the CORS simple-request set, so a cross-origin POST has to preflight —
+      // and the preflight fails, because we answer no CORS headers.
+      if (!hasContentType(req.headers['content-type'], 'application/msgpack')) {
+        writeMsgpack(res, 415, {
+          kind: 'err',
+          requestId: '',
+          code: ErrorCode.InvalidRequest,
+          message: 'expected content-type application/msgpack',
+        });
+        return;
+      }
       void (async (): Promise<void> => {
         let body: Buffer;
         try {

--- a/packages/mcp/src/local-access.ts
+++ b/packages/mcp/src/local-access.ts
@@ -1,0 +1,93 @@
+/**
+ * Who may talk to the leader's loopback endpoints.
+ *
+ * Binding to 127.0.0.1 keeps the LAN out; it does not keep the user's own browser out. Two distinct
+ * paths lead from a web page to a local port, and they need two distinct checks:
+ *
+ * - **Cross-site.** A page can open a WebSocket to a local port (WebSockets have no same-origin
+ *   policy) or POST a CORS "simple request" to one. It can't read the reply, but the side effect
+ *   already happened. Such a request carries an `Origin` the page cannot forge → gated by origin.
+ * - **DNS rebinding.** A page on attacker.com whose DNS re-resolves to 127.0.0.1 reaches us as
+ *   _same-origin_, so a GET carries no `Origin` at all and the reply IS readable. What it cannot
+ *   change is `Host`, which still names the attacker's domain → gated by host.
+ *
+ * The MCP security best practices ("Local MCP Server Compromise") name DNS rebinding explicitly;
+ * the host gate follows the shape Playwright uses for its own local servers.
+ */
+
+/**
+ * Figma renders plugin UI in a sandboxed iframe, whose serialized origin is the literal string
+ * "null". The www/apex pair is belt-and-braces for a host that ever sends a real origin instead.
+ */
+const PLUGIN_ORIGINS = new Set(['null', 'https://www.figma.com', 'https://figma.com']);
+
+/** The names a legitimate caller can address us by. The server always binds loopback. */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * Escape hatch for an environment whose plugin host sends an origin we don't anticipate. Read per
+ * call rather than at module load so tests (and a user editing their client config) see changes.
+ * Deliberately does not lift the host gate: that set is our own bind address, not something an
+ * outside party influences, so there is nothing for it to break.
+ */
+const allowAnyOrigin = (): boolean => process.env.FIGWRIGHT_ALLOW_ANY_ORIGIN === '1';
+
+/** Strip the port, keeping an IPv6 literal's brackets intact. */
+const hostnameFromHostHeader = (host: string): string => {
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    return end < 0 ? host : host.slice(0, end + 1);
+  }
+  const colon = host.indexOf(':');
+  return colon < 0 ? host : host.slice(0, colon);
+};
+
+/**
+ * True when the request addressed us by a loopback name. Blocks DNS rebinding, where the browser
+ * treats the call as same-origin — so no `Origin` is sent and the reply is readable — but `Host`
+ * still carries the attacker's domain.
+ *
+ * Unconditional because Node hard-codes the 127.0.0.1 bind. If the bind host ever becomes
+ * configurable, this has to become conditional on it being loopback, the way Playwright's
+ * `computeAllowedHosts` disables itself when bound to a public address.
+ */
+export const isAllowedHost = (host: string | undefined): boolean => {
+  // HTTP/1.1 requires Host; a caller omitting it is not a browser following the rules.
+  if (host === undefined || host === '') return false;
+  return LOOPBACK_HOSTS.has(hostnameFromHostHeader(host.toLowerCase()));
+};
+
+/** True when a WebSocket upgrade carrying this `Origin` may become a plugin session. */
+export const isAllowedWsOrigin = (origin: string | undefined): boolean => {
+  if (allowAnyOrigin()) return true;
+  // Absent header: a non-browser client (the desktop app's plugin host, a test harness). Browsers
+  // always set Origin on a WebSocket handshake, so this can't be a web page.
+  if (origin === undefined || origin === '') return true;
+  return PLUGIN_ORIGINS.has(origin);
+};
+
+/**
+ * True when an HTTP request carrying this `Origin` may reach /rpc, /ping or /abdicate. Stricter
+ * than the WebSocket rule on purpose: only followers call these, over Node's fetch, which never
+ * sets Origin. Anything that does set it is a browser, and no browser has business here — including
+ * one pointed at figma.com. A user opening http://127.0.0.1:3055/ping in a tab still works, because
+ * top-level navigations send no Origin.
+ */
+export const isAllowedHttpOrigin = (origin: string | undefined): boolean => {
+  if (allowAnyOrigin()) return true;
+  return origin === undefined || origin === '';
+};
+
+/**
+ * True when `header` names exactly `expected`, ignoring parameters (`; charset=…`) and case.
+ *
+ * Defence in depth behind the origin check: the CORS "simple request" forms a page can send without
+ * a preflight are limited to text/plain, form-urlencoded and multipart. Demanding a media type
+ * outside that set means a cross-origin POST must preflight, and the preflight fails — we answer no
+ * CORS headers at all.
+ */
+export const hasContentType = (header: string | undefined, expected: string): boolean => {
+  if (header === undefined) return false;
+  const [type] = header.split(';');
+  return type?.trim().toLowerCase() === expected;
+};

--- a/packages/mcp/src/relay/relay.ts
+++ b/packages/mcp/src/relay/relay.ts
@@ -20,6 +20,7 @@ import {
 } from '@figwright/shared';
 import { WebSocketServer, type WebSocket } from 'ws';
 
+import { isAllowedHost, isAllowedWsOrigin } from '../local-access.js';
 import { DEFAULT_DISCONNECT_GRACE_MS, type Session, SessionManager } from './session.js';
 
 export interface RelayOptions {
@@ -64,7 +65,28 @@ export class Relay {
       heartbeatMaxMisses: opts.heartbeatMaxMisses ?? HEARTBEAT_MAX_MISSES,
       disconnectGraceMs: opts.disconnectGraceMs ?? DEFAULT_DISCONNECT_GRACE_MS,
     };
-    this.wss = new WebSocketServer({ server: opts.server });
+    this.wss = new WebSocketServer({
+      server: opts.server,
+      // Refuse the upgrade before it becomes a session: an accepted socket can claim a plugin
+      // identity via $hello and then win routing via $activity, which would put a web page between
+      // the agent and the real file.
+      verifyClient: ({ req }, done) => {
+        if (!isAllowedHost(req.headers.host)) {
+          this.opts.log(
+            `[relay] refused WebSocket upgrade for host ${req.headers.host ?? '(none)'}`,
+          );
+          done(false, 403, 'Forbidden');
+          return;
+        }
+        const origin = req.headers.origin;
+        if (isAllowedWsOrigin(origin)) {
+          done(true);
+          return;
+        }
+        this.opts.log(`[relay] refused WebSocket upgrade from origin ${origin ?? '(none)'}`);
+        done(false, 403, 'Forbidden');
+      },
+    });
     this.wss.on('connection', socket => this.handleConnection(socket));
   }
 

--- a/packages/mcp/test/election/leader-endpoints.test.ts
+++ b/packages/mcp/test/election/leader-endpoints.test.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server as HttpServer } from 'node:http';
+import { createServer, type Server as HttpServer, request as httpRequest } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 import {
@@ -293,6 +293,78 @@ describe('leader endpoints', () => {
     const b = await startLeader();
     const res = await fetch(`http://127.0.0.1:${b.port}/nope`);
     expect(res.status).toBe(404);
+  });
+
+  it('refuses any request carrying an Origin, since only browsers send one', async () => {
+    const b = await startLeader();
+    const attach = await attachFakePlugin(b, () => Promise.resolve({ pong: true }));
+    expect(attach).toBeDefined();
+
+    // The CSRF shape: a simple request needs no preflight, so the page's POST would land and its
+    // side effect would happen even though the reply is unreadable.
+    const rpc = await fetch(`http://127.0.0.1:${b.port}${RPC_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain', origin: 'https://evil.example' },
+      body: Buffer.from(encode({ requestId: 'r-csrf', toolName: 'ping' })),
+    });
+    expect(rpc.status).toBe(403);
+
+    const ping = await fetch(`http://127.0.0.1:${b.port}${PING_PATH}`, {
+      headers: { origin: 'https://evil.example' },
+    });
+    expect(ping.status).toBe(403);
+
+    const abdicate = await fetch(`http://127.0.0.1:${b.port}${ABDICATE_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: 'https://evil.example' },
+      body: JSON.stringify({ buildId: 999_999 }),
+    });
+    expect(abdicate.status).toBe(403);
+  });
+
+  it('refuses a request addressed to a rebound domain, on the readable GET path too', async () => {
+    const b = await startLeader();
+
+    // What DNS rebinding looks like on the wire: the page believes it is same-origin with
+    // attacker.com, so it sends no Origin and *can* read the reply — but Host gives it away.
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest(
+        {
+          host: '127.0.0.1',
+          port: b.port,
+          path: PING_PATH,
+          method: 'GET',
+          headers: { host: 'evil.example:' + String(b.port) },
+        },
+        res => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(status).toBe(403);
+  });
+
+  it('POST /rpc refuses a media type that would skip the CORS preflight', async () => {
+    const b = await startLeader();
+    const res = await fetch(`http://127.0.0.1:${b.port}${RPC_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: Buffer.from(encode({ requestId: 'r-ct', toolName: 'ping' })),
+    });
+    expect(res.status).toBe(415);
+  });
+
+  it('POST /abdicate refuses a non-JSON media type', async () => {
+    const b = await startLeader();
+    const res = await fetch(`http://127.0.0.1:${b.port}${ABDICATE_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: JSON.stringify({ buildId: 999_999 }),
+    });
+    expect(res.status).toBe(415);
   });
 
   it('GET /ping advertises the buildId (0 when unset)', async () => {

--- a/packages/mcp/test/local-access.test.ts
+++ b/packages/mcp/test/local-access.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  hasContentType,
+  isAllowedHost,
+  isAllowedHttpOrigin,
+  isAllowedWsOrigin,
+} from '../src/local-access.js';
+
+afterEach(() => {
+  delete process.env.FIGWRIGHT_ALLOW_ANY_ORIGIN;
+});
+
+describe('isAllowedHost', () => {
+  it('admits the loopback names a real caller uses, port and case notwithstanding', () => {
+    expect(isAllowedHost('127.0.0.1:3055')).toBe(true);
+    expect(isAllowedHost('localhost:3055')).toBe(true);
+    expect(isAllowedHost('LocalHost:3055')).toBe(true);
+    expect(isAllowedHost('127.0.0.1')).toBe(true);
+    expect(isAllowedHost('[::1]:3055')).toBe(true);
+  });
+
+  it('refuses a rebound domain, the one header the attacking page cannot change', () => {
+    expect(isAllowedHost('evil.example:3055')).toBe(false);
+    expect(isAllowedHost('attacker.com')).toBe(false);
+  });
+
+  it('is not fooled by a loopback-looking name', () => {
+    expect(isAllowedHost('localhost.evil.example:3055')).toBe(false);
+    expect(isAllowedHost('127.0.0.1.evil.example')).toBe(false);
+    expect(isAllowedHost('notlocalhost:3055')).toBe(false);
+  });
+
+  it('refuses a request with no Host at all', () => {
+    expect(isAllowedHost(undefined)).toBe(false);
+    expect(isAllowedHost('')).toBe(false);
+  });
+
+  it('stays enforced under the origin escape hatch, which does not cover it', () => {
+    process.env.FIGWRIGHT_ALLOW_ANY_ORIGIN = '1';
+    expect(isAllowedHost('evil.example:3055')).toBe(false);
+  });
+});
+
+describe('isAllowedWsOrigin', () => {
+  it('admits the real plugin, whose sandboxed iframe serializes its origin as "null"', () => {
+    expect(isAllowedWsOrigin('null')).toBe(true);
+  });
+
+  it('admits a non-browser client, which sends no Origin at all', () => {
+    expect(isAllowedWsOrigin(undefined)).toBe(true);
+    expect(isAllowedWsOrigin('')).toBe(true);
+  });
+
+  it('admits a plugin host that sends a real figma.com origin', () => {
+    expect(isAllowedWsOrigin('https://www.figma.com')).toBe(true);
+    expect(isAllowedWsOrigin('https://figma.com')).toBe(true);
+  });
+
+  it('refuses a web page, which would otherwise claim a session and win routing', () => {
+    expect(isAllowedWsOrigin('https://evil.example')).toBe(false);
+    expect(isAllowedWsOrigin('http://localhost:5173')).toBe(false);
+    expect(isAllowedWsOrigin('null.evil.example')).toBe(false);
+  });
+
+  it('does not fall for a lookalike host', () => {
+    expect(isAllowedWsOrigin('https://figma.com.evil.example')).toBe(false);
+    expect(isAllowedWsOrigin('http://www.figma.com')).toBe(false);
+  });
+
+  it('opens up under the escape hatch', () => {
+    process.env.FIGWRIGHT_ALLOW_ANY_ORIGIN = '1';
+    expect(isAllowedWsOrigin('https://evil.example')).toBe(true);
+  });
+});
+
+describe('isAllowedHttpOrigin', () => {
+  it('admits a follower, which reaches the leader over fetch and sets no Origin', () => {
+    expect(isAllowedHttpOrigin(undefined)).toBe(true);
+    expect(isAllowedHttpOrigin('')).toBe(true);
+  });
+
+  it('refuses every browser origin, figma.com included', () => {
+    expect(isAllowedHttpOrigin('https://evil.example')).toBe(false);
+    expect(isAllowedHttpOrigin('null')).toBe(false);
+    expect(isAllowedHttpOrigin('https://www.figma.com')).toBe(false);
+  });
+
+  it('opens up under the escape hatch', () => {
+    process.env.FIGWRIGHT_ALLOW_ANY_ORIGIN = '1';
+    expect(isAllowedHttpOrigin('https://evil.example')).toBe(true);
+  });
+});
+
+describe('hasContentType', () => {
+  it('matches ignoring parameters and case', () => {
+    expect(hasContentType('application/msgpack', 'application/msgpack')).toBe(true);
+    expect(hasContentType('Application/MsgPack; charset=utf-8', 'application/msgpack')).toBe(true);
+    expect(hasContentType(' application/json ', 'application/json')).toBe(true);
+  });
+
+  it('rejects the simple-request media types a page can send without a preflight', () => {
+    expect(hasContentType('text/plain', 'application/msgpack')).toBe(false);
+    expect(hasContentType('multipart/form-data', 'application/msgpack')).toBe(false);
+    expect(hasContentType('application/x-www-form-urlencoded', 'application/msgpack')).toBe(false);
+  });
+
+  it('rejects a missing header', () => {
+    expect(hasContentType(undefined, 'application/msgpack')).toBe(false);
+  });
+});

--- a/packages/mcp/test/relay/relay.test.ts
+++ b/packages/mcp/test/relay/relay.test.ts
@@ -83,6 +83,48 @@ const helloParams = (overrides: Partial<HelloParams> = {}): HelloParams => ({
   ...overrides,
 });
 
+describe('Relay upgrade gating', () => {
+  it('refuses a WebSocket upgrade from a web page', async () => {
+    const b = await startRelay();
+    const ws = new WebSocket(`ws://127.0.0.1:${b.port}`, {
+      headers: { origin: 'https://evil.example' },
+    });
+
+    const status = await new Promise<number>((resolve, reject) => {
+      ws.once('unexpected-response', (_req, res) => resolve(res.statusCode ?? 0));
+      ws.once('open', () => reject(new Error('upgrade should have been refused')));
+      ws.once('error', () => resolve(0));
+    });
+    expect(status).toBe(403);
+    expect(b.relay.sessions.connected()).toHaveLength(0);
+  });
+
+  it('refuses an upgrade addressed to a rebound domain', async () => {
+    const b = await startRelay();
+    const ws = new WebSocket(`ws://127.0.0.1:${b.port}`, {
+      headers: { host: `evil.example:${b.port}` },
+    });
+
+    const status = await new Promise<number>((resolve, reject) => {
+      ws.once('unexpected-response', (_req, res) => resolve(res.statusCode ?? 0));
+      ws.once('open', () => reject(new Error('upgrade should have been refused')));
+      ws.once('error', () => resolve(0));
+    });
+    expect(status).toBe(403);
+  });
+
+  it('admits the plugin, whose sandboxed origin is the literal "null"', async () => {
+    const b = await startRelay();
+    const ws = new WebSocket(`ws://127.0.0.1:${b.port}`, { headers: { origin: 'null' } });
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve());
+      ws.once('error', reject);
+    });
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+});
+
 describe('Relay hello loop', () => {
   it('accepts a $hello request and returns server info', async () => {
     const { port } = await startRelay();


### PR DESCRIPTION
## Description

The relay binds to `127.0.0.1`, which keeps the LAN out but not the user's own browser. Two paths led from any web page the user visited to the leader on port 3055, both verified against a running instance before the fix:

**Cross-site.** WebSockets have no same-origin policy, so a page could complete the upgrade (`upgrade ACCEPTED`), then claim a plugin session via `$hello` and win routing via `$activity` — putting itself between the agent and the real file. Separately, a `POST /rpc` with a `text/plain` body is a CORS *simple request*, so it needs no preflight: the reply is unreadable, but the tool call has already run. That reached the relay with `status: 200`, and covers destructive writes and exports to agent-chosen paths.

**DNS rebinding.** A page whose domain re-resolves to `127.0.0.1` reaches us as *same-origin*, so a `GET` carries no `Origin` at all — and the reply **is** readable, leaking `/ping`'s server version, build id and `activeSessionId`. This is the case an origin check alone does not cover, and it is the one the [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices) name explicitly under "Local MCP Server Compromise".

### Approach

Gate both surfaces on the two headers a page cannot forge, in a single shared module (`packages/mcp/src/local-access.ts`) used by the WebSocket upgrade and the HTTP endpoints alike:

- **`Host` must name loopback** (`localhost`, `127.0.0.1`, `[::1]`; port stripped, IPv6 brackets kept, missing header refused). This is what stops rebinding, and it applies on every method. Shape borrowed from Playwright's own local servers (`packages/utils/httpServer.ts` — `computeAllowedHosts` / `hostnameFromHostHeader`), whose config notes that this check "is not for CORS, but rather for the DNS rebinding protection".
- **`Origin` must be absent or the plugin's** sandboxed origin (Figma serializes it as the literal `"null"`). Header-less callers — the plugin host, follower processes over Node's `fetch` — are exactly the legitimate ones. `/rpc`, `/ping` and `/abdicate` are stricter still and refuse *any* `Origin`, and additionally require a media type outside the simple-request set, so a cross-origin POST must preflight and the preflight fails.

The host gate deliberately has **no** escape hatch — its allowlist is our own bind address, which no outside party influences. `FIGWRIGHT_ALLOW_ANY_ORIGIN=1` lifts only the origin gate, for an environment whose plugin host ever sends something unanticipated. A code comment records that the host gate must become conditional if the bind address ever becomes configurable, the way Playwright's disables itself when bound to a public address.

Server behaviour is otherwise unchanged; this is additive gating, no protocol or tool changes.

### Verification

Probed against a real running leader with the plugin connected, before and after:

| | before | after |
|---|---|---|
| `POST /rpc` + `Origin: evil` + `text/plain` | 200, reached relay | **403** |
| WebSocket upgrade + `Origin: evil` | ACCEPTED | **403** |
| `GET /ping` + `Host: evil.example` (rebinding) | 200 | **403** |
| `Host: localhost.evil.example` (lookalike) | 200 | **403** |
| `Host: 127.0.0.1` / `localhost` / `LOCALHOST` | 200 | 200 |
| plugin — `Origin: "null"`, both host aliases | ACCEPTED | ACCEPTED |
| plugin end-to-end `ping` | `hop: "e2e"` | `hop: "e2e"` |

A refused upgrade leaves no residue: `connectedCount` stays at 1 with the session id unchanged, so a blocked attempt cannot strand a half-session that pollutes routing.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` (1001 tests)
- [x] Tests are added or updated for any behavior change (in `test/` mirroring `src/`; cross-package tests in the root `test/`)
- [x] Read-path / serializer changes are verified with a live round-trip against a real Figma file (plugin connected, running the built `dist`)
- [x] Documentation is updated if needed (README, AGENTS.md, tool descriptions) — README gains a Security section, SECURITY.md documents both gates
