### PR TITLE
refactor: read the plugin version via a JSON import attribute

### DIFF
--- a/packages/plugin/vite.config.ts
+++ b/packages/plugin/vite.config.ts
@@ -1,14 +1,12 @@
-import { readFileSync } from 'node:fs';
-
 import tailwindcss from '@tailwindcss/vite';
 import vue from '@vitejs/plugin-vue';
 import { defineConfig } from 'vite';
 import { viteSingleFile } from 'vite-plugin-singlefile';
 
+import pkg from '../mcp/package.json' with { type: 'json' };
+
 // Single product version, sourced from the published package (@figwright/mcp).
-const { version } = JSON.parse(
-  readFileSync(new URL('../mcp/package.json', import.meta.url), 'utf8'),
-) as { version: string };
+const { version } = pkg;
 
 export default defineConfig({
   root: 'ui',


### PR DESCRIPTION
## Description

Two places read `@figwright/mcp`'s `version`, in two different ways:

- `packages/mcp/src/index.ts` — `import pkg from '../package.json' with { type: 'json' }`. This is **required**, not stylistic: that package inherits `module: "NodeNext"`, under which importing JSON without the attribute is a hard TS error (`TS1543`).
- `packages/plugin/vite.config.ts` — `readFileSync` + `JSON.parse` + a cast. The plugin overrides `moduleResolution` to `Bundler`, so the attribute is *optional* here, and this longhand was a historical choice — the git history has no explanatory commit, and it most likely predates stable config-time support for JSON import attributes.

On the current Node 24 / Vite 8 baseline there is no longer a reason for the two to differ. Verified the import form in the plugin config end to end: `pnpm typecheck` and `pnpm build` both pass, and the injected `__APP_VERSION__` still renders as `Figwright v0.3.0` in the built single-file output.

### Change

Use the JSON import attribute in the plugin config too, dropping the `node:fs` import, the `JSON.parse`, and the `as` cast. The two version reads now look identical — with the caveat that the *reason* differs (NodeNext requires it in mcp; Bundler resolution merely permits it here). Byte-for-byte the injected version is unchanged; this is a readability/consistency refactor with no build-output change.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` (1001 tests)
- [x] Tests are added or updated for any behavior change — n/a: no behavior change; the injected version is identical, covered by the existing build
- [x] Read-path / serializer changes are verified with a live round-trip — n/a: no read-path change
- [x] Documentation is updated if needed — n/a
