### PR TITLE
refactor(plugin): hoist the required prop key out of the `in` check

### DIFF
--- a/packages/plugin/src/handlers/batch.ts
+++ b/packages/plugin/src/handlers/batch.ts
@@ -40,7 +40,8 @@ const nodeProps = (tool: string, props: readonly string[]): BatchInverse => ({
     if (typeof id !== 'string') throw new TypeError(`batch/${tool}: nodeId must be a string`);
     const node = await figmaCtx.getNodeByIdAsync(id);
     if (node === null) throw new Error(`batch/${tool}: node ${id} not found`);
-    if (!(props[0]! in node)) throw new Error(`batch/${tool}: node ${id} has no ${props[0]}`);
+    const required = props[0]!;
+    if (!(required in node)) throw new Error(`batch/${tool}: node ${id} has no ${required}`);
     const bag = node as unknown as Record<string, unknown>;
     const snapshot: Record<string, unknown> = {};
     for (const k of props) if (k in node) snapshot[k] = bag[k];


### PR DESCRIPTION
## What

`batch.ts` guarded its snapshot capture with:

```ts
if (!(props[0]! in node)) throw new Error(`batch/${tool}: node ${id} has no ${props[0]}`);
```

A non-null assertion sitting immediately left of `in` reads like `!(props[0] in node)` — the opposite of what it means — and here the whole expression is *already* negated, so the two `!` compound the misreading.

This hoists the key into a local:

```ts
const required = props[0]!;
if (!(required in node)) throw new Error(`batch/${tool}: node ${id} has no ${required}`);
```

The assertion stays (`props[0]` is required by contract, but `readonly string[]` cannot express non-emptiness), the membership test is now unambiguous, and the error message reuses the same value instead of re-indexing.

Behaviour is unchanged.

## Why now

oxlint 1.76 adds `typescript(no-confusing-non-null-assertion)`, which flags the old form. This is the only occurrence in the repo, and it is currently the sole reason CI is red on #112 (`chore(deps): update all non-major dependencies`, which bumps oxlint 1.75 → 1.76):

```
##[warning]Confusing combination of non-null assertion and `in` operator like `a! in b`, which might be misinterpreted as `!(a in b)`.
Found 1 warning and 0 errors.
##[error]Process completed with exit code 1.
```

Landing this on `main` first lets #112 rebase and go green, keeping the dependency bump free of unrelated source changes.

## Verification

Full gate run locally against the upgraded toolchain (oxlint 1.76 / oxfmt 0.61 / oxc-parser 0.142 / vite 8.2):

- `pnpm typecheck` — passed (shared / mcp / plugin)
- `pnpm lint` — passed (failed before this change)
- `pnpm format:check` — passed, 546 files
- `pnpm knip` — passed, no hints
- `pnpm build` — passed
- `pnpm test` — passed, 172 files / 1212 tests

This branch itself builds against the current lockfile (oxlint 1.75), where the new form is equally valid.