### PR TITLE
chore(plugin): align tsconfig target with its own lib array

### DIFF
--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary
- `packages/plugin/tsconfig.json` had `target: "ES2022"` while its own `lib` was already `["ES2023", "DOM", "DOM.Iterable"]` — a one-year mismatch within the same file.
- Harmless in practice: this tsconfig is `noEmit: true`, so `tsc`/`vue-tsc` only type-checks here — the actual shipped-output syntax is owned by Vite/Rolldown (see #107), not `tsc`. But no reason to leave a self-inconsistent value on the books.
- Bumps `target` to `ES2023` to match the file's own `lib` array and `tsconfig.base.json`'s `ES2023`.
- Independent of #107 — can merge in either order.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` — all pass (172 files / 1212 tests)