### PR TITLE
chore(plugin): raise build target from es2017 to Vite's baseline default

### DIFF
--- a/packages/plugin/vite.config.main.ts
+++ b/packages/plugin/vite.config.main.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: false,
-    target: 'es2017',
+    target: 'baseline-widely-available',
     lib: {
       entry: 'src/code.ts',
       formats: ['iife'],

--- a/packages/plugin/vite.config.ts
+++ b/packages/plugin/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   build: {
     outDir: '../dist',
     emptyOutDir: false,
-    target: 'es2017',
+    target: 'baseline-widely-available',
     rollupOptions: {
       input: 'ui/index.html',
     },


### PR DESCRIPTION
## Summary
- Both `vite.config.ts` (UI panel) and `vite.config.main.ts` (sandbox) were pinned to `target: 'es2017'` since the initial commit, uncommented, with no compatibility rationale on record.
- `es2017` predates ES2018 object rest/spread, which `@lucide/vue`'s `Icon` component uses — every build was silently synthesizing a downlevel shim for it (visible as an inlined `"@babel/helpers - typeof"` helper; Rolldown reuses Babel's algorithm for this, there's no actual Babel dependency in the project).
- The codebase already calls `Array.prototype.toSorted`/`toReversed` (ES2023 built-ins — unrelated to `target`, which only downlevels syntax and never polyfills methods) unconditionally in both the sandbox (`get-design-context.ts`) and the UI panel (`diagnostics.ts`), and both are live-verified against real Figma. That's concrete proof the real runtime floor is already far newer than es2017.
- Switched both to Vite 8's own `'baseline-widely-available'` default (`chrome111`/`edge111`/`firefox114`/`safari16.4`/`ios16.4`) rather than picking an arbitrary ES-year string — it's pinned to real engine versions and tracks Vite's own maintained assessment of what's safe to assume.
- Side benefit: smaller output — `dist/index.html` 258KB → 236.79KB, `dist/code.js` 203KB → 195.69KB.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` — all pass (172 files / 1212 tests)
- [x] Verified no `babel` string remains in either build output