### PR TITLE
fix(join): ground component reuse in what the code actually declares

### DIFF
--- a/packages/mcp/src/join/casefold.ts
+++ b/packages/mcp/src/join/casefold.ts
@@ -1,0 +1,27 @@
+// The one casefold every join uses to compare a Figma-authored name against a code-authored one.
+// Shared rather than copied per join because all three (component / icon / token) compare the same
+// two worlds, and a rule that drifts between them produces inconsistent matches for the same repo.
+//
+// Three things get normalized away, each because the two sides genuinely disagree on it:
+//
+//  1. Separators and case — Figma labels are prose ("Show icon", "Full width"), code identifiers
+//     are `showIcon` / `full-width`. Without this only single-word names ever match.
+//  2. Latin diacritics — a designer writes "Café", the identifier is `Cafe`, because a JS/TS symbol
+//     is ASCII by convention even when the product name isn't. Decompose, drop the combining marks,
+//     then recompose: recomposing matters because NFD also splits Hangul syllables into jamo, and
+//     leaving them split would change every Korean name's bigrams.
+//  3. Nothing else. Letters and digits are kept in EVERY script.
+//
+// That last point is load-bearing. An `[a-z0-9]` filter doesn't merely fail to match a CJK name —
+// it folds every one of them to the empty string, and equal empty strings compare as a *perfect*
+// match. A Chinese "按鈕" then scores 1.0 against a Japanese "ボタン", and any map keyed on the fold
+// collapses every non-Latin entry onto one bucket.
+
+/** Casefold a name for cross-side comparison. See the notes above before changing this. */
+export const casefold = (s: string): string =>
+  s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // combining diacritical marks
+    .normalize('NFC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, '');

--- a/packages/mcp/src/join/component-map.ts
+++ b/packages/mcp/src/join/component-map.ts
@@ -1,6 +1,8 @@
 import type { DesignContextNode } from '@figwright/shared';
 
 import type { ScannedComponent } from '../scan/scan.js';
+import { casefold } from './casefold.js';
+import { CANDIDATE_FLOOR, statusFor } from './status.js';
 
 // The component join: Figma component name → existing code component. Unlike the token half (CSS
 // custom properties are mechanically derivable from the variable name), there is no shortcut here —
@@ -82,7 +84,7 @@ export interface ComponentMapping {
   staleOverride?: { name: string; filePath: string };
 }
 
-const norm = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+const norm = casefold;
 
 const bigramCounts = (s: string): Map<string, number> => {
   const m = new Map<string, number>();
@@ -104,18 +106,34 @@ export const diceSimilarity = (a: string, b: string): number => {
   return (2 * overlap) / (a.length - 1 + (b.length - 1));
 };
 
+// Figma writes a variant's own name as `Prop=Value, Prop=Value` ("Size=Large, State=Hover"). The
+// text before the first `=` is therefore a PROPERTY name, never the component's — and the property
+// names a design system uses (Size, State, Type, Variant, Style, Icon) are exactly the words it
+// also names components after. Treating that text as a logical name is how a usage whose component
+// set couldn't be resolved gets confidently mapped to an unrelated `Size` component at 1.0.
+const VARIANT_NAMED = /=/;
+
 /**
  * Figma names carry decoration the code side won't ("Button/Primary", "Size=Large, State=Hover").
- * Generate the plausible logical names to try so a slash- or variant-suffixed name still matches
- * the bare code component name.
+ * Generate the plausible logical names to try so a slash- or comma-suffixed name still matches the
+ * bare code component name.
+ *
+ * A variant-style segment contributes nothing but noise, so it's dropped rather than mined for a
+ * base: when a usage is named purely by its variant axes there is no component name in the string
+ * to recover, and inventing one is strictly worse than reporting it unmapped. `Button/Size=Large`
+ * still matches, via its `Button` slash part.
  */
 const nameCandidates = (figmaName: string): string[] => {
-  const base = figmaName.split(/[=,]/)[0]?.trim() ?? figmaName;
-  const slashParts = figmaName
+  const parts = figmaName
     .split('/')
     .map(s => s.trim())
-    .filter(Boolean);
-  return [...new Set([figmaName, base, ...slashParts])];
+    .filter(part => part.length > 0 && !VARIANT_NAMED.test(part));
+  // The comma split only applies to a non-variant name ("Card, Elevated" → "Card"); a variant name
+  // has already been excluded above.
+  const base = VARIANT_NAMED.test(figmaName)
+    ? undefined
+    : (figmaName.split(',')[0]?.trim() ?? figmaName);
+  return [...new Set([figmaName, ...(base === undefined ? [] : [base]), ...parts])];
 };
 
 interface NameScore {
@@ -143,33 +161,35 @@ const TIE_EPSILON = 0.05;
 // Cap the surfaced runner-ups so a scan with many similar names doesn't dump a long list.
 const MAX_AMBIGUOUS = 3;
 
-const statusFor = (confidence: number, threshold: number): MappingStatus => {
-  if (confidence >= 0.85) return 'high';
-  if (confidence >= threshold) return 'medium';
-  if (confidence >= 0.5) return 'low';
-  return 'unmapped';
-};
-
 /**
  * Split a usage's Figma axes into those the candidate already has as props (matchedProps) and those
- * it lacks (unmatchedProps — the component-extension TODOs). Same casefold predicate for both, so
- * matched ∪ unmatched == variantAxes.
+ * it lacks (unmatchedProps — the component-extension TODOs). Same predicate for both, so matched ∪
+ * unmatched == variantAxes.
  *
- * When the component's props couldn't be parsed (propsExtracted === false — a baseline scan that
- * didn't read props), we can't tell matched from unmatched: return both empty rather than dumping
- * every axis into unmatchedProps, which would otherwise report a true "extend this component" TODO
- * for props that very likely already exist (the case for an unparsed Vue/Svelte SFC).
+ * Axes and props are compared with the same separator-insensitive fold used for component names,
+ * because the two sides name the same thing under different conventions: Figma property labels are
+ * written as prose ("Show icon", "Full width", "Is Disabled") while the code side is an identifier
+ * (`showIcon`, `fullWidth`, `isDisabled`). A plain lowercase compare only ever matched single-word
+ * axes, so every multi-word property — the common case on a real component — was reported as a
+ * missing prop the component should be extended with.
+ *
+ * When the prop list is incomplete (propsExtracted === false — a prop type we couldn't read, an
+ * imported base class), the two halves are not symmetric. A prop we DID read still matches: that's
+ * a fact about the component, and dropping it loses a real reuse signal. What we must not do is
+ * call the remainder missing, since the props we couldn't see are exactly the ones likely to cover
+ * them — that would be a false "extend this component" TODO. So an incomplete scan reports the
+ * matches it can prove and claims nothing about the rest.
  */
 const partitionAxes = (
   variantAxes: readonly string[],
   component: ScannedComponent,
 ): { matchedProps: string[]; unmatchedProps: string[] } => {
-  if (!component.propsExtracted) return { matchedProps: [], unmatchedProps: [] };
-  const codeProps = new Set(component.propNames.map(p => p.toLowerCase()));
+  const codeProps = new Set(component.propNames.map(p => norm(p)));
   const matchedProps: string[] = [];
   const unmatchedProps: string[] = [];
   for (const axis of variantAxes) {
-    (codeProps.has(axis.toLowerCase()) ? matchedProps : unmatchedProps).push(axis);
+    if (codeProps.has(norm(axis))) matchedProps.push(axis);
+    else if (component.propsExtracted) unmatchedProps.push(axis);
   }
   return { matchedProps, unmatchedProps };
 };
@@ -256,7 +276,7 @@ const joinScan = (
   // Winner: highest name score, first-wins on an exact tie (strict `>`, preserving the prior pick).
   let winner: NameScore | null = null;
   for (const s of scores) if (winner === null || s.score > winner.score) winner = s;
-  if (winner === null || winner.score < 0.5) {
+  if (winner === null || winner.score < CANDIDATE_FLOOR) {
     return { ...shared, status: 'unmapped', source: 'scan' };
   }
   const best = winner;
@@ -267,13 +287,17 @@ const joinScan = (
   const bonus = Math.min(MAX_VARIANT_BONUS, matchedProps.length * VARIANT_BONUS_PER_PROP);
   const confidence = Math.min(1, Number((best.score + bonus).toFixed(3)));
 
-  // Near-ties: other plausible components (name ≥ 0.5) whose score is within TIE_EPSILON of the
-  // winner. A near-tie means the name couldn't confidently pick one — surface the runner-up(s) so
-  // codegen verifies the reuse instead of silently importing the winner. The winner itself is
-  // unchanged; this only adds a caution signal (and never presents a tie as a confident 'high').
+  // Near-ties: other plausible components (name at/above the floor) whose score is within
+  // TIE_EPSILON of the winner. A near-tie means the name couldn't confidently pick one — surface
+  // the runner-up(s) so codegen verifies the reuse instead of silently importing the winner. The
+  // winner itself is unchanged; this only adds a caution signal (and never presents a tie as a
+  // confident 'high').
   const ambiguousWith = scores
     .filter(
-      s => s.component !== best.component && s.score >= 0.5 && best.score - s.score <= TIE_EPSILON,
+      s =>
+        s.component !== best.component &&
+        s.score >= CANDIDATE_FLOOR &&
+        best.score - s.score <= TIE_EPSILON,
     )
     .toSorted((a, b) => b.score - a.score)
     .slice(0, MAX_AMBIGUOUS)

--- a/packages/mcp/src/join/icon-map.ts
+++ b/packages/mcp/src/join/icon-map.ts
@@ -2,7 +2,9 @@ import type { DesignContextNode, SerializedPaint } from '@figwright/shared';
 
 import type { RepoSvg, SvgColorContract } from '../icons/repo-icons.js';
 import type { ProjectProfile } from '../profile/profile.js';
+import { casefold } from './casefold.js';
 import { diceSimilarity, type MappingStatus } from './component-map.js';
+import { statusFor } from './status.js';
 
 // The icon join: a Figma icon node → an existing project `.svg` file, so codegen reuses the designer's
 // curated asset instead of re-exporting a duplicate. Like the component/token joins it's name-based and
@@ -45,7 +47,8 @@ export const iconLabel = (raw: string): string => {
   return last.replace(/^ic(on)?s?[-_]/i, '').trim();
 };
 
-const norm = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+// The grouping key below — so a fold that collapsed non-Latin labels would merge whole icon sets.
+const norm = casefold;
 
 const hex2 = (n: number): string =>
   Math.round(Math.max(0, Math.min(1, n)) * 255)
@@ -163,13 +166,6 @@ const recolorGuidance = (
     case 'unknown':
       return 'color contract unclear (no explicit fill or currentColor found) — inspect the svg before relying on recolor';
   }
-};
-
-const statusFor = (confidence: number, threshold: number): MappingStatus => {
-  if (confidence >= 0.85) return 'high';
-  if (confidence >= threshold) return 'medium';
-  if (confidence >= 0.5) return 'low';
-  return 'unmapped';
 };
 
 export interface IconJoinOptions {

--- a/packages/mcp/src/join/status.ts
+++ b/packages/mcp/src/join/status.ts
@@ -1,0 +1,38 @@
+import type { MappingStatus } from './component-map.js';
+
+// The one confidence→status bucketing shared by all three joins (component / icon / token). They
+// grade the same kind of guess against the same caller-supplied bar, so a rule that drifted between
+// them would make `threshold` mean different things per tool.
+//
+// What the buckets are FOR (see skills/figma-codegen): `high` and `medium` both mean "reuse this,
+// don't regenerate"; `low` means "a candidate exists, but decide for yourself". So the boundary
+// between medium and low is the reuse decision, and `threshold` is exactly the caller's bar for it.
+//
+// Which is why threshold has to bind the top bucket too. A caller raising it past HIGH_CONFIDENCE
+// is saying "0.85 similarity isn't good enough for me to reuse on" — usually after a wrong reuse,
+// which is a silent visual bug. Grading such a match `high` anyway (as a hardcoded top cut does)
+// ignores the request in the one direction where being wrong actually costs something, so `high`
+// requires clearing BOTH the absolute mark and the caller's bar.
+
+/** Absolute similarity above which a match is confident on its own terms. */
+const HIGH_CONFIDENCE = 0.85;
+
+/**
+ * Floor for reporting a candidate at all. Deliberately NOT lowered by `threshold`: the bar governs
+ * what counts as reliable, while this governs what's worth showing, and flooding codegen with
+ * sub-0.5 name guesses trades a silent wrong reuse for a noisy one.
+ */
+export const CANDIDATE_FLOOR = 0.5;
+
+/**
+ * Grade a confidence against the caller's reliability bar. Monotonic in both arguments: raising
+ * `threshold` can only ever demote a mapping, never promote one.
+ */
+export const statusFor = (confidence: number, threshold: number): MappingStatus => {
+  // The floor is checked first so it holds regardless of the bar — a bar of 0 asks for a lenient
+  // grade, not for sub-floor noise to be graded at all.
+  if (confidence < CANDIDATE_FLOOR) return 'unmapped';
+  if (confidence >= Math.max(HIGH_CONFIDENCE, threshold)) return 'high';
+  if (confidence >= threshold) return 'medium';
+  return 'low';
+};

--- a/packages/mcp/src/join/token-map.ts
+++ b/packages/mcp/src/join/token-map.ts
@@ -1,7 +1,9 @@
 import type { FigmaToken } from '../tokens/figma-tokens.js';
 import { normHex } from '../tokens/hex.js';
 import type { ProjectToken } from '../tokens/tokens.js';
+import { casefold } from './casefold.js';
 import { diceSimilarity, type MappingStatus, parseMapLine } from './component-map.js';
+import { statusFor } from './status.js';
 
 // The token join: Figma variable → project design token. Name-match is the primary, framework-agnostic
 // signal (normalized Figma "Primary/500" vs project "color-primary-500" / utility "primary-500"); an
@@ -226,13 +228,6 @@ const candidateFrom = (
     : {}),
 });
 
-const statusFor = (confidence: number, threshold: number): MappingStatus => {
-  if (confidence >= 0.85) return 'high';
-  if (confidence >= threshold) return 'medium';
-  if (confidence >= 0.5) return 'low';
-  return 'unmapped';
-};
-
 export interface TokenJoinOptions {
   threshold: number;
   /** The project is a Tailwind project — enables the framework built-in scale fallback below. */
@@ -245,7 +240,9 @@ export interface TokenJoinOptions {
   overrides?: ReadonlyMap<string, string>;
 }
 
-const normKey = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+// Used for override lookups AND as a map key, so a fold that collapsed non-Latin names would make
+// several rows collide on one bucket.
+const normKey = casefold;
 
 /**
  * Resolve a recorded override ref to a project token. The ref is whatever the map file author wrote

--- a/packages/mcp/src/scan/scan.ts
+++ b/packages/mcp/src/scan/scan.ts
@@ -10,8 +10,17 @@ import { walkRepoFiles } from '../repo-walk.js';
 // flat all differ); identify a component by its *AST signature* (a PascalCase, exported, function-ish
 // binding) and take its name from the export/filename. Folder is only a confidence hint, applied later
 // in the join. React (.tsx/.jsx) and Angular (.ts, an @Component-decorated class) are parsed with oxc;
-// Vue/Svelte fall back to filename-derived names (their SFC name is the file by convention) as a
-// baseline until a dedicated pass is added.
+// Vue/Svelte are parsed from their SFC <script> blocks, with the file supplying the component name
+// (their SFC name is the file by convention).
+//
+// Two invariants earn their keep here, because both failure modes are silent:
+//   1. Detection breadth — a component we don't find is reported `unmapped` by the join, and codegen
+//      then rebuilds a component the project already has. So every *export* form has to resolve, not
+//      just the inline-declaration one (`export { Button }`, `export default Button`, class
+//      components, `React.memo(...)` all name real components).
+//   2. Honest `propsExtracted` — see the field docs. Claiming an extraction we didn't do is worse
+//      than admitting we couldn't: the join turns a false [] into "this component is missing every
+//      variant axis", a wrong extension TODO.
 
 export type ComponentFramework = 'react' | 'vue' | 'svelte' | 'angular';
 
@@ -20,21 +29,45 @@ export interface ScannedComponent {
   /** Repo-relative path. */
   filePath: string;
   exportKind: 'default' | 'named';
-  /** The component's prop names; [] when the component has none OR they couldn't be parsed. */
+  /**
+   * The prop names that were read. Every entry is a prop the component really declares; whether the
+   * list is EXHAUSTIVE is what `propsExtracted` says. So it can be a partial list — a component
+   * whose own props parsed but whose base class is imported reports its own and is flagged
+   * incomplete.
+   */
   propNames: string[];
   /**
-   * Whether propNames is a real parse result (so [] means "genuinely no props") versus a baseline
-   * that couldn't read props (so [] means "unknown"). The component join uses this to avoid
-   * reporting every variant axis as an unmatched prop just because we never parsed the props — a
-   * false "extend this component" TODO. True once we've parsed the source; false only on a parse
-   * failure.
+   * Whether `propNames` is the complete set (so [] means "genuinely no props") rather than as much
+   * as could be read (so it may be missing entries). The component join uses this to avoid
+   * reporting every variant axis as an unmatched prop just because we couldn't see them all — a
+   * false "extend this component" TODO.
+   *
+   * It must stay honest in BOTH directions. False when the props are declared in a way we can't
+   * fully read — a parse failure, a prop type imported from another file, an interface or base
+   * class extending one. True only when the list is exhaustive: props we read in full, or a
+   * component that genuinely declares none (no parameter at all / a script-less SFC).
    */
   propsExtracted: boolean;
   framework: ComponentFramework;
 }
 
+/** Prop extraction outcome — names plus whether the list is complete (see `propsExtracted`). */
+interface PropsResult {
+  names: string[];
+  extracted: boolean;
+}
+
+const UNKNOWN_PROPS: PropsResult = { names: [], extracted: false };
+const NO_PROPS: PropsResult = { names: [], extracted: true };
+
 /** React HOCs whose call wraps a component function — the binding is still a component. */
 const COMPONENT_WRAPPERS = new Set(['forwardRef', 'memo', 'observer']);
+
+/** Base classes that make an exported class a React class component. */
+const REACT_COMPONENT_BASES = new Set(['Component', 'PureComponent']);
+
+/** Depth limit when unwrapping nested HOCs (`memo(forwardRef(fn))`) — guards a pathological chain. */
+const MAX_WRAPPER_DEPTH = 4;
 
 const isPascalCase = (name: string): boolean => /^[A-Z][A-Za-z0-9]*$/.test(name);
 
@@ -49,56 +82,307 @@ export const nameFromFile = (filePath: string): string => {
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- oxc returns an untyped ESTree-ish AST */
 
-/** Pull destructured prop names from a function node's first param ({ size, variant } → [...]). */
-const propNamesOf = (fn: any): string[] => {
-  const p0 = fn?.params?.[0];
-  if (p0?.type !== 'ObjectPattern') return [];
-  return (p0.properties ?? [])
-    .filter((pr: any) => pr.type === 'Property' && pr.key?.name)
-    .map((pr: any) => pr.key.name as string);
+// ── Named prop types ────────────────────────────────────────────────────────────────────────────
+// Across all three JS frameworks the dominant way to declare props is a *named* type in the same
+// file — `interface Props { … }` paired with `defineProps<Props>()`, `(props: Props)`, or
+// `$props()`. Reading only inline literals (`defineProps<{ … }>()`) therefore misses the majority
+// authoring style, so we resolve type names against the file's own declarations.
+//
+// Resolution is deliberately file-local: an imported prop type is NOT chased across modules. That
+// keeps the scanner a single-pass, no-resolver pass (a type-aware crawl would need the whole
+// program), and the honest answer for an unresolvable name is `null` → propsExtracted=false, which
+// the join already handles by suppressing prop claims. Partial reads are treated as unresolved for
+// the same reason: `interface Props extends ImportedBase { size }` really does have props we can't
+// see, and reporting just `size` would make every inherited prop look missing.
+
+/** Named type declarations in a file: type name → its declaration node. */
+type TypeTable = Map<string, any>;
+
+/** Index a program's `interface X {}` / `type X = {}` declarations, including exported ones. */
+const collectTypeDeclarations = (program: any): TypeTable => {
+  const table: TypeTable = new Map();
+  for (const node of program?.body ?? []) {
+    // `export interface Props {}` wraps the declaration; unwrap to the same shape as a bare one.
+    const decl = node?.type === 'ExportNamedDeclaration' ? node.declaration : node;
+    if (decl?.type !== 'TSInterfaceDeclaration' && decl?.type !== 'TSTypeAliasDeclaration')
+      continue;
+    const name = decl.id?.name;
+    if (typeof name === 'string') table.set(name, decl);
+  }
+  return table;
 };
 
-/** If a binding's initializer is (or wraps) a function, return that function node, else null. */
-const functionOf = (init: any): any => {
+/** Member names of a TSTypeLiteral / TSInterfaceBody member list (`{ size?: string }` → [size]). */
+const memberNames = (members: any[]): string[] =>
+  (members ?? [])
+    .filter((m: any) => m?.type === 'TSPropertySignature' || m?.type === 'TSMethodSignature')
+    .map((m: any) => m.key?.name ?? m.key?.value)
+    .filter((n: unknown): n is string => typeof n === 'string');
+
+/**
+ * Resolve a type node to its complete list of property names, or null when any part of it can't be
+ * read from this file alone (an imported type, a mapped/conditional type, a utility generic).
+ * `seen` breaks reference cycles (`interface A extends B`, `interface B extends A`).
+ */
+const resolveTypeMembers = (
+  node: any,
+  table: TypeTable,
+  seen: Set<string> = new Set(),
+): string[] | null => {
+  if (node == null) return null;
+  switch (node.type) {
+    case 'TSTypeLiteral':
+      return memberNames(node.members);
+    case 'TSTypeReference': {
+      // A type argument doesn't rename members — a generic component's `Props<T>` still declares
+      // `items` / `size`, only their types depend on T — so `Props<T>` resolves exactly like
+      // `Props`. Utility types (`Partial<Props>`, `Omit<Props, 'x'>`) DO reshape the member set,
+      // and they fall out naturally: they're TS built-ins, so the file's table has no entry and the
+      // lookup below returns null. Same for `NS.Props`, whose typeName is a TSQualifiedName.
+      const name = node.typeName?.name;
+      if (typeof name !== 'string') return null;
+      if (seen.has(name)) return [];
+      const decl = table.get(name);
+      if (decl === undefined) return null; // imported / built-in — unknowable here
+      return resolveTypeMembers(decl, table, new Set([...seen, name]));
+    }
+    case 'TSInterfaceDeclaration': {
+      const own = memberNames(node.body?.body);
+      const names = new Set(own);
+      // `interface Props extends Base` — Base's members are props too, so an unresolvable parent
+      // makes the whole list incomplete.
+      for (const heritage of node.extends ?? []) {
+        const parent = resolveTypeMembers(
+          {
+            type: 'TSTypeReference',
+            typeName: heritage.expression,
+            typeArguments: heritage.typeArguments,
+          },
+          table,
+          seen,
+        );
+        if (parent === null) return null;
+        for (const n of parent) names.add(n);
+      }
+      return [...names];
+    }
+    case 'TSTypeAliasDeclaration':
+      return resolveTypeMembers(node.typeAnnotation, table, seen);
+    case 'TSIntersectionType': {
+      // `type Props = Base & { size }` — every arm contributes; one unreadable arm sinks the list.
+      const names = new Set<string>();
+      for (const part of node.types ?? []) {
+        const partNames = resolveTypeMembers(part, table, seen);
+        if (partNames === null) return null;
+        for (const n of partNames) names.add(n);
+      }
+      return [...names];
+    }
+    default:
+      return null;
+  }
+};
+
+/** Resolve a `: Props` annotation (on a parameter or a variable) to its prop names. */
+const propsFromAnnotation = (annotated: any, table: TypeTable): PropsResult => {
+  const names = resolveTypeMembers(annotated?.typeAnnotation?.typeAnnotation, table);
+  return names === null ? UNKNOWN_PROPS : { names, extracted: true };
+};
+
+// ── React / Solid ───────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Prop names from a component function's first parameter.
+ *
+ * A type annotation, when present, is the component's _declared_ contract and so takes precedence
+ * over the destructuring pattern: `({ size }: Props)` accepts every member of Props, not just the
+ * one the body happens to pull out, and treating the pattern as the answer would report the rest as
+ * props the component is missing. An unresolvable annotation (imported type) therefore makes the
+ * list incomplete even though the pattern named something — the same rule as `extends
+ * ImportedBase`.
+ *
+ * Without an annotation the pattern is all there is, and in that case it _is_ the prop list. A
+ * pattern that names nothing (`({ ...rest })`) is the exception: the props are real but written
+ * down nowhere we can read, so that's unknown rather than none. No parameter at all is genuinely
+ * prop-less.
+ */
+const propsOfFunction = (fn: any, table: TypeTable): PropsResult => {
+  const p0 = fn?.params?.[0];
+  if (p0 == null) return NO_PROPS;
+  const destructured =
+    p0.type === 'ObjectPattern'
+      ? (p0.properties ?? [])
+          .filter((pr: any) => pr.type === 'Property' && pr.key?.name)
+          .map((pr: any) => pr.key.name as string)
+      : [];
+  if (p0.typeAnnotation != null) {
+    const annotated = propsFromAnnotation(p0, table);
+    // An unreadable annotation doesn't erase what the pattern spelled out: keep those names (the
+    // join still counts them as matches) but leave the list flagged incomplete.
+    return annotated.extracted ? annotated : { names: destructured, extracted: false };
+  }
+  if (p0.type === 'ObjectPattern')
+    return destructured.length > 0 ? { names: destructured, extracted: true } : UNKNOWN_PROPS;
+  return UNKNOWN_PROPS;
+};
+
+/** The called name of a HOC, whether imported bare (`memo`) or off the namespace (`React.memo`). */
+const calleeName = (callee: any): string | undefined =>
+  callee?.type === 'MemberExpression' ? callee.property?.name : callee?.name;
+
+/**
+ * If a binding's initializer is (or wraps) a function, return that function node, else null.
+ * Wrappers nest in practice (`memo(forwardRef(fn))`) and are just as often reached through the
+ * namespace (`React.memo`), so both are unwrapped, up to a small depth cap.
+ */
+const functionOf = (init: any, depth = 0): any => {
   if (init == null) return null;
   if (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') return init;
-  if (init.type === 'CallExpression' && COMPONENT_WRAPPERS.has(init.callee?.name)) {
-    const arg0 = init.arguments?.[0];
-    if (arg0?.type === 'ArrowFunctionExpression' || arg0?.type === 'FunctionExpression')
-      return arg0;
-  }
-  return null;
-};
-
-interface Candidate {
-  name: string | null;
-  fn: any;
-  exportKind: 'default' | 'named';
-}
-
-/** Resolve an export declaration node to a (name, function) candidate, or null if not function-ish. */
-const candidateOf = (node: any): Candidate | null => {
-  const d = node.declaration;
-  if (d == null) return null;
-  const exportKind = node.type === 'ExportDefaultDeclaration' ? 'default' : 'named';
-
-  if (d.type === 'FunctionDeclaration') return { name: d.id?.name ?? null, fn: d, exportKind };
-  // `export default () => ...` / `export default forwardRef(...)`
-  const directFn = functionOf(d);
-  if (directFn !== null && exportKind === 'default')
-    return { name: null, fn: directFn, exportKind };
-  if (d.type === 'VariableDeclaration') {
-    const decl = d.declarations?.[0];
-    const fn = functionOf(decl?.init);
-    if (fn !== null) return { name: decl?.id?.name ?? null, fn, exportKind };
+  if (
+    init.type === 'CallExpression' &&
+    depth < MAX_WRAPPER_DEPTH &&
+    COMPONENT_WRAPPERS.has(calleeName(init.callee) ?? '')
+  ) {
+    return functionOf(init.arguments?.[0], depth + 1);
   }
   return null;
 };
 
 /**
+ * Generic component types whose first type argument is the props type (`const B: FC<Props> = …`).
+ * Covers React's spellings and Solid's, which the same extractor parses — and Solid matters more
+ * here than it looks: its components must NOT destructure props (that breaks reactivity), so
+ * annotating the binding is the idiomatic way to declare them.
+ */
+const COMPONENT_TYPE_WRAPPERS = new Set([
+  'FC',
+  'FunctionComponent',
+  'VFC',
+  'ComponentType',
+  'Component',
+  'ParentComponent',
+  'VoidComponent',
+  'FlowComponent',
+]);
+
+/**
+ * Props from the _binding's_ type annotation rather than the parameter's — `const Button: FC<Props>
+ * = (props) => …` puts the prop type on the variable, so a parameter-only read finds nothing.
+ * Handles both the bare (`FC`) and namespaced (`React.FC`) spellings.
+ */
+const propsFromComponentType = (declId: any, table: TypeTable): PropsResult => {
+  const ref = declId?.typeAnnotation?.typeAnnotation;
+  if (ref?.type !== 'TSTypeReference') return UNKNOWN_PROPS;
+  // `React.FC` parses as a TSQualifiedName; its `right` is the member being referenced.
+  const name =
+    ref.typeName?.type === 'TSQualifiedName' ? ref.typeName.right?.name : ref.typeName?.name;
+  if (typeof name !== 'string' || !COMPONENT_TYPE_WRAPPERS.has(name)) return UNKNOWN_PROPS;
+  const arg0 = ref.typeArguments?.params?.[0];
+  // A bare `FC` declares nothing, so it must not short-circuit the parameter read — `const B: FC =
+  // ({ size }) => …` still names its props in the pattern.
+  if (arg0 == null) return UNKNOWN_PROPS;
+  const names = resolveTypeMembers(arg0, table);
+  return names === null ? UNKNOWN_PROPS : { names, extracted: true };
+};
+
+/** True when a class extends React's component base, bare or namespaced (`React.Component`). */
+const isReactComponentClass = (cls: any): boolean => {
+  const sup = cls?.superClass;
+  if (sup == null) return false;
+  const name = sup.type === 'MemberExpression' ? sup.property?.name : sup.name;
+  return typeof name === 'string' && REACT_COMPONENT_BASES.has(name);
+};
+
+/** Props of a class component — the first type argument of `extends Component<Props>`. */
+const propsOfClass = (cls: any, table: TypeTable): PropsResult => {
+  const arg0 = cls?.superTypeArguments?.params?.[0];
+  if (arg0 == null) return UNKNOWN_PROPS;
+  const names = resolveTypeMembers(arg0, table);
+  return names === null ? UNKNOWN_PROPS : { names, extracted: true };
+};
+
+interface Candidate {
+  name: string | null;
+  props: PropsResult;
+  exportKind: 'default' | 'named';
+}
+
+/** Resolve a declaration node (function, class, or initialized binding) to a candidate component. */
+const candidateOfDeclaration = (
+  d: any,
+  exportKind: 'default' | 'named',
+  table: TypeTable,
+): Candidate | null => {
+  if (d == null) return null;
+  if (d.type === 'FunctionDeclaration')
+    return { name: d.id?.name ?? null, props: propsOfFunction(d, table), exportKind };
+  // Class components predate hooks but still fill maintained codebases; missing them means codegen
+  // rebuilds a component that exists.
+  if (d.type === 'ClassDeclaration' && isReactComponentClass(d))
+    return { name: d.id?.name ?? null, props: propsOfClass(d, table), exportKind };
+  // `export default () => ...` / `export default forwardRef(...)`
+  const directFn = functionOf(d);
+  if (directFn !== null && exportKind === 'default')
+    return { name: null, props: propsOfFunction(directFn, table), exportKind };
+  if (d.type === 'VariableDeclaration') {
+    const decl = d.declarations?.[0];
+    const fn = functionOf(decl?.init);
+    if (fn !== null) {
+      // The binding's `FC<Props>` annotation is the component's declared public contract, so it
+      // wins when present — a body that ignores a prop (`FC<Props> = () => …`) doesn't remove it.
+      const fromType = propsFromComponentType(decl?.id, table);
+      const props = fromType.extracted ? fromType : propsOfFunction(fn, table);
+      return { name: decl?.id?.name ?? null, props, exportKind };
+    }
+  }
+  return null;
+};
+
+/** Resolve an export _declaration_ node to a candidate, or null if not function-ish. */
+const candidateOf = (node: any, table: TypeTable): Candidate | null =>
+  candidateOfDeclaration(
+    node.declaration,
+    node.type === 'ExportDefaultDeclaration' ? 'default' : 'named',
+    table,
+  );
+
+/**
+ * Index a file's top-level value declarations by binding name, so an export that only _references_
+ * a binding (`export { Button }`, `export default Button`) can be resolved back to its declaration.
+ * Declaring first and exporting at the bottom is an extremely common house style; without this the
+ * component is invisible to the scanner.
+ */
+const collectLocalDeclarations = (program: any): Map<string, any> => {
+  const locals = new Map<string, any>();
+  for (const node of program?.body ?? []) {
+    // Unwrap `export const X = …` too: it may also be re-exported under another name.
+    const d = node?.type === 'ExportNamedDeclaration' ? node.declaration : node;
+    if (d == null) continue;
+    if (d.type === 'FunctionDeclaration' || d.type === 'ClassDeclaration') {
+      if (typeof d.id?.name === 'string') locals.set(d.id.name, d);
+    } else if (d.type === 'VariableDeclaration') {
+      for (const decl of d.declarations ?? []) {
+        if (typeof decl?.id?.name === 'string') {
+          // Wrap back into a single-declarator VariableDeclaration so candidateOfDeclaration can
+          // treat it exactly like an inline `export const X = …`.
+          locals.set(decl.id.name, { type: 'VariableDeclaration', declarations: [decl] });
+        }
+      }
+    }
+  }
+  return locals;
+};
+
+/**
  * Extract React components from one file's source. Pure (no fs) so it can be unit-tested directly.
- * A component is an exported, function-ish binding whose name is PascalCase — this excludes utility
- * exports (`export const API_URL = '…'`). An anonymous default export borrows the filename.
+ * A component is an exported, function-ish (or React-class) binding whose name is PascalCase — this
+ * excludes utility exports (`export const API_URL = '…'`). An anonymous default export borrows the
+ * filename.
+ *
+ * Exports are read in two passes: inline declarations first (`export const Button = …`), then
+ * reference exports (`export { Button }` / `export default Button`) resolved against the file's own
+ * declarations. Inline-first keeps a binding that is both declared-and-exported inline and
+ * re-exported from being emitted twice, and preserves the original pass's naming exactly.
  */
 export const extractReactComponents = (filePath: string, code: string): ScannedComponent[] => {
   let program: any;
@@ -107,24 +391,60 @@ export const extractReactComponents = (filePath: string, code: string): ScannedC
   } catch {
     return [];
   }
-  const out: ScannedComponent[] = [];
+  const table = collectTypeDeclarations(program);
+  const byName = new Map<string, ScannedComponent>();
+
+  const add = (name: string | null, cand: Candidate): void => {
+    const resolved = name ?? (cand.exportKind === 'default' ? nameFromFile(filePath) : null);
+    if (resolved === null || !isPascalCase(resolved) || byName.has(resolved)) return;
+    byName.set(resolved, {
+      name: resolved,
+      filePath,
+      exportKind: cand.exportKind,
+      propNames: cand.props.names,
+      propsExtracted: cand.props.extracted,
+      framework: 'react',
+    });
+  };
+
   for (const node of program.body ?? []) {
     if (node.type !== 'ExportNamedDeclaration' && node.type !== 'ExportDefaultDeclaration')
       continue;
-    const cand = candidateOf(node);
-    if (cand === null) continue;
-    const name = cand.name ?? (cand.exportKind === 'default' ? nameFromFile(filePath) : null);
-    if (name === null || !isPascalCase(name)) continue;
-    out.push({
-      name,
-      filePath,
-      exportKind: cand.exportKind,
-      propNames: propNamesOf(cand.fn),
-      propsExtracted: true,
-      framework: 'react',
-    });
+    const cand = candidateOf(node, table);
+    if (cand !== null) add(cand.name, cand);
   }
-  return out;
+
+  const locals = collectLocalDeclarations(program);
+  for (const node of program.body ?? []) {
+    if (node.type === 'ExportNamedDeclaration') {
+      // `export type { Props }` carries no value; `export { X } from './y'` re-exports another
+      // file's component, which that file's own scan already reports (counting it here would
+      // attribute the component to the barrel).
+      if (node.exportKind === 'type' || node.source != null) continue;
+      for (const spec of node.specifiers ?? []) {
+        if (spec?.exportKind === 'type') continue;
+        const localName = spec?.local?.name;
+        // `export { Button as default }` is a default export written the long way; naming it
+        // "default" would fail the PascalCase gate and drop the component entirely.
+        const isDefault = spec?.exported?.name === 'default';
+        const cand = candidateOfDeclaration(
+          locals.get(localName),
+          isDefault ? 'default' : 'named',
+          table,
+        );
+        if (cand !== null)
+          add((isDefault ? localName : spec?.exported?.name) ?? localName ?? null, cand);
+      }
+    } else if (
+      node.type === 'ExportDefaultDeclaration' &&
+      node.declaration?.type === 'Identifier'
+    ) {
+      const cand = candidateOfDeclaration(locals.get(node.declaration.name), 'default', table);
+      // The binding name is the author's own name for the component — better than the filename.
+      if (cand !== null) add(node.declaration.name, cand);
+    }
+  }
+  return [...byName.values()];
 };
 
 /** Whether an oxc class/member node carries a decorator called `name` (e.g. Component, Input). */
@@ -132,6 +452,15 @@ const hasDecorator = (node: any, name: string): boolean =>
   (node.decorators ?? []).some(
     (d: any) => (d.expression?.callee?.name ?? d.expression?.name) === name,
   );
+
+/** The `alias: 'foo'` member of an options object (`@Input({alias})` / `input(…, {alias})`). */
+const aliasFromOptions = (obj: any): string | undefined => {
+  if (obj?.type !== 'ObjectExpression') return undefined;
+  const alias = (obj.properties ?? []).find(
+    (p: any) => (p?.key?.name ?? p?.key?.value) === 'alias',
+  )?.value;
+  return alias?.type === 'Literal' && typeof alias.value === 'string' ? alias.value : undefined;
+};
 
 /**
  * The public input name for an @Input()-decorated member: the alias when one is given
@@ -143,13 +472,7 @@ const angularInputName = (member: any, keyName: string): string => {
     (d: any) => (d.expression?.callee?.name ?? d.expression?.name) === 'Input',
   )?.expression?.arguments?.[0];
   if (arg0?.type === 'Literal' && typeof arg0.value === 'string') return arg0.value;
-  if (arg0?.type === 'ObjectExpression') {
-    const alias = (arg0.properties ?? []).find(
-      (p: any) => (p?.key?.name ?? p?.key?.value) === 'alias',
-    )?.value;
-    if (alias?.type === 'Literal' && typeof alias.value === 'string') return alias.value;
-  }
-  return keyName;
+  return aliasFromOptions(arg0) ?? keyName;
 };
 
 /** True for a signal-input field initializer: input(), input.required(), model(), model.required(). */
@@ -160,17 +483,103 @@ const isSignalInput = (value: any): boolean => {
   return base === 'input' || base === 'model';
 };
 
-/** Public input names of an @Component class — both classic @Input() and signal input()/model(). */
-const angularInputs = (cls: any): string[] => {
-  const names = new Set<string>();
+/**
+ * The public name of a signal input. Like the decorator form it can be aliased, but the options
+ * object sits in a different argument slot — after the initial value for `input(init, {alias})`,
+ * first for the required form `input.required({alias})`. Reading the field name instead of the
+ * alias would line the Figma axis up against a name the template never binds.
+ */
+const signalInputName = (value: any, keyName: string): string => {
+  const isRequired = value.callee?.type === 'MemberExpression';
+  const options = isRequired ? value.arguments?.[0] : value.arguments?.[1];
+  return aliasFromOptions(options) ?? keyName;
+};
+
+/**
+ * Inputs declared in the `@Component({ inputs: [...] })` metadata rather than on the members. The
+ * pre-decorator style is still valid and still appears in real code; each entry is either a plain
+ * field name or the `'field: alias'` mapping, whose alias is the bound name.
+ */
+const metadataInputNames = (cls: any): string[] => {
+  const decorator = (cls.decorators ?? []).find(
+    (d: any) => (d.expression?.callee?.name ?? d.expression?.name) === 'Component',
+  );
+  const arg0 = decorator?.expression?.arguments?.[0];
+  if (arg0?.type !== 'ObjectExpression') return [];
+  const inputs = (arg0.properties ?? []).find(
+    (p: any) => (p?.key?.name ?? p?.key?.value) === 'inputs',
+  )?.value;
+  if (inputs?.type !== 'ArrayExpression') return [];
+  return (inputs.elements ?? [])
+    .flatMap((e: any) => {
+      if (e?.type === 'Literal' && typeof e.value === 'string') {
+        const [field, alias] = e.value.split(':');
+        return [(alias ?? field ?? '').trim()];
+      }
+      // Object form: { name: 'field', alias: 'bound' }
+      if (e?.type === 'ObjectExpression') {
+        const name = (e.properties ?? []).find(
+          (p: any) => (p?.key?.name ?? p?.key?.value) === 'name',
+        )?.value;
+        const bound =
+          aliasFromOptions(e) ??
+          (name?.type === 'Literal' && typeof name.value === 'string' ? name.value : undefined);
+        return bound === undefined ? [] : [bound];
+      }
+      return [];
+    })
+    .filter((n: string) => n.length > 0);
+};
+
+/**
+ * Public input names of an @Component class — decorator, signal, and metadata forms alike.
+ *
+ * An Angular component can also inherit inputs from a base class. When that base is declared in the
+ * same file its inputs are folded in; when it's imported (or reached through a namespace / mixin
+ * call) we can't see them, so the result is flagged incomplete — the class's OWN inputs are still
+ * returned, since those are read facts, and the join reports proven matches off an incomplete list
+ * while claiming nothing about the rest.
+ */
+const angularInputs = (
+  cls: any,
+  classes: Map<string, any>,
+  seen: Set<string> = new Set(),
+): PropsResult => {
+  const names = new Set<string>(metadataInputNames(cls));
   for (const member of cls.body?.body ?? []) {
     const keyName = member?.key?.name;
     if (typeof keyName !== 'string') continue;
     if (hasDecorator(member, 'Input')) names.add(angularInputName(member, keyName));
     else if (member.type === 'PropertyDefinition' && isSignalInput(member.value))
-      names.add(keyName);
+      names.add(signalInputName(member.value, keyName));
   }
-  return [...names];
+  const sup = cls.superClass;
+  if (sup != null) {
+    // Anything other than a local class name — `extends NS.Base`, `extends mixin(Base)` — hides
+    // inputs just as an imported base does, so it's incomplete rather than "no inherited inputs".
+    if (sup.type !== 'Identifier' || typeof sup.name !== 'string')
+      return { names: [...names], extracted: false };
+    if (seen.has(sup.name)) return { names: [...names], extracted: true }; // cycle guard
+    const base = classes.get(sup.name);
+    if (base === undefined) return { names: [...names], extracted: false }; // imported base
+    const inherited = angularInputs(base, classes, new Set([...seen, sup.name]));
+    for (const n of inherited.names) names.add(n);
+    if (!inherited.extracted) return { names: [...names], extracted: false };
+  }
+  return { names: [...names], extracted: true };
+};
+
+/** Index a file's class declarations by name, so an `extends Base` in the same file resolves. */
+const collectClassDeclarations = (program: any): Map<string, any> => {
+  const classes = new Map<string, any>();
+  for (const node of program?.body ?? []) {
+    const d =
+      node?.type === 'ExportNamedDeclaration' || node?.type === 'ExportDefaultDeclaration'
+        ? node.declaration
+        : node;
+    if (d?.type === 'ClassDeclaration' && typeof d.id?.name === 'string') classes.set(d.id.name, d);
+  }
+  return classes;
 };
 
 /** Strip Angular's conventional `Component` class-name suffix so it matches suffix-free Figma names. */
@@ -195,6 +604,7 @@ export const extractAngularComponents = (filePath: string, code: string): Scanne
   } catch {
     return [];
   }
+  const classes = collectClassDeclarations(program);
   const out: ScannedComponent[] = [];
   for (const node of program.body ?? []) {
     if (node.type !== 'ExportNamedDeclaration' && node.type !== 'ExportDefaultDeclaration')
@@ -203,12 +613,13 @@ export const extractAngularComponents = (filePath: string, code: string): Scanne
     if (cls?.type !== 'ClassDeclaration' || !hasDecorator(cls, 'Component')) continue;
     const className = cls.id?.name;
     if (typeof className !== 'string') continue;
+    const inputs = angularInputs(cls, classes);
     out.push({
       name: angularLogicalName(className),
       filePath,
       exportKind: node.type === 'ExportDefaultDeclaration' ? 'default' : 'named',
-      propNames: angularInputs(cls),
-      propsExtracted: true,
+      propNames: inputs.names,
+      propsExtracted: inputs.extracted,
       framework: 'angular',
     });
   }
@@ -233,18 +644,19 @@ const collectCalls = (root: any): any[] => {
   return out;
 };
 
-/** Prop names from a `defineProps` call: a type literal, an object, or an array of string keys. */
-const definePropsNames = (call: any): string[] => {
-  // Type form: defineProps<{ size?: string; variant: 'a' | 'b' }>(). oxc exposes the instantiation as
-  // typeArguments (older trees: typeParameters); its first param is a TSTypeLiteral whose members'
-  // keys are the prop names.
+/**
+ * Prop names from a `defineProps` call: a type argument (literal OR a named type), an object, or an
+ * array of string keys. Returns null when the call declares props we can't fully read (a type
+ * imported from another file), so the caller can report them as unextracted instead of empty.
+ */
+const definePropsNames = (call: any, table: TypeTable): string[] | null => {
+  // Type form: defineProps<{ size?: string }>() or defineProps<Props>(). oxc exposes the
+  // instantiation as typeArguments (older trees: typeParameters). The named form is by far the more
+  // common in real code — it's what `withDefaults` and every generic component use.
   const typeArgs = call.typeArguments ?? call.typeParameters;
-  const typeLiteral = typeArgs?.params?.[0];
-  if (typeLiteral?.type === 'TSTypeLiteral') {
-    return (typeLiteral.members ?? [])
-      .map((m: any) => m?.key?.name)
-      .filter((n: unknown): n is string => typeof n === 'string');
-  }
+  const typeArg = typeArgs?.params?.[0];
+  if (typeArg != null) return resolveTypeMembers(typeArg, table);
+
   const arg0 = call.arguments?.[0];
   // Object form: defineProps({ size: String, variant: { type: String } }) → keys.
   if (arg0?.type === 'ObjectExpression') {
@@ -259,6 +671,17 @@ const definePropsNames = (call: any): string[] => {
       .filter((n: unknown): n is string => typeof n === 'string');
   }
   return [];
+};
+
+/**
+ * The prop a `defineModel()` call declares (Vue 3.4+). It's a real prop on the public API —
+ * `defineModel()` is `modelValue`, `defineModel('title')` is `title` — and a v-model binding is
+ * exactly the kind of thing a Figma variant axis lines up against, so missing it understates the
+ * component. The options-object form (`defineModel({ required: true })`) still means modelValue.
+ */
+const defineModelName = (call: any): string => {
+  const arg0 = call.arguments?.[0];
+  return arg0?.type === 'Literal' && typeof arg0.value === 'string' ? arg0.value : 'modelValue';
 };
 
 /** Names from a `props: { … } | [ … ]` member of an object (Vue Options API props declaration). */
@@ -295,9 +718,16 @@ const vueOptionsPropsNames = (program: any): string[] => {
   return [];
 };
 
-/** Svelte prop names: `export let foo` (Svelte 4) and `let { a, b } = $props()` (Svelte 5 runes). */
-const sveltePropNames = (program: any): string[] => {
+/**
+ * Svelte prop names: `export let foo` (Svelte 4) and `$props()` (Svelte 5 runes). The runes form
+ * appears three ways in real code — destructured, type-annotated, or typed via a generic argument —
+ * and the latter two carry the props in a named type, so they resolve through the type table.
+ * Returns null when a `$props()` declares a type we can't fully read (imported), so the SFC path
+ * can mark props unextracted rather than empty.
+ */
+const sveltePropNames = (program: any, table: TypeTable): PropsResult => {
   const names = new Set<string>();
+  let unresolved = false;
   for (const node of program.body ?? []) {
     if (
       node.type === 'ExportNamedDeclaration' &&
@@ -308,17 +738,26 @@ const sveltePropNames = (program: any): string[] => {
         if (d?.id?.type === 'Identifier' && typeof d.id.name === 'string') names.add(d.id.name);
     }
   }
-  // Svelte 5 runes: `let { a, b } = $props()` — a destructuring declarator initialized by $props().
+  // Svelte 5 runes: a declarator initialized by $props().
   for (const node of program.body ?? []) {
     if (node.type !== 'VariableDeclaration') continue;
     for (const d of node.declarations ?? []) {
-      if (d?.init?.type === 'CallExpression' && d.init.callee?.name === '$props') {
-        for (const p of d.id?.properties ?? [])
-          if (p?.key?.name && typeof p.key.name === 'string') names.add(p.key.name);
+      if (d?.init?.type !== 'CallExpression' || d.init.callee?.name !== '$props') continue;
+      // `let { a, b } = $props()` — the destructuring pattern names the props directly.
+      if (d.id?.type === 'ObjectPattern') {
+        for (const p of d.id.properties ?? [])
+          if (p?.type === 'Property' && typeof p.key?.name === 'string') names.add(p.key.name);
+        continue;
       }
+      // `let props: Props = $props()` / `let props = $props<Props>()` — read the named type.
+      const typeArg = d.init.typeArguments?.params?.[0] ?? d.id?.typeAnnotation?.typeAnnotation;
+      const resolved = resolveTypeMembers(typeArg, table);
+      if (resolved === null) unresolved = true;
+      else for (const n of resolved) names.add(n);
     }
   }
-  return [...names];
+  // An unreadable `$props()` type doesn't erase props read elsewhere in the block (`export let`).
+  return { names: [...names], extracted: !unresolved };
 };
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -328,6 +767,10 @@ const REACT_EXTS = new Set(['.tsx', '.jsx']);
 // Pull every <script> / <script setup> body out of an SFC. lang="ts" (or its absence) decides the
 // parser dialect; a .vue/.svelte file with no script block is a genuinely prop-less template.
 const SCRIPT_BLOCK = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+// Whether the file opens a script at all. "No blocks extracted" only means "prop-less template"
+// when this is false; when it's true the block exists but didn't close (or closed inside a string),
+// so its props are unread rather than absent.
+const SCRIPT_OPEN = /<script\b/i;
 
 interface ScriptBlock {
   body: string;
@@ -349,11 +792,12 @@ const extractScriptBlocks = (code: string): ScriptBlock[] => {
  * forms) and Options-API `props`, Svelte's `export let` / `$props()`.
  *
  * PropsExtracted distinguishes "[] = genuinely no props" from "[] = unknown" so the join won't
- * invent extension TODOs. It's true only when we either found props, or the file is a script-less
- * (so genuinely prop-less) template. When a script is present but we read no props — a parse error,
- * or a prop-declaration style we don't recognize — it stays false (conservative: the join then
- * suppresses matched/unmatched rather than asserting prop gaps we can't actually see). oxc doesn't
- * throw on bad input, so a parse failure surfaces here simply as "no props found".
+ * invent extension TODOs. It's true when we read the props, or the file is a script-less (so
+ * genuinely prop-less) template. It stays false when a script is present but the props couldn't be
+ * fully read — a parse error, a prop type imported from another file, or a declaration style we
+ * don't recognize (conservative: the join then suppresses matched/unmatched rather than asserting
+ * prop gaps we can't actually see). oxc doesn't throw on bad input, so a parse failure surfaces
+ * here simply as "no props found".
  */
 export const extractSfcComponent = (
   filePath: string,
@@ -367,28 +811,52 @@ export const extractSfcComponent = (
     framework,
   };
   const scripts = extractScriptBlocks(code);
-  if (scripts.length === 0) return [{ ...base, propNames: [], propsExtracted: true }];
+  if (scripts.length === 0) {
+    // A template with no script really has no props; a script we failed to delimit has props we
+    // simply didn't read, and saying "none" there is the same false claim as an empty parse.
+    return [{ ...base, propNames: [], propsExtracted: !SCRIPT_OPEN.test(code) }];
+  }
 
-  const names = new Set<string>();
+  // Parse every block first: a type is routinely declared in `<script>` and consumed in `<script
+  // setup>`, so the type table has to span the whole SFC before any block is read for props.
+  const programs: any[] = [];
   for (const script of scripts) {
-    let program: ReturnType<typeof parseSync>['program'];
     try {
       // Name the virtual source so oxc picks the right dialect (TS enables defineProps<...>()).
-      program = parseSync(`sfc.${script.ts ? 'ts' : 'js'}`, script.body).program;
+      programs.push(parseSync(`sfc.${script.ts ? 'ts' : 'js'}`, script.body).program);
     } catch {
       continue;
     }
+  }
+  const table: TypeTable = new Map();
+  for (const program of programs)
+    for (const [name, decl] of collectTypeDeclarations(program)) table.set(name, decl);
+
+  const names = new Set<string>();
+  // Set when a props declaration was found but couldn't be fully resolved (an imported type), so an
+  // empty/partial list is never reported as a complete one.
+  let unresolved = false;
+  for (const program of programs) {
     if (framework === 'vue') {
-      for (const call of collectCalls(program))
-        if ((call as { callee?: { name?: string } }).callee?.name === 'defineProps')
-          for (const n of definePropsNames(call)) names.add(n);
+      for (const call of collectCalls(program)) {
+        const callee = (call as { callee?: { name?: string } }).callee?.name;
+        if (callee === 'defineProps') {
+          const resolved = definePropsNames(call, table);
+          if (resolved === null) unresolved = true;
+          else for (const n of resolved) names.add(n);
+        } else if (callee === 'defineModel') {
+          names.add(defineModelName(call));
+        }
+      }
       for (const n of vueOptionsPropsNames(program)) names.add(n);
     } else {
-      for (const n of sveltePropNames(program)) names.add(n);
+      const resolved = sveltePropNames(program, table);
+      if (!resolved.extracted) unresolved = true;
+      for (const n of resolved.names) names.add(n);
     }
   }
-  // Found props → confidently extracted. None found despite a script → unknown (don't claim).
-  return [{ ...base, propNames: [...names], propsExtracted: names.size > 0 }];
+  // Read the props → confidently extracted. Nothing found, or a type we couldn't chase → unknown.
+  return [{ ...base, propNames: [...names], propsExtracted: !unresolved && names.size > 0 }];
 };
 
 const frameworkForExt = (ext: string): ComponentFramework | null => {

--- a/packages/mcp/test/join/casefold.test.ts
+++ b/packages/mcp/test/join/casefold.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { casefold } from '../../src/join/casefold.js';
+
+describe('casefold', () => {
+  it('folds the separator and case conventions the two sides disagree on', () => {
+    // A Figma property label and the code identifier for it are the same thing spelled differently.
+    for (const variant of ['Show icon', 'show-icon', 'show_icon', 'showIcon', 'SHOW ICON'])
+      expect(casefold(variant)).toBe('showicon');
+  });
+
+  it('strips Latin diacritics so an accented label matches an ASCII identifier', () => {
+    // Designers write the product name; the JS symbol is ASCII by convention.
+    expect(casefold('Café')).toBe(casefold('Cafe'));
+    expect(casefold('Ünï-Tëst')).toBe('unitest');
+  });
+
+  it('keeps letters and digits in every script, distinctly', () => {
+    // Load-bearing: an [a-z0-9] filter folds all of these to '', and equal empty strings compare as
+    // a *perfect* Dice match — so a Chinese name would score 1.0 against a Japanese one, and any
+    // map keyed on the fold would collapse every non-Latin entry onto a single bucket.
+    const folded = ['按鈕', 'ボタン', '버튼', 'Кнопка', 'κουμπί'].map(casefold);
+    expect(folded.every(f => f.length > 0)).toBe(true);
+    expect(new Set(folded).size).toBe(folded.length); // all distinct
+  });
+
+  it('recomposes so Hangul stays syllables rather than decomposed jamo', () => {
+    // NFD splits Hangul; leaving it split would change every Korean name's bigrams.
+    expect(casefold('버튼')).toBe('버튼');
+    expect([...casefold('버튼')]).toHaveLength(2);
+  });
+
+  it('drops separators and symbols entirely', () => {
+    expect(casefold('Button/Primary')).toBe('buttonprimary');
+    expect(casefold('🔍 Search')).toBe('search');
+    expect(casefold('   ')).toBe('');
+  });
+});

--- a/packages/mcp/test/join/component-map.test.ts
+++ b/packages/mcp/test/join/component-map.test.ts
@@ -85,6 +85,95 @@ describe('joinComponents', () => {
     expect(m?.candidate?.unmatchedProps).toEqual(['Show icon_L']);
   });
 
+  it('matches multi-word Figma axes against camelCase props', () => {
+    // Figma property labels are prose ("Show icon"); code props are identifiers (`showIcon`). A
+    // plain lowercase compare only ever matched single-word axes, so every multi-word property on a
+    // real component was reported as a missing prop to add.
+    const [m] = joinComponents(
+      [
+        usage({
+          name: 'Button',
+          variantAxes: ['Show icon', 'Is Disabled', 'icon-position', 'Full width', 'State'],
+        }),
+      ],
+      [comp('Button', ['showIcon', 'isDisabled', 'iconPosition', 'fullWidth'])],
+      { threshold: 0.7 },
+    );
+    expect(m?.candidate?.matchedProps).toEqual([
+      'Show icon',
+      'Is Disabled',
+      'icon-position',
+      'Full width',
+    ]);
+    expect(m?.candidate?.unmatchedProps).toEqual(['State']); // genuinely absent — still reported
+  });
+
+  it('does not match a name to an unrelated one in another script', () => {
+    // Regression: an [a-z0-9] casefold reduced BOTH of these to '', and diceSimilarity('','')
+    // short-circuits to 1 — so a Chinese "按鈕" was a confident, high-status match for a Japanese
+    // "ボタン", or for any other non-Latin component that happened to be scanned.
+    const jp: ScannedComponent = {
+      name: 'ボタン',
+      filePath: 'src/components/ボタン.vue',
+      exportKind: 'default',
+      propNames: [],
+      propsExtracted: true,
+      framework: 'vue',
+    };
+    const [m] = joinComponents([usage({ name: '按鈕' })], [jp], { threshold: 0.7 });
+    expect(m?.status).toBe('unmapped');
+    expect(m?.candidate).toBeUndefined();
+  });
+
+  it('matches an accented Figma name to its ASCII code identifier', () => {
+    const [m] = joinComponents([usage({ name: 'Café' })], [comp('Cafe')], { threshold: 0.7 });
+    expect(m?.candidate?.name).toBe('Cafe');
+    expect(m?.candidate?.confidence).toBe(1);
+  });
+
+  it('matches components and axes named in a non-Latin script', () => {
+    // An [a-z0-9] casefold erases a CJK name entirely, so every such component compared as the
+    // empty string and could only ever match an exact duplicate.
+    const cjk: ScannedComponent = {
+      name: '按鈕',
+      filePath: 'src/components/按鈕.vue',
+      exportKind: 'default',
+      propNames: ['尺寸', '是否停用'],
+      propsExtracted: true,
+      framework: 'vue',
+    };
+    const [m] = joinComponents(
+      [usage({ name: '按鈕/主要', variantAxes: ['尺寸', '是否停用'] })],
+      [cjk],
+      { threshold: 0.7 },
+    );
+    expect(m?.candidate?.name).toBe('按鈕');
+    expect(m?.status).toBe('high');
+    expect(m?.candidate?.matchedProps).toEqual(['尺寸', '是否停用']);
+  });
+
+  it('reports proven matches off an incomplete prop list, but claims nothing is missing', () => {
+    // A component whose own props parsed but whose base/prop-type is imported has propsExtracted
+    // false with a PARTIAL propNames. The two halves aren't symmetric: a prop we did read still
+    // matches, while the axes we can't account for may well be covered by the props we couldn't
+    // see — calling those missing would be a false extension TODO.
+    const partial: ScannedComponent = {
+      name: 'Button',
+      filePath: 'src/app/button.component.ts',
+      exportKind: 'named',
+      propNames: ['size'],
+      propsExtracted: false,
+      framework: 'angular',
+    };
+    const [m] = joinComponents(
+      [usage({ name: 'Button', variantAxes: ['Size', 'Tone'] })],
+      [partial],
+      { threshold: 0.7 },
+    );
+    expect(m?.candidate?.matchedProps).toEqual(['Size']);
+    expect(m?.candidate?.unmatchedProps).toEqual([]);
+  });
+
   it('suppresses unmatchedProps when the candidate props were not extracted (SFC baseline)', () => {
     // A Vue/Svelte component whose props couldn't be parsed has propsExtracted=false. The join must
     // not dump every variant axis into unmatchedProps (a false "extend this component" TODO) just
@@ -105,6 +194,40 @@ describe('joinComponents', () => {
     expect(m?.candidate?.name).toBe('Button');
     expect(m?.candidate?.matchedProps).toEqual([]);
     expect(m?.candidate?.unmatchedProps).toEqual([]);
+  });
+
+  // Figma writes a variant's own name as `Prop=Value, …`, so the text before the first `=` is a
+  // PROPERTY name — and Size / State / Type / Variant are exactly what a design system also names
+  // components. Mining it mapped an unresolved variant usage onto an unrelated component at 1.0.
+  it.each(['Size=Large, State=Hover', 'Type=Primary', 'State=Default, Size=Medium'])(
+    'does not mine a component name out of the variant decoration in %s',
+    name => {
+      const ds = [comp('Size'), comp('State'), comp('Type'), comp('Button')];
+      const [m] = joinComponents([usage({ name })], ds, { threshold: 0.7 });
+      expect(m?.status).not.toBe('high');
+      expect(m?.candidate?.confidence ?? 0).toBeLessThan(0.85);
+    },
+  );
+
+  // The slash part carries the real name, and a comma-only name has no variant syntax at all —
+  // neither may be lost to the rule above.
+  it.each(['Button/Size=Large, State=Hover', 'Button/Primary', 'Button, Large'])(
+    'still recovers the component name from %s',
+    name => {
+      const ds = [comp('Button'), comp('Card'), comp('Size')];
+      const [m] = joinComponents([usage({ name })], ds, { threshold: 0.7 });
+      expect(m?.candidate?.name).toBe('Button');
+      expect(m?.status).toBe('high');
+    },
+  );
+
+  it('honours a threshold raised above the absolute high mark', () => {
+    const scanned2 = [comp('Button')];
+    const at = (threshold: number) =>
+      joinComponents([usage({ name: 'Buton' })], scanned2, { threshold })[0];
+    expect(at(0.7)?.status).toBe('high'); // 0.889 — confident by default
+    expect(at(0.95)?.status).toBe('low'); // …but below a caller who asked for 0.95
+    expect(at(0.95)?.candidate?.name).toBe('Button'); // still surfaced, just not reuse-grade
   });
 
   it('flags unmapped when nothing is close', () => {

--- a/packages/mcp/test/join/icon-map.test.ts
+++ b/packages/mcp/test/join/icon-map.test.ts
@@ -93,6 +93,21 @@ describe('collectFigmaIcons', () => {
     ]);
     expect(icons[0]?.name).toBe('Bell');
   });
+
+  it('keeps non-Latin icon names distinct', () => {
+    // The grouping key is the casefolded label. An [a-z0-9] fold turns every CJK label into the
+    // empty string, collapsing a whole icon set into one usage with all of their node ids merged.
+    const icons = collectFigmaIcons([
+      node({ id: '1:1', type: 'VECTOR', name: '搜尋' }),
+      node({ id: '1:2', type: 'VECTOR', name: '刪除' }),
+      node({ id: '1:3', type: 'VECTOR', name: '編輯' }),
+      node({ id: '1:4', type: 'VECTOR', name: '搜尋' }),
+    ]);
+    expect(icons.map(i => i.name).toSorted()).toEqual(['刪除', '搜尋', '編輯']);
+    // The repeated one groups; the distinct ones don't merge into it.
+    expect(icons.find(i => i.name === '搜尋')?.nodeIds).toEqual(['1:1', '1:4']);
+    expect(icons.find(i => i.name === '刪除')?.nodeIds).toEqual(['1:2']);
+  });
 });
 
 const opts = (

--- a/packages/mcp/test/join/status.test.ts
+++ b/packages/mcp/test/join/status.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { CANDIDATE_FLOOR, statusFor } from '../../src/join/status.js';
+
+describe('statusFor', () => {
+  it('grades against the absolute mark at the default bar', () => {
+    expect(statusFor(1, 0.7)).toBe('high');
+    expect(statusFor(0.9, 0.7)).toBe('high');
+    expect(statusFor(0.8, 0.7)).toBe('medium');
+    expect(statusFor(0.6, 0.7)).toBe('low');
+    expect(statusFor(0.4, 0.7)).toBe('unmapped');
+  });
+
+  it('lets a raised bar demote a match the absolute mark would call high', () => {
+    // The bug this encodes: `high`/`medium` mean "reuse this component" to codegen, so threshold is
+    // the reuse bar. A hardcoded top cut ignored a caller asking for something stricter than 0.85 —
+    // exactly the caller who has already been burned by a wrong reuse.
+    expect(statusFor(0.889, 0.7)).toBe('high');
+    expect(statusFor(0.889, 0.9)).toBe('low'); // below the caller's bar → not reuse-grade
+    expect(statusFor(0.95, 0.9)).toBe('high'); // clears both → still reuse-grade
+    expect(statusFor(1, 1)).toBe('high'); // a bar of 1 still admits a perfect match
+  });
+
+  it('is monotonic: raising the bar never promotes a mapping', () => {
+    const rank = { unmapped: 0, low: 1, medium: 2, high: 3, 'framework-builtin': 0 } as const;
+    for (let c = 0; c <= 1.0001; c += 0.05) {
+      let previous = 4;
+      for (let t = 0; t <= 1.0001; t += 0.05) {
+        const current = rank[statusFor(c, t)];
+        expect(current).toBeLessThanOrEqual(previous);
+        previous = current;
+      }
+    }
+  });
+
+  it('does not let a lowered bar drag candidates below the reporting floor', () => {
+    // The floor is what's worth showing, not what counts as reliable: flooding codegen with
+    // sub-0.5 name guesses trades a silent wrong reuse for a noisy one.
+    expect(statusFor(CANDIDATE_FLOOR - 0.01, 0)).toBe('unmapped');
+    expect(statusFor(CANDIDATE_FLOOR, 0)).toBe('medium'); // clears the bar, not the absolute mark
+  });
+});

--- a/packages/mcp/test/join/token-map.test.ts
+++ b/packages/mcp/test/join/token-map.test.ts
@@ -401,4 +401,24 @@ describe('parseTokenMapFile', () => {
     expect(map.has('Figma')).toBe(false);
     expect([...map.keys()].some(k => k.startsWith(':'))).toBe(false);
   });
+
+  it('keys non-Latin names without collapsing them onto one another', () => {
+    // Every row is stored under a raw AND a normalized key. An [a-z0-9] fold normalizes every CJK
+    // name to '', so all of them collide on a single key and the last row silently wins — a lookup
+    // that missed the raw name would then resolve to the wrong token.
+    const map = parseTokenMapFile(
+      [
+        '| Figma | Token |',
+        '| --- | --- |',
+        '| 顏色/主要 | --color-primary |',
+        '| 顏色/次要 | --color-secondary |',
+        '| 顏色/危險 | --color-danger |',
+      ].join('\n'),
+    );
+    expect(map.get('顏色/主要')).toBe('--color-primary');
+    expect(map.get('顏色主要')).toBe('--color-primary'); // normalized key stays distinct
+    expect(map.get('顏色次要')).toBe('--color-secondary');
+    expect(map.get('顏色危險')).toBe('--color-danger');
+    expect(map.has('')).toBe(false); // no all-rows-collide bucket
+  });
 });

--- a/packages/mcp/test/scan/scan.test.ts
+++ b/packages/mcp/test/scan/scan.test.ts
@@ -42,10 +42,205 @@ describe('extractReactComponents (pure)', () => {
       export const Icon = forwardRef((props, ref) => <svg ref={ref}/>);
       export const Badge = memo(({ label }) => <span>{label}</span>);
     `;
-    const names = extractReactComponents('x.tsx', code)
-      .map(c => c.name)
-      .toSorted();
-    expect(names).toEqual(['Badge', 'Icon']);
+    const comps = extractReactComponents('x.tsx', code);
+    expect(comps.map(c => c.name).toSorted()).toEqual(['Badge', 'Icon']);
+    // Icon takes an un-annotated `props` param: its prop list is unknowable, and saying so is the
+    // whole point of propsExtracted. Asserting only the names here is what let a false
+    // propsExtracted=true survive — the join then reports every Figma axis as a missing prop.
+    expect(comps.find(c => c.name === 'Icon')?.propsExtracted).toBe(false);
+    expect(comps.find(c => c.name === 'Badge')?.propNames).toEqual(['label']);
+  });
+
+  it('unwraps namespaced and nested HOCs (React.memo, memo(forwardRef(...)))', () => {
+    const code = `
+      export const Icon = React.memo(({ size }) => <svg/>);
+      export const Chip = React.forwardRef(({ tone }, ref) => <span ref={ref}/>);
+      export const Tag = memo(forwardRef(({ label }, ref) => <b ref={ref}/>));
+    `;
+    const comps = extractReactComponents('x.tsx', code);
+    expect(comps.map(c => c.name).toSorted()).toEqual(['Chip', 'Icon', 'Tag']);
+    expect(comps.find(c => c.name === 'Tag')?.propNames).toEqual(['label']);
+  });
+
+  it('resolves components exported by reference, not just inline declarations', () => {
+    // Declaring at the top and exporting at the bottom is a common house style; a scanner that only
+    // reads `export const` reports these as absent and codegen rebuilds components that exist.
+    const code = `
+      interface Props { size?: string }
+      const Button = ({ size }: Props) => <button/>;
+      function Card({ title }: { title: string }) { return <div/>; }
+      const Inner = ({ tone }: { tone: string }) => <i/>;
+      export { Button, Card, Inner as Badge };
+      export default Button;
+    `;
+    const comps = extractReactComponents('ui/Button.tsx', code);
+    expect(comps.map(c => c.name).toSorted()).toEqual(['Badge', 'Button', 'Card']);
+    expect(comps.find(c => c.name === 'Badge')?.propNames).toEqual(['tone']);
+    // Button is exported both ways — it must be reported once, not duplicated.
+    expect(comps.filter(c => c.name === 'Button')).toHaveLength(1);
+  });
+
+  it('names a default-exported binding after the binding, not the file', () => {
+    const code = `const Button = ({ size }: { size?: string }) => <button/>;\nexport default Button;`;
+    const [c] = extractReactComponents('ui/index.tsx', code);
+    expect(c?.name).toBe('Button'); // the author's name beats the filename baseline (`Ui`)
+    expect(c?.exportKind).toBe('default');
+    expect(c?.propNames).toEqual(['size']);
+  });
+
+  it('ignores type-only exports and re-exports from other modules', () => {
+    // `export { Button } from './Button'` is a barrel: that file's own scan reports the component,
+    // so counting it here would attribute it to the wrong path.
+    const code = `
+      interface Props { size?: string }
+      export type { Props };
+      export { Button } from './Button';
+    `;
+    expect(extractReactComponents('index.tsx', code)).toEqual([]);
+  });
+
+  it('extracts class components and their props', () => {
+    const code = `
+      interface Props { size?: string; tone: string }
+      export class Button extends React.Component<Props> { render() { return <button/>; } }
+      export class Chip extends PureComponent<{ label: string }> { render() { return <b/>; } }
+      export class NotAComponent extends Base { }
+    `;
+    const comps = extractReactComponents('x.tsx', code);
+    expect(comps.map(c => c.name).toSorted()).toEqual(['Button', 'Chip']);
+    expect(comps.find(c => c.name === 'Button')?.propNames.toSorted()).toEqual(['size', 'tone']);
+    expect(comps.find(c => c.name === 'Chip')?.propNames).toEqual(['label']);
+  });
+
+  // Only the destructured form was read before, so `(props: Props)` — and any component that
+  // destructures in its body — reported zero props while claiming the list was complete.
+  it.each([
+    ['a plain annotated parameter', `export const Button = (props: Props) => <button/>;`],
+    [
+      'a body destructure',
+      `export function Button(props: Props) { const { size } = props; return <button/>; }`,
+    ],
+    ['React.FC on the binding', `export const Button: React.FC<Props> = (props) => <button/>;`],
+    ['FC on a binding that ignores them', `export const Button: FC<Props> = () => <button/>;`],
+  ])('reads props declared via %s', (_label, form) => {
+    const code = `interface Props { size?: string; tone: string }\n${form}`;
+    const [c] = extractReactComponents('x.tsx', code);
+    expect(c?.propNames.toSorted()).toEqual(['size', 'tone']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('resolves type aliases, intersections and interface inheritance declared in the file', () => {
+    const code = `
+      interface Base { tone: string }
+      interface Props extends Base { size?: string }
+      type Extra = { id: string };
+      type CardProps = Extra & { title: string };
+      export const Button = (props: Props) => <button/>;
+      export const Card = (props: CardProps) => <div/>;
+    `;
+    const comps = extractReactComponents('x.tsx', code);
+    expect(comps.find(c => c.name === 'Button')?.propNames.toSorted()).toEqual(['size', 'tone']);
+    expect(comps.find(c => c.name === 'Card')?.propNames.toSorted()).toEqual(['id', 'title']);
+  });
+
+  // The honesty invariant: an imported prop type, or an interface extending one, leaves props we
+  // genuinely cannot see. Claiming [] would make the join report every Figma axis as missing.
+  it.each([
+    [
+      'imported prop type',
+      `import type { Props } from './t';\nexport const Button = (props: Props) => <button/>;`,
+    ],
+    [
+      'interface extending an imported one',
+      `import type { Base } from './t';\ninterface Props extends Base { size?: string }\nexport const Button = (props: Props) => <button/>;`,
+    ],
+    [
+      'intersection with an imported type',
+      `import type { Base } from './t';\ntype Props = Base & { size?: string };\nexport const Button = (props: Props) => <button/>;`,
+    ],
+    // A utility generic changes the member set in ways this pass doesn't model.
+    [
+      'a utility generic',
+      `interface Base { size?: string }\nexport const Button = (props: Partial<Base>) => <button/>;`,
+    ],
+    ['an un-annotated parameter', `export const Button = (props) => <button/>;`],
+  ])('reports props as NOT extracted for %s', (_label, code) => {
+    const [c] = extractReactComponents('x.tsx', code);
+    expect(c?.name).toBe('Button');
+    expect(c?.propsExtracted).toBe(false);
+    expect(c?.propNames).toEqual([]);
+  });
+
+  it('resolves a generic component type but not a utility type', () => {
+    // `Props<T>` still declares the same member names — only their types depend on T — so it must
+    // resolve. `Partial<Props>` / `Omit<…>` genuinely reshape the member set and must not.
+    const generic = `interface Props<T> { items: T[]; size?: string }\nexport const List = <T,>({ items }: Props<T>) => <ul/>;`;
+    const [g] = extractReactComponents('x.tsx', generic);
+    expect(g?.propNames.toSorted()).toEqual(['items', 'size']);
+    expect(g?.propsExtracted).toBe(true);
+
+    const utility = `interface Props { size?: string }\nexport const B = (p: Omit<Props, 'size'>) => <i/>;`;
+    expect(extractReactComponents('x.tsx', utility)[0]?.propsExtracted).toBe(false);
+  });
+
+  it('prefers the declared prop type over what the body destructures', () => {
+    // `({ size }: Props)` accepts every member of Props; treating the pattern as the answer would
+    // report the rest as props the component is missing.
+    const code = `interface Props { size?: string; tone?: string }\nexport const B = ({ size }: Props) => <i/>;`;
+    const [c] = extractReactComponents('x.tsx', code);
+    expect(c?.propNames.toSorted()).toEqual(['size', 'tone']);
+  });
+
+  it('treats a rest-only pattern as unknown, not as prop-less', () => {
+    // `({ ...rest })` has real props, just none written down anywhere readable.
+    const [c] = extractReactComponents('x.tsx', 'export const B = ({ ...rest }) => <i/>;');
+    expect(c?.propsExtracted).toBe(false);
+    // …unless the annotation says what they are.
+    const typed = `interface Props { size?: string }\nexport const B = ({ ...rest }: Props) => <i/>;`;
+    expect(extractReactComponents('x.tsx', typed)[0]?.propNames).toEqual(['size']);
+  });
+
+  it('resolves `export { X as default }` as a default export', () => {
+    // Naming it "default" would fail the PascalCase gate and drop the component entirely.
+    const code = `const Button = ({ size }: { size?: string }) => <button/>;\nexport { Button as default };`;
+    const [c] = extractReactComponents('ui/Button.tsx', code);
+    expect(c?.name).toBe('Button');
+    expect(c?.exportKind).toBe('default');
+    expect(c?.propNames).toEqual(['size']);
+  });
+
+  it('reads props of a Solid component, which never destructures them', () => {
+    // Destructuring breaks Solid's reactivity, so idiomatic Solid always takes `props` whole —
+    // exactly the shape that used to report zero props while claiming the list was complete.
+    const P = 'interface Props { size?: string; tone?: string }\n';
+    const [fn] = extractReactComponents(
+      'x.tsx',
+      `${P}export function Button(props: Props) { return <b>{props.size}</b>; }`,
+    );
+    expect(fn?.propNames.toSorted()).toEqual(['size', 'tone']);
+    expect(fn?.propsExtracted).toBe(true);
+    // Solid's own component types are the FC<Props> equivalent.
+    const [typed] = extractReactComponents(
+      'x.tsx',
+      `${P}export const Button: ParentComponent<Props> = (props) => <b/>;`,
+    );
+    expect(typed?.propNames.toSorted()).toEqual(['size', 'tone']);
+  });
+
+  it('treats a component with no parameter as genuinely prop-less', () => {
+    const [c] = extractReactComponents('x.tsx', 'export const Button = () => <button/>;');
+    expect(c?.propNames).toEqual([]);
+    expect(c?.propsExtracted).toBe(true); // [] here means "none", not "unknown"
+  });
+
+  it('does not mistake a cyclic type for an unreadable one', () => {
+    const code = `
+      interface A extends B { a?: string }
+      interface B extends A { b?: string }
+      export const Button = (props: A) => <button/>;
+    `;
+    const [c] = extractReactComponents('x.tsx', code);
+    expect(c?.propNames.toSorted()).toEqual(['a', 'b']);
   });
 
   it('names an anonymous default export from the filename', () => {
@@ -118,6 +313,85 @@ describe('extractSfcComponent (Vue / Svelte props)', () => {
     const [c] = extractSfcComponent('C.vue', '<script setup>const = = =</script>', 'vue');
     expect(c?.propsExtracted).toBe(false);
     expect(c?.propNames).toEqual([]);
+  });
+
+  it('distinguishes a script-less template from a script it could not delimit', () => {
+    // Both yield zero script blocks, but they mean opposite things: one genuinely declares no
+    // props, the other has props we failed to read.
+    const [template] = extractSfcComponent('C.vue', '<template><button/></template>', 'vue');
+    expect(template?.propsExtracted).toBe(true);
+
+    const [unclosed] = extractSfcComponent(
+      'C.vue',
+      '<script setup lang="ts">defineProps<{ size?: string }>()',
+      'vue',
+    );
+    expect(unclosed?.propsExtracted).toBe(false);
+  });
+
+  // `defineProps<Props>()` — with an interface and withDefaults — is the dominant Vue authoring
+  // style. Reading only the inline literal form missed it, leaving prop-less components.
+  it.each([
+    ['an interface', `interface Props { size?: string }\ndefineProps<Props>()`],
+    ['a type alias', `type Props = { size?: string }\ndefineProps<Props>()`],
+    [
+      'withDefaults',
+      `interface Props { size?: string }\nwithDefaults(defineProps<Props>(), { size: 'md' })`,
+    ],
+    ['an assigned result', `interface Props { size?: string }\nconst props = defineProps<Props>()`],
+  ])('resolves defineProps declared with %s', (_label, body) => {
+    const [c] = extractSfcComponent('C.vue', `<script setup lang="ts">${body}</script>`, 'vue');
+    expect(c?.propNames).toEqual(['size']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('folds inherited interface members into Vue props', () => {
+    const code = `<script setup lang="ts">
+      interface Base { tone: string }
+      interface Props extends Base { size?: string }
+      defineProps<Props>()
+    </script>`;
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propNames.toSorted()).toEqual(['size', 'tone']);
+  });
+
+  it('counts defineModel() as the prop it declares', () => {
+    // v-model bindings are public props (modelValue by default, or the given name) and are exactly
+    // what a Figma variant axis lines up against.
+    const [c] = extractSfcComponent(
+      'C.vue',
+      `<script setup lang="ts">const m = defineModel<string>()\nconst t = defineModel<string>('title')</script>`,
+      'vue',
+    );
+    expect(c?.propNames.toSorted()).toEqual(['modelValue', 'title']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('resolves a type declared in one script block and used in another', () => {
+    const code = `<script lang="ts">export interface Props { size?: string }</script>
+      <script setup lang="ts">defineProps<Props>()</script>`;
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propNames).toEqual(['size']);
+  });
+
+  it.each([
+    ['a type annotation', `interface Props { size?: string }\nlet props: Props = $props();`],
+    ['a generic argument', `interface Props { size?: string }\nlet props = $props<Props>();`],
+  ])('reads Svelte $props() declared with %s', (_label, body) => {
+    const [c] = extractSfcComponent('C.svelte', `<script lang="ts">${body}</script>`, 'svelte');
+    expect(c?.propNames).toEqual(['size']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('marks SFC props NOT extracted when the prop type is imported', () => {
+    const vue = `<script setup lang="ts">import type { Props } from './types'\ndefineProps<Props>()</script>`;
+    const [v] = extractSfcComponent('C.vue', vue, 'vue');
+    expect(v?.propsExtracted).toBe(false);
+    expect(v?.propNames).toEqual([]);
+
+    const svelte = `<script lang="ts">import type { Props } from './types'\nlet props: Props = $props();</script>`;
+    const [s] = extractSfcComponent('C.svelte', svelte, 'svelte');
+    expect(s?.propsExtracted).toBe(false);
   });
 });
 
@@ -196,6 +470,75 @@ describe('extractAngularComponents (pure)', () => {
       export class PlainThing {}
     `;
     expect(extractAngularComponents('x.ts', code)).toEqual([]);
+  });
+
+  it('uses the alias of a signal input as the public prop name', () => {
+    // The options object sits in a different argument slot per form — after the initial value for
+    // input(), first for the required form — so the field name would otherwise leak as the prop.
+    const code = `
+      import { Component, input, model } from '@angular/core';
+      @Component({ template: '' })
+      export class FieldComponent {
+        kind = input('primary', { alias: 'variant' });
+        busy = input.required<boolean>({ alias: 'isBusy' });
+        val = model('x', { alias: 'value' });
+      }
+    `;
+    const [c] = extractAngularComponents('field.component.ts', code);
+    expect(c?.propNames).toEqual(['variant', 'isBusy', 'value']);
+  });
+
+  it('reads inputs declared in the @Component metadata', () => {
+    const code = `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-b', template: '', inputs: ['size', 'kind: variant'] })
+      export class ButtonComponent {}
+    `;
+    const [c] = extractAngularComponents('button.component.ts', code);
+    // 'kind: variant' binds as `variant` in the template — that's the name a Figma axis matches.
+    expect(c?.propNames).toEqual(['size', 'variant']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('folds inputs inherited from a base class declared in the same file', () => {
+    const code = `
+      import { Component, Directive, Input } from '@angular/core';
+      @Directive()
+      export class BaseComponent { @Input() tone = 'a'; }
+      @Component({ template: '' })
+      export class ButtonComponent extends BaseComponent { @Input() size = 'md'; }
+    `;
+    const [c] = extractAngularComponents('button.component.ts', code);
+    expect(c?.name).toBe('Button');
+    expect(c?.propNames.toSorted()).toEqual(['size', 'tone']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it.each([
+    [
+      'an imported base',
+      `import { BaseComponent } from './base';\n@Component({ template: '' })\nexport class ButtonComponent extends BaseComponent { @Input() size = 'md'; }`,
+    ],
+    // A namespaced or computed base hides inputs exactly as an imported one does.
+    [
+      'a namespaced base',
+      `@Component({ template: '' })\nexport class ButtonComponent extends NS.BaseComponent { @Input() size = 'md'; }`,
+    ],
+    [
+      'a mixin base',
+      `@Component({ template: '' })\nexport class ButtonComponent extends mixin(Base) { @Input() size = 'md'; }`,
+    ],
+  ])('flags the input list incomplete, keeping its own, for %s', (_label, body) => {
+    const [c] = extractAngularComponents(
+      'button.component.ts',
+      `import { Component, Input } from '@angular/core';\n${body}`,
+    );
+    expect(c?.name).toBe('Button');
+    // The inherited inputs are unreadable, so the list isn't exhaustive…
+    expect(c?.propsExtracted).toBe(false);
+    // …but the class's own input is a read fact and must survive: the join reports it as a proven
+    // match while claiming nothing about the axes it can't account for.
+    expect(c?.propNames).toEqual(['size']);
   });
 
   it('does not crash on unparseable source', () => {


### PR DESCRIPTION
`component_map` decides whether codegen **reuses** a component or rebuilds it. Both halves of that decision — finding the component, and diffing its props against the Figma variant axes — were wrong in ways nothing could catch: every gate stays green because the scanner returns a plausible-looking answer either way.

## What was wrong

**The scanner only recognised one shape.** A component was found only via its inline export declaration, and its props only from a destructured first parameter. Everything else was invisible or misreported:

| | before |
|---|---|
| `export { Button }` / `export default Button` / `export { Button as default }` | component **not found** |
| React class components, `React.memo(...)`, `memo(forwardRef(...))` | component **not found** |
| `(props: Props)`, body destructure, `FC<Props>` | `props: []` **claimed complete** |
| `defineProps<Props>()`, `withDefaults`, `$props<Props>()` | `props: []` |
| `defineModel()`, Angular `inputs: []`, signal-input aliases | missing / wrong name |

A component that isn't found is reported `unmapped`, so codegen rebuilds one the project already has. A component whose props are "read" as `[]` makes the join report *every* Figma axis as a prop to add. Solid was hit hardest: its components must not destructure props at all, so the prop list was empty for the entire framework.

**The join's casefold kept only `[a-z0-9]`.** That erased more than accents. Multi-word Figma labels never matched their identifier (`"Show icon"` vs `showIcon`) — on a real component nearly every axis read as missing. And every non-Latin name folded to the empty string, where equal empty strings are a *perfect* Dice match: a Chinese `按鈕` scored **1.0** against a Japanese `ボタン`. Keyed maps were worse — several CJK rows in a token map file collided on one key and the last row silently won.

**`threshold` was inert where it mattered.** Documented as the bar at/above which a match counts as a reliable reuse, but `high` was a hardcoded `0.85` that never consulted it. A caller asking for `0.95` still got `high` on a `0.889` guess, and codegen reuses anything graded high or medium — so the parameter was ignored in the one direction where being wrong costs something.

**Variant names were mined for a component name.** A Figma variant is named `Prop=Value, …`, so the text before the first `=` is a *property* name — and `Size` / `State` / `Type` / `Variant` are exactly what a design system also calls its components. An unresolved variant usage mapped onto an unrelated component at confidence 1.0.

## What changed

Detection now covers every export and HOC form. Props are read from the **declaration** rather than the destructuring pattern, resolving named types declared in the same file (interface / alias / `extends` / intersection / generic argument) — the dominant authoring style in all four frameworks.

`propsExtracted` is honest in both directions, and `propNames` may now be **partial**: an unreadable prop type or imported base class keeps the props we did read and flags the list incomplete. The join uses that — proven matches still count, while axes it cannot account for are no longer called missing.

The two duplicated join helpers are now shared (`casefold.ts`, `status.ts`) so the rules can't drift between the three tools.

## Verification

Differential-tested against the previous implementation: **468 generated React/Solid sources** (props form × wrapper × export form), the Vue / Svelte / Angular declaration forms, and **432 name pairs** spanning ASCII, separators, accents, CJK, Hangul, Cyrillic, Greek, emoji and fullwidth.

```
LOST (component found before, not now)   0
PROPS_LOST (prop present before, not now) 0
EXT_FALSE_TO_TRUE (honest → claimed)      0
components newly found                  381
```

At the default `threshold` of 0.7 every confidence still grades exactly as before. Also stress-tested for crashes and hangs (cyclic types, 500-deep inheritance chains, 200-deep HOC nesting, malformed sources, 5000 exports) — no crash, nothing over 30ms — and sanity-checked against this repo's own 15 Vue components, verified line by line against their source.

Tests 1240 → 1302. Six gates green.

## Live round-trip

Run end to end against a production design file over a connected plugin, on a freshly built server.

That file names several of its components in Chinese, which turned the CJK fold from a latent bug into an observable one. Three distinctly-named components, joined against a Vue project whose components carry the matching names:

| Figma component | before | after |
|---|---|---|
| `card/<CJK-A>` | → `<CJK-C>` &nbsp;**wrong** | → `<CJK-A>` |
| `btn/Default/btn/Default/card/<CJK-B>` | → `<CJK-C>` &nbsp;**wrong** | → `<CJK-B>` |
| `card/<CJK-C>` | → `<CJK-C>` | → `<CJK-C>` |

All three folded to the empty string, and `diceSimilarity` short-circuits equal strings to 1.0 — so every one of them matched the same component at full confidence, and whichever was scanned last won. Two of the three were silently wrong reuses. (They graded `medium` rather than `high` only because the three-way tie tripped the existing `ambiguousWith` cap — and codegen reuses `medium` too, so the wrong import still shipped.) Each now resolves to its own component, including through a deeply nested slash path.

The same run also confirms, on real data: distinct components sharing a name stay separate rows rather than merging; a semantically wrong fuzzy match (`footer` → a same-named component in an unrelated project) grades `low` and is correctly not offered for reuse; `unmatchedProps` reports the axis the code component genuinely lacks; and framework detection resolves off the manifest.

Replaying the same 18 real component names against an unrelated project — one with no CJK names, where the old fold could not collide — reproduces the previous behaviour exactly, so the change is inert where the bug could not fire.

## Not covered

The multi-word axis fix is not exercised by that file: its variant axes are Figma's default `Property 1` and a single-word `Type`, so `"Show icon"` vs `showIcon` rests on the unit and differential tests rather than a live observation.
