### PR TITLE
chore(mcp): drop sourcemap output from the published build

### DIFF
--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   // and binds stdio on import), not a library. Emitting a `.d.mts` would only advertise an import
   // surface that must not be used — a stray `import '@figwright/mcp'` would seize the relay port.
   dts: false,
-  sourcemap: true,
   clean: true,
   shims: false,
   // Build stamp for newest-build-wins election (src/build-id.ts). Epoch ms of this build; absent


### PR DESCRIPTION
## Summary
- Removes `sourcemap: true` from `packages/mcp/tsdown.config.ts` — nothing consumes the `.map` today: Node only reads sourcemaps for stack traces with `--enable-source-maps` (not set anywhere in the bin), and the error path (`dispatch.ts`, `index.ts`'s `log()`) only ever surfaces `.message`, never `.stack`.
- The map file (679KB) outweighs the code it maps (317KB) and ships to npm since `files` includes `dist`, roughly doubling published package size for a benefit nobody can currently reach.
- Checked against comparable MCP servers: the direct competitor (`figma-developer-mcp`) and the official `@modelcontextprotocol/server-filesystem` reference implementation both ship without one. (`@sentry/mcp-server` is the one counterexample, but that's because Sentry's own SDK has its own sourcemap-consuming pipeline for crash reporting — a consumer Figwright doesn't have.)
- `minify` was evaluated too (tested: 317KB → 197KB) and deliberately left off — the same "can the user actually feel it" bar that killed the plugin's `sideEffects: false` proposal applies here, and minifying would also wreck the one fallback we still have (manually reading a reported `dist/index.mjs:LINE` against the readable, unminified bundle).

## Test plan
- [x] `pnpm build` — dist now contains only `index.mjs` (317KB), no `.map`
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip` — all pass
- [x] `pnpm test` — 172 files / 1212 tests pass