### PR TITLE
feat: add MCP registry metadata for the official registry listing

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -57,5 +57,6 @@
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
-  }
+  },
+  "mcpName": "io.github.awdr74100/figwright"
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.awdr74100/figwright",
+  "description": "Free, two-way Figma MCP server: designs to code and code to canvas, via a Figma plugin.",
+  "version": "0.3.0",
+  "websiteUrl": "https://github.com/awdr74100/figwright",
+  "repository": {
+    "url": "https://github.com/awdr74100/figwright",
+    "source": "github",
+    "subfolder": "packages/mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@figwright/mcp",
+      "version": "0.3.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Prepare `@figwright/mcp` to be listed on the **official MCP Registry** (`registry.modelcontextprotocol.io`) — the community feed that MCP clients read to discover servers. This is the most precise distribution channel we don't yet have (Glama and awesome-mcp-servers are already done).

This PR lands only the **metadata**; publishing is a separate manual step (below), because the registry verifies against the *published* npm package and publishing needs a GitHub OAuth login.

### Changes

- **`packages/mcp/package.json`** — add `"mcpName": "io.github.awdr74100/figwright"`. The registry proves package ownership by fetching the published npm package and checking this field equals the server's registry `name`. It ships in the package manifest, so it must be present in a *released* version before publishing succeeds.
- **`server.json`** (repo root) — the registry record: an npm package with a stdio transport, pointing at `packages/mcp`. `name` equals `mcpName`; `version` tracks the package version. The `description` is honest that the server pairs with a Figma plugin.

### Verification

- `mcp-publisher validate` → **`✅ server.json is valid`** (checked against the live registry schema).
- Name/version/identifier consistency asserted: `server.name === package.mcpName`, `server.version === package.version === packages[0].version`, `packages[0].identifier === package.name`.
- `mcpName` is an extra manifest field; `publint` reports **No issues found** and all six gates pass (1001 tests).

## Publishing (manual, after merge)

The registry checks the npm package that is actually published, so `mcpName` must reach npm first:

1. **Release a version carrying `mcpName`.** Three merged PRs (#96, #98, #99) are already unreleased, so the next normal `pnpm release` ships `mcpName` for free — no dedicated version needed. Then bump `server.json`'s `version` (top-level + `packages[0]`) to match the released version.
2. **Log in:** `mcp-publisher login github` — opens a browser OAuth flow, grants the `io.github.awdr74100/*` namespace.
3. **Publish:** `mcp-publisher publish` (run from the repo root, where `server.json` lives).

Only steps 2–3 require the maintainer (OAuth); step 1 is the existing release flow. A future option is to automate publish in the release CI via `mcp-publisher login github-oidc`, but that's out of scope here.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` (1001 tests, publint clean)
- [x] Tests are added or updated for any behavior change — n/a: metadata only, no runtime code change; server.json validated with the official tool instead
- [x] Read-path / serializer changes are verified with a live round-trip — n/a
- [x] Documentation is updated if needed — the publishing steps are documented in this PR; README's distribution section can be updated once the listing is live
