### PR TITLE
chore: normalise line endings to LF for every clone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Store every text file with LF in the repo, and check it out as LF on every
+# platform. Attributes outrank the contributor's core.autocrlf, so a Windows
+# clone with the installer default (autocrlf=true) still lands LF instead of
+# CRLF — which oxfmt reports as a format issue on every single line, and which
+# CI (ubuntu-only) would never catch.
+* text=auto eol=lf


### PR DESCRIPTION
## Description

Adds a one-line `.gitattributes` so line endings are pinned to LF by the repo itself, not by each contributor remembering to set `core.autocrlf`.

Path attributes outrank `core.autocrlf`, so this holds even on a Windows clone left at the Git for Windows installer default (`autocrlf=true`) — which today checks out CRLF. That matters here because **oxfmt treats CRLF as a format issue**: a contributor in that state sees `pnpm format:check` fail on every file while the repo itself is perfectly clean, and the format-on-save path rewrites whatever it touches. All five workflows are `ubuntu-latest`, so nothing in CI would ever surface it — the cost lands entirely on the contributor's machine, looking like the repo is broken.

Verified locally:

- All **588 tracked blobs are already LF** — `git add --renormalize .` is a no-op, so this lands with no history-wide reformat commit and no `git blame` churn.
- Clone test with `core.autocrlf=true`: without the file the working tree lands CRLF, with it LF, and `git status` is clean immediately after clone.
- oxfmt on a CRLF `.ts`: `--check` exits 1 and a plain run rewrites the file to LF.

Deliberately kept to the single rule. No `*.png binary` (git's own binary detection already covers the PNG/GIF/SVG assets), and no `*.bat text eol=crlf` — there are no Windows scripts tracked yet; that exception is worth adding the day one appears.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test`
- [x] Tests are added or updated for any behavior change — n/a, no runtime behavior changes
- [x] Read-path / serializer changes are verified with a live round-trip against a real Figma file — n/a, no code changes
- [x] Documentation is updated if needed — n/a, the file documents itself in a comment