### PR TITLE
chore: point oxfmt's Tailwind sorter at the panel's own stylesheet

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -24,6 +24,7 @@
     "changelogen",
     "fdir",
     "hoppscotch",
-    "slidev"
+    "slidev",
+    "stylesheet"
   ]
 }

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,6 +9,9 @@
     "pnpm-lock.yaml",
     ".claude/skills/**"
   ],
+  "sortTailwindcss": {
+    "stylesheet": "packages/plugin/ui/style.css"
+  },
   "arrowParens": "avoid",
   "singleQuote": true,
   "printWidth": 100,

--- a/packages/plugin/ui/App.vue
+++ b/packages/plugin/ui/App.vue
@@ -21,13 +21,13 @@ const tab = ref<Tab>('activity');
 
 <template>
   <main
-    class="relative flex h-full flex-col bg-surface text-panel text-fg scrollbar-thin scrollbar-track-transparent scrollbar-thumb-line-strong"
+    class="relative flex h-full scrollbar-thin scrollbar-thumb-line-strong scrollbar-track-transparent flex-col bg-surface text-panel text-fg"
   >
     <!-- Indeterminate sweep along the panel's top edge — the one ambient signal that the agent is
          mid-call. It sits above the header rather than under the tabs, where a moving line would
          read as a tab underline and fight the selected-tab pill. -->
     <span v-if="busy" class="absolute inset-x-0 top-0 z-10 block h-0.5 overflow-hidden">
-      <span class="block h-full w-1/4 bg-brand animate-sweep" />
+      <span class="block h-full w-1/4 animate-sweep bg-brand" />
     </span>
 
     <header class="relative shrink-0 border-b border-line px-3 pt-2.5 pb-2">

--- a/packages/plugin/ui/components/PanelFooter.vue
+++ b/packages/plugin/ui/components/PanelFooter.vue
@@ -15,7 +15,7 @@ defineProps<{ version: string; totalCalls: number; failedCalls: number }>();
          healthy session, and the point of the number is to catch your eye when it isn't zero. -->
     <template v-if="failedCalls > 0">
       <span aria-hidden="true" class="opacity-50">·</span>
-      <span class="shrink-0 tabular-nums text-danger">{{ failedCalls }} failed</span>
+      <span class="shrink-0 text-danger tabular-nums">{{ failedCalls }} failed</span>
     </template>
   </footer>
 </template>

--- a/packages/plugin/ui/components/PanelStatus.vue
+++ b/packages/plugin/ui/components/PanelStatus.vue
@@ -47,13 +47,13 @@ const meta = computed(() => {
 <template>
   <div class="flex items-center gap-2.5">
     <span class="relative flex size-2 shrink-0" :class="STATUS_TONE[status]">
-      <span v-if="settling" class="absolute inset-0 rounded-full bg-current animate-ping-ring" />
+      <span v-if="settling" class="absolute inset-0 animate-ping-ring rounded-full bg-current" />
       <span
         class="relative size-2 rounded-full bg-current"
         :class="status === 'connected' ? 'shadow-[0_0_7px_currentColor]' : ''"
       />
     </span>
     <span class="font-medium tracking-tight text-fg">{{ STATUS_LABEL[status] }}</span>
-    <span class="ml-auto min-w-0 truncate text-meta tabular-nums text-faint">{{ meta }}</span>
+    <span class="ml-auto min-w-0 truncate text-meta text-faint tabular-nums">{{ meta }}</span>
   </div>
 </template>

--- a/packages/plugin/ui/components/TabActivityRow.vue
+++ b/packages/plugin/ui/components/TabActivityRow.vue
@@ -80,7 +80,7 @@ const durationTone = computed(() =>
         <!-- Relative age reads best at a glance; the exact clock time is there on hover for when
              you're lining the panel up against a log or a recording. -->
         <span
-          class="w-7 shrink-0 text-right text-meta tabular-nums text-faint"
+          class="w-7 shrink-0 text-right text-meta text-faint tabular-nums"
           :title="formatClockTime(entry.startedAt)"
         >
           {{ formatRelativeTime(entry.startedAt, now.getTime()) }}

--- a/packages/plugin/ui/components/TabContext.vue
+++ b/packages/plugin/ui/components/TabContext.vue
@@ -40,7 +40,7 @@ const hiddenCount = computed(() =>
           <span class="shrink-0 rounded bg-raised px-1 py-px font-mono text-chip text-dim">
             {{ node.type }}
           </span>
-          <span class="shrink-0 text-meta tabular-nums text-faint">
+          <span class="shrink-0 text-meta text-faint tabular-nums">
             {{ node.width }}×{{ node.height }}
           </span>
         </li>

--- a/packages/plugin/ui/components/TabDebug.vue
+++ b/packages/plugin/ui/components/TabDebug.vue
@@ -71,7 +71,7 @@ const averageMs = computed(() => {
           <div class="flex items-baseline justify-between gap-2">
             <span class="min-w-0 truncate font-medium text-danger">{{ entry.method }}</span>
             <span
-              class="shrink-0 text-meta tabular-nums text-faint"
+              class="shrink-0 text-meta text-faint tabular-nums"
               :title="formatClockTime(entry.startedAt)"
             >
               {{ formatRelativeTime(entry.startedAt, now.getTime()) }}

--- a/packages/plugin/ui/components/UiPayloadBlock.vue
+++ b/packages/plugin/ui/components/UiPayloadBlock.vue
@@ -20,7 +20,7 @@ defineProps<{
   <div>
     <div class="mb-1 flex items-center gap-2">
       <UiSectionHeading class="min-w-0 truncate">{{ label }}</UiSectionHeading>
-      <span v-if="bytes !== undefined" class="shrink-0 text-meta tabular-nums text-faint">
+      <span v-if="bytes !== undefined" class="shrink-0 text-meta text-faint tabular-nums">
         {{ formatSize(bytes) }}
       </span>
       <UiCopyButton class="ml-auto" label="Copy" :value="preview" compact />


### PR DESCRIPTION
## Summary
- `sortTailwindcss` was enabled with the default stylesheet (Tailwind's stock theme), so the panel's custom `@theme` tokens (`text-fg`, `text-meta`, `animate-ping-ring`, `bg-hover`, ...) sorted as unrecognized classes instead of by category.
- Point it at `packages/plugin/ui/style.css` — which itself `@import`s tailwindcss before layering the panel's custom tokens — so both stock and custom classes sort together correctly.
- Reformatted the 7 Vue files this affected, and allowlisted "stylesheet" in `.cspell.json`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm knip`
- [x] `pnpm build`
- [x] `pnpm test` (172 files, 1212 tests passed)