### PR TITLE
refactor(plugin): move the iframe bridge protocol out of shared

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@lucide/vue": "^1.26.0",
     "@vueuse/core": "^14.3.0",
-    "vue": "^3.5.40"
+    "vue": "^3.5.40",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@figma/plugin-typings": "^1.131.0",

--- a/packages/plugin/protocol/bridge.ts
+++ b/packages/plugin/protocol/bridge.ts
@@ -1,3 +1,19 @@
+/**
+ * Tool RPC across the plugin's own iframe boundary: the panel hands a tool call down to the
+ * sandbox, which executes it against the Figma API and answers with a result or an error. Plus the
+ * one-way context event the sandbox pushes back up so the panel can show what the plugin sees.
+ *
+ * This binds the panel and the sandbox — the same two parties as `panel-control.ts`, which is why
+ * both live here rather than in `@figwright/shared`. The relay carries these calls, but the MCP
+ * server never constructs or reads one: it addresses tools by name over the wire protocol in
+ * `shared`, and what crosses this boundary afterwards is the plugin's own business.
+ *
+ * Zod, unlike the panel-control channel next door, is warranted here: `params` and `result` are
+ * `unknown` by construction — they carry whatever the agent asked for and whatever the Figma API
+ * returned — so the tag and envelope are the only things a receiver can check before trusting the
+ * message at all.
+ */
+
 import { z } from 'zod';
 
 export const PLUGIN_BRIDGE_TAG = '@figwright/bridge';
@@ -92,7 +108,6 @@ export const SelectionItemSchema = z.object({
   width: z.number(),
   height: z.number(),
 });
-export type SelectionItem = z.infer<typeof SelectionItemSchema>;
 
 export const PluginContextEventSchema = z.object({
   tag: z.literal(PLUGIN_BRIDGE_TAG),

--- a/packages/plugin/src/code.ts
+++ b/packages/plugin/src/code.ts
@@ -1,5 +1,4 @@
-import { createPluginContextEvent, SELECTION_DETAIL_LIMIT } from '@figwright/shared';
-
+import { createPluginContextEvent, SELECTION_DETAIL_LIMIT } from '../protocol/bridge.js';
 import { parsePanelControl } from '../protocol/panel-control.js';
 import { dispatchSandboxMessage } from './dispatcher.js';
 import { createSandboxHandlers } from './handlers/registry.js';

--- a/packages/plugin/src/dispatcher.ts
+++ b/packages/plugin/src/dispatcher.ts
@@ -1,11 +1,12 @@
+import { ErrorCode } from '@figwright/shared';
+
 import {
   createToolError,
   createToolResult,
-  ErrorCode,
   isPluginBridgeMessage,
   type PluginToolError,
   type PluginToolResult,
-} from '@figwright/shared';
+} from '../protocol/bridge.js';
 
 export type SandboxToolHandler = (params: unknown) => unknown | Promise<unknown>;
 export type SandboxHandlers = Record<string, SandboxToolHandler>;

--- a/packages/plugin/test/components/tab-panels.test.ts
+++ b/packages/plugin/test/components/tab-panels.test.ts
@@ -1,8 +1,8 @@
-// @vitest-environment happy-dom
-import { createPluginContextEvent, type PluginContextEvent } from '@figwright/shared';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 
+// @vitest-environment happy-dom
+import { createPluginContextEvent, type PluginContextEvent } from '../../protocol/bridge.js';
 import TabActivity from '../../ui/components/TabActivity.vue';
 import TabContext from '../../ui/components/TabContext.vue';
 import TabDebug from '../../ui/components/TabDebug.vue';

--- a/packages/plugin/test/composables/use-relay-session.test.ts
+++ b/packages/plugin/test/composables/use-relay-session.test.ts
@@ -1,8 +1,8 @@
-// @vitest-environment happy-dom
-import { createPluginContextEvent, type PluginContextEvent } from '@figwright/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type App, createApp, h, nextTick } from 'vue';
 
+// @vitest-environment happy-dom
+import { createPluginContextEvent, type PluginContextEvent } from '../../protocol/bridge.js';
 import type { ActivityEntry, RelayClientState } from '../../ui/relay/state.js';
 
 /**

--- a/packages/plugin/test/dispatcher.test.ts
+++ b/packages/plugin/test/dispatcher.test.ts
@@ -1,6 +1,7 @@
-import { createToolCall, ErrorCode, isPluginBridgeMessage } from '@figwright/shared';
+import { ErrorCode } from '@figwright/shared';
 import { describe, expect, it, vi } from 'vitest';
 
+import { createToolCall, isPluginBridgeMessage } from '../protocol/bridge.js';
 import { dispatchSandboxMessage, type SandboxHandlers } from '../src/dispatcher.js';
 
 describe('dispatchSandboxMessage', () => {

--- a/packages/plugin/test/protocol/bridge.test.ts
+++ b/packages/plugin/test/protocol/bridge.test.ts
@@ -10,7 +10,7 @@ import {
   PLUGIN_BRIDGE_TAG,
   PluginBridgeMessageSchema,
   PluginContextEventSchema,
-} from '../src/plugin-bridge.js';
+} from '../../protocol/bridge.js';
 
 describe('plugin-bridge envelope factories', () => {
   it('createToolCall tags and round-trips through schema', () => {

--- a/packages/plugin/test/relay/diagnostics.test.ts
+++ b/packages/plugin/test/relay/diagnostics.test.ts
@@ -1,6 +1,6 @@
-import type { PluginContextEvent } from '@figwright/shared';
 import { describe, expect, it } from 'vitest';
 
+import type { PluginContextEvent } from '../../protocol/bridge.js';
 import { buildDiagnosticBundle, DIAGNOSTIC_SCHEMA } from '../../ui/relay/diagnostics.js';
 import { summarizePayload } from '../../ui/relay/payload.js';
 import type { ActivityEntry, RelayClientState } from '../../ui/relay/state.js';

--- a/packages/plugin/test/sandbox/messaging.test.ts
+++ b/packages/plugin/test/sandbox/messaging.test.ts
@@ -1,7 +1,7 @@
-// @vitest-environment happy-dom
-import { createPluginContextEvent, createToolResult } from '@figwright/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// @vitest-environment happy-dom
+import { createPluginContextEvent, createToolResult } from '../../protocol/bridge.js';
 import { createPanelHide } from '../../protocol/panel-control.js';
 import { onSandboxContext, onSandboxMessage, postToSandbox } from '../../ui/sandbox/messaging.js';
 

--- a/packages/plugin/test/sandbox/tool-bridge.test.ts
+++ b/packages/plugin/test/sandbox/tool-bridge.test.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it, vi } from 'vitest';
+
 import {
   createToolError,
   createToolResult,
   isPluginBridgeMessage,
   type PluginBridgeMessage,
-} from '@figwright/shared';
-import { describe, expect, it, vi } from 'vitest';
-
+} from '../../protocol/bridge.js';
 import {
   createToolBridge,
   type PostMessageFn,

--- a/packages/plugin/ui/components/TabContext.vue
+++ b/packages/plugin/ui/components/TabContext.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { PluginContextEvent } from '@figwright/shared';
 import { computed } from 'vue';
 
+import type { PluginContextEvent } from '../../protocol/bridge.js';
 import UiMetaRow from './UiMetaRow.vue';
 import UiSection from './UiSection.vue';
 

--- a/packages/plugin/ui/composables/useRelaySession.ts
+++ b/packages/plugin/ui/composables/useRelaySession.ts
@@ -1,7 +1,8 @@
-import { DEFAULT_PORT, type PluginContextEvent, PROTOCOL_VERSION } from '@figwright/shared';
+import { DEFAULT_PORT, PROTOCOL_VERSION } from '@figwright/shared';
 import { tryOnScopeDispose, useDocumentVisibility } from '@vueuse/core';
 import { computed, type ComputedRef, onMounted, type Ref, ref, watch } from 'vue';
 
+import { type PluginContextEvent } from '../../protocol/bridge.js';
 import { RelayClient } from '../relay/client.js';
 import { buildDiagnosticBundle } from '../relay/diagnostics.js';
 import type { RelayClientState } from '../relay/state.js';

--- a/packages/plugin/ui/relay/diagnostics.ts
+++ b/packages/plugin/ui/relay/diagnostics.ts
@@ -6,8 +6,7 @@
 // elided, huge trees capped). The bundle therefore contains the user's design content + file/page
 // names — the caller surfaces that before copying.
 
-import type { PluginContextEvent } from '@figwright/shared';
-
+import type { PluginContextEvent } from '../../protocol/bridge.js';
 import type { ActivityPayload } from './payload.js';
 import type { RelayClientState } from './state.js';
 

--- a/packages/plugin/ui/sandbox/messaging.ts
+++ b/packages/plugin/ui/sandbox/messaging.ts
@@ -13,8 +13,7 @@ import {
   isPluginContextEvent,
   type PluginBridgeMessage,
   type PluginContextEvent,
-} from '@figwright/shared';
-
+} from '../../protocol/bridge.js';
 import type { PanelControlMessage } from '../../protocol/panel-control.js';
 
 /** Everything the panel is allowed to send up to the sandbox. */

--- a/packages/plugin/ui/sandbox/tool-bridge.ts
+++ b/packages/plugin/ui/sandbox/tool-bridge.ts
@@ -3,14 +3,13 @@
  * a bridge message the sandbox can execute, and resolves once the matching reply comes back.
  */
 
+import { getToolBudget, newId } from '@figwright/shared';
+
 import {
   createToolCall,
-  getToolBudget,
   isPluginBridgeMessage,
-  newId,
   type PluginBridgeMessage,
-} from '@figwright/shared';
-
+} from '../../protocol/bridge.js';
 import type { ToolHandler } from '../relay/state.js';
 import { onSandboxMessage, postToSandbox } from './messaging.js';
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,7 +4,6 @@ export * from './design-context.js';
 export * from './design-context-dedupe.js';
 export * from './envelope.js';
 export * from './heartbeat.js';
-export * from './plugin-bridge.js';
 export * from './protocol.js';
 export * from './queries.js';
 export * from './rpc.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@figma/plugin-typings':
         specifier: ^1.131.0


### PR DESCRIPTION
Follow-up to #102, which opened `packages/plugin/protocol/` for the panel↔sandbox control channel. That made it visible that the *same boundary* already had a contract living somewhere else.

## `plugin-bridge.ts` binds the panel and the sandbox, not the plugin and the server

It carries the tool RPC across the plugin's own iframe boundary — the panel hands a call down, the sandbox executes it against the Figma API and answers — plus the context event the sandbox pushes back up.

The MCP server is not a party to any of it. It addresses tools by name over the wire protocol in `shared`; what crosses this boundary afterwards is the plugin's business. **Nothing under `packages/mcp/src` imports a single one of its twenty exports.**

So it moves to `packages/plugin/protocol/bridge.ts`, beside `panel-control.ts`, which binds the same two parties.

## Two costs of it having lived in `shared`

**One boundary in two places.** Since #102 the panel↔sandbox contract has been split: window control in `protocol/`, tool RPC in `shared`. Anyone tracing that boundary had to know both.

**It shipped.** `shared` is bundled into the server at build time, and these Zod schemas were *not* tree-shaken out — the strings `@figwright/bridge`, `tool-call`, `tool-result` and `selectionCount` are each present in `main`'s `packages/mcp/dist/index.mjs`. Removing them:

```
318,293 → 317,114 bytes   (−1,179)
```

Small, and not the reason to do this on its own — but it is real, where I had previously claimed the opposite.

## What else changed

- **`zod` becomes a direct plugin dependency.** It was already in the plugin's bundle by way of `shared`, so nothing grows; the declaration just stops being a phantom. (`packages/plugin/dist/code.js` is byte-identical at 202.67 kB.)
- **`SelectionItem` is dropped.** `PluginContextEvent` infers its selection type straight from `SelectionItemSchema`, so nothing referenced it — being re-exported through `shared`'s barrel had kept it outside knip's reach. The move surfaced it immediately.
- The bridge's test moves with it, to `packages/plugin/test/protocol/bridge.test.ts`.

## What deliberately stays in `shared`

`writes.ts` (24 exports), `components.ts` (10), `queries.ts`, `serialized-node.ts`, `design-context.ts`.

I had initially flagged the first two as misplaced on the grounds that the server never imports them. **That was the wrong test.** They hold the *result* contracts — `MutateResult`, `CreateResult`, `GetLocalComponentsResult` — which the plugin produces, the relay forwards verbatim, and the e2e suite asserts on:

```ts
// packages/mcp/test/e2e/read-tools.test.ts
const response: GetLocalComponentsResult = { components: [...] };
…
expect(result).toEqual(response);
```

The server not naming one in a type position reflects the relay being a transparent pipe, not the contract belonging elsewhere. The right question is *which two parties does this bind*, and for those it is plugin and server.

## Verification

Six gates green; 1207 tests unchanged.

Verified live, with the plugin reloaded on this build. `scan_text_nodes`, `get_document`
(1.4M characters) and `get_screenshot` (four full-size PNGs returned as base64) all completed end
to end. Each of those makes the full round trip — panel → sandbox → Figma API → back — over the
bridge protocol this PR moves, so the tool-call path is exercised in both directions and across
small and very large payloads. The Context tab renders file, page and selection correctly, which
covers the `createPluginContextEvent` half.


