### PR TITLE
fix: make @figwright/mcp bin-only so a stray import can't seize the relay port

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -35,13 +35,6 @@
     "LICENSE"
   ],
   "type": "module",
-  "main": "./dist/index.mjs",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
-    }
-  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   format: 'esm',
   target: 'node24',
   platform: 'node',
-  dts: true,
+  // Bin-only package: the entry is a stdio CLI with top-level side effects (it starts the election
+  // and binds stdio on import), not a library. Emitting a `.d.mts` would only advertise an import
+  // surface that must not be used — a stray `import '@figwright/mcp'` would seize the relay port.
+  dts: false,
   sourcemap: true,
   clean: true,
   shims: false,


### PR DESCRIPTION
## Description

While evaluating whether to add a programmatic entry point (à la `playwright-mcp`'s `createConnection`), I hit an existing packaging defect that is worth fixing on its own, independent of that idea.

`packages/mcp/package.json` declared `main` and `exports`, presenting `@figwright/mcp` as an importable library. But the entry (`src/index.ts`) is a stdio **CLI**, not a library: on load it runs top-level `await election.start()` and binds stdio. So `import '@figwright/mcp'` is not inert — it wins the election, seizes the relay port, and attaches to stdio, purely as an import side effect.

Verified against the built `dist` before the fix:

```
$ FIGWRIGHT_PORT=3097 node -e "import('@figwright/mcp/dist/index.mjs')"
[node] became LEADER on :3097
[figwright] server 0.3.0 (protocol 0.1.0) ready as leader, relay on :3097
```

In normal use the port is 3055, so a stray import would collide with a running client's leader.

### Approach

Make the package **bin-only**, which is what it actually is:

- Remove `main` and `exports`. The only supported use — an MCP client launching it via `bin` / `npx @figwright/mcp` — does not go through either field and is unchanged.
- Set `dts: false` in `tsdown.config.ts`. The emitted `.d.mts` was `export {}` anyway (the entry exports nothing), so it only advertised an import surface that must not be used.

This does **not** close the door on a future programmatic API — that would live at a dedicated subpath (e.g. a thin `@figwright/mcp/client` that dials the existing leader over `/rpc`), not by dressing the CLI entry up as a library. This PR just stops the current entry from pretending to be one.

### Verification

- `import '@figwright/mcp'` now fails cleanly with `ERR_MODULE_NOT_FOUND` instead of hijacking the port.
- The bin still launches: `became LEADER` on an isolated port, then exits on stdin EOF as before.
- `publint` reports "All good!"; `dist/` no longer carries the dead `.d.mts`.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` (1001 tests, publint clean)
- [x] Tests are added or updated for any behavior change — n/a: this is a packaging-manifest fix with no runtime code change; the import behavior is not something the test suite (which drives the CLI/relay directly) meaningfully covers
- [x] Read-path / serializer changes are verified with a live round-trip — n/a: no read-path change
- [x] Documentation is updated if needed — n/a: no import usage was ever documented, so nothing to correct
