### PR TITLE
fix(plugin): let an in-flight call be opened to see what it was asked to do

### DIFF
--- a/packages/plugin/test/components/tab-activity-row.test.ts
+++ b/packages/plugin/test/components/tab-activity-row.test.ts
@@ -109,7 +109,7 @@ describe('TabActivityRow', () => {
   });
 
   describe('expansion', () => {
-    it('is not interactive when there is no payload to show', () => {
+    it('is not interactive when there is nothing to show', () => {
       const wrapper = mountRow();
 
       expect(wrapper.find('button').exists()).toBe(false);
@@ -121,6 +121,54 @@ describe('TabActivityRow', () => {
       const wrapper = mountRow({ payload: payload() });
       expect(wrapper.find('button').exists()).toBe(true);
       expect(wrapper.find('.lucide-chevron-right').exists()).toBe(true);
+    });
+
+    /**
+     * The request snapshot is recorded at dispatch, so it is readable while the call is still
+     * running — which is when it matters most, since a call that is taking too long is the one
+     * whose arguments you want to see.
+     */
+    describe('while the call is still in flight', () => {
+      const inFlight = {
+        status: 'pending' as const,
+        request: payload({ preview: '{"nodeId":"1:2"}' }),
+      };
+
+      it('opens on a pending call that has recorded its params', async () => {
+        const wrapper = mountRow(inFlight);
+        expect(wrapper.find('button').exists()).toBe(true);
+
+        await wrapper.find('button').trigger('click');
+
+        expect(isExpanded(wrapper)).toBe(true);
+        expect(wrapper.text()).toContain('Request');
+        expect(wrapper.text()).toContain('nodeId');
+      });
+
+      // Absence is the signal: the breathing dot and empty duration already say "running", and a
+      // placeholder would only add a second layout shift when the real block lands.
+      it('shows no result block until there is a result', async () => {
+        const wrapper = mountRow(inFlight);
+
+        await wrapper.find('button').trigger('click');
+
+        expect(wrapper.text()).not.toContain('Payload → LLM');
+      });
+
+      it('slides the result in under a row the user already opened', async () => {
+        const wrapper = mountRow(inFlight);
+        await wrapper.find('button').trigger('click');
+        expect(isExpanded(wrapper)).toBe(true);
+
+        await wrapper.setProps({
+          entry: entry({ ...inFlight, status: 'ok', durationMs: 42, payload: payload() }),
+        });
+
+        // Still open — settling a call must not collapse what the user was reading.
+        expect(isExpanded(wrapper)).toBe(true);
+        expect(wrapper.text()).toContain('Payload → LLM');
+        expect(wrapper.text()).toContain('Request');
+      });
     });
 
     it('starts collapsed and toggles open and shut on click', async () => {

--- a/packages/plugin/ui/components/TabActivityRow.vue
+++ b/packages/plugin/ui/components/TabActivityRow.vue
@@ -24,7 +24,15 @@ const now = useSharedNow();
 // Expansion is per-row state: the list keys rows by request id, so Vue reuses this component across
 // updates and the open/closed state survives new calls arriving above it.
 const expanded = ref(false);
-const expandable = computed(() => props.entry.payload !== undefined);
+/**
+ * Openable as soon as there is anything to show — which is at dispatch, since the request snapshot
+ * is recorded before the call is sent. Waiting for the result would withhold the arguments exactly
+ * when they matter most: while a call is still running and you want to know what it was asked to
+ * do.
+ */
+const expandable = computed(
+  () => props.entry.request !== undefined || props.entry.payload !== undefined,
+);
 
 // Calls that named a node can jump the canvas to it; read-only queries usually can't.
 const revealable = computed(() => (props.entry.nodeIds?.length ?? 0) > 0);
@@ -102,9 +110,10 @@ const durationTone = computed(() =>
       </span>
     </div>
 
-    <!-- 0fr → 1fr animates to the content's natural height without measuring it in JS. -->
+    <!-- 0fr → 1fr animates to the content's natural height without measuring it in JS — which is
+         also what lets the result block slide in later, under an already-open row. -->
     <div
-      v-if="entry.payload"
+      v-if="expandable"
       class="grid transition-[grid-template-rows] duration-240 ease-out-expo"
       :class="expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'"
     >
@@ -123,7 +132,11 @@ const durationTone = computed(() =>
             :preview="entry.request.preview"
             max-height="max-h-40"
           />
+          <!-- Absent while the call is in flight. Its absence is the signal — the row's breathing
+               dot and empty duration already say "running", so a placeholder here would only add a
+               second layout shift when the real block arrives. -->
           <UiPayloadBlock
+            v-if="entry.payload"
             label="Payload → LLM"
             :preview="entry.payload.preview"
             :bytes="entry.payload.bytes"


### PR DESCRIPTION
A row in the Activity tab could only be expanded once its **result** had arrived:

```ts
const expandable = computed(() => props.entry.payload !== undefined);
```

But the request snapshot is recorded at dispatch — `recordCallStart` stores `summarizePayload(params)` before the call is even sent. So the arguments were sitting in memory, hidden, for the entire time the call was running.

That withheld them at the one moment they are most wanted. **A call that is taking too long is exactly the one whose parameters you want to read**, and until it finished the panel would not show them — which rather defeats the point of an activity inspector.

## The change

A row is openable as soon as it has anything to show:

```ts
const expandable = computed(
  () => props.entry.request !== undefined || props.entry.payload !== undefined,
);
```

The result block is simply absent while the call is in flight. Its absence is the signal — the breathing status dot and the empty duration column already say "running", and a placeholder would only add a second layout shift when the real block lands.

The existing `0fr → 1fr` grid transition does the rest: the result block **slides in under a row the user has already opened**, without collapsing it. Rows are keyed by request id, so Vue reuses the component instance and the open state survives the call settling.

## Side effect worth calling out

Every row now carries a chevron, where previously one appeared only when a call settled.

That is steadier, not busier: the column was **always** reserved as an empty spacer (so rows keep aligning), and a glyph popping into it the moment a call finished was the odd part. Now the affordance is there from the start, which is also accurate — the row really is openable from the start.

## Tests

23 → 26 in `tab-activity-row.test.ts`, all under a new `while the call is still in flight` block:

- a pending call that recorded its params opens, and shows the request
- no result block appears until there is a result
- **settling a call slides the result in without collapsing a row the user already opened**

One existing test was renamed — `is not interactive when there is no payload to show` → `…when there is nothing to show` — since the rule it guards is now about both halves, not just the result.

## Size

UI-only; `dist/code.js` is byte-identical. `dist/index.html` +57 bytes.

Six gates green, 1210 tests.

Verified live: an in-flight row opens and shows its `Request` block, and when the call settles the
result block slides in underneath — without collapsing the row the user had already opened.

Independent of #103 — no file overlap, either can merge first.

