### PR TITLE
fix: enable plugin to run in Dev Mode handoff panel

### DIFF
--- a/packages/plugin/manifest.json
+++ b/packages/plugin/manifest.json
@@ -9,5 +9,6 @@
   "networkAccess": {
     "allowedDomains": ["*"],
     "reasoning": "The core connection is a local WebSocket relay on 127.0.0.1:3055 (the Figwright MCP server on this machine). Open domains are required because the import_image tool can additionally fetch an image from a user-supplied URL."
-  }
+  },
+  "capabilities": ["inspect"]
 }


### PR DESCRIPTION
## Problem

When a user runs the Figwright plugin from Figma's Dev Mode — e.g. a seat that only has Dev Mode access (no Design Mode) — Figma refuses to run it and throws:

> Plugin not compatible to run in dev handoff panel. Make sure you have "dev" as an editorType and "inspect" as a capability in your manifest.json.

The manifest already lists `"dev"` in `editorType`, but it's missing the `capabilities` field with `"inspect"`.

## Fix

Add `"capabilities": ["inspect"]` to `packages/plugin/manifest.json`. Per [Figma's Dev Mode plugin docs](https://developers.figma.com/docs/plugins/working-in-dev-mode/), running in the Dev Mode inspect/handoff panel requires `editorType: ["dev"]` together with `capabilities: ["inspect"]`.

```diff
   "networkAccess": {
     "allowedDomains": ["*"],
     "reasoning": "..."
-  }
+  },
+  "capabilities": ["inspect"]
 }
```

## Verification

Tested in Figma desktop with a Dev-Mode-only seat:

- **Before:** clicking Run throws the error above; no plugin UI opens; `ping` from the MCP server shows `connectedCount: 0`.
- **After:** plugin UI opens, connects to the local relay on `127.0.0.1:3055`; `ping` returns `hop: "e2e"`, `connectedCount: 1`; `get_selection` / design-context tools work end-to-end.

## Notes

1-line manifest change; no source or build output is touched. The same root cause (missing `capabilities` → rejected in Dev Mode handoff panel) shows up in other Figma MCP plugins too.
