### PR TITLE
fix(mcp): cap the bytes get_screenshot inlines in one batch

### DIFF
--- a/packages/mcp/src/tools/get-screenshot.ts
+++ b/packages/mcp/src/tools/get-screenshot.ts
@@ -17,7 +17,7 @@ export const getScreenshotTool: ToolSpec = {
     'bytes buy no detail — use save_screenshots when you need a full-res file on disk. Past 20 ' +
     'nodes in one call the whole batch drops to a 2000px long edge, which is what providers require ' +
     'of many-image requests; ask for fewer nodes when you need the detail. A batch is also capped ' +
-    'by total size, not just resolution: a full-page frame is ~2.4MB, so roughly 3 of them fill one ' +
+    'by total size, not just resolution: a full-page frame is ~2.4MB, so 3–4 of them fill one ' +
     'response. Past that the remaining nodes come back labelled but not inlined, with a note naming ' +
     'them — re-request those ids in a follow-up call, or use save_screenshots for many nodes at once. ' +
     'Each raster label reports the exported width×height px and the ' +
@@ -67,6 +67,13 @@ const RASTER_MIME: Partial<Record<string, string>> = { PNG: 'image/png', JPG: 'i
  * one, which is a regression, not a safeguard. The margin only has to cover what rides alongside
  * the payloads (labels, the closing note, the JSON-RPC envelope), and that measures under 1 KB;
  * half a megabyte is three orders of magnitude more than it needs.
+ *
+ * This is the batch-level twin of a cap the sandbox already applies per image: `capScaleForVision`
+ * bounds one raster's pixels partly because a single image has its own provider ceiling (10 MB
+ * base64 on the Claude API, 5 MB on Bedrock/Vertex). That cap bounds bytes only indirectly, through
+ * resolution, and it says nothing about how many images ride in one response — which is the gap
+ * this closes. The two ceilings are independent: passing this budget does not make an individual
+ * export acceptable to a provider, and vice versa.
  *
  * Figma's own MCP server sidesteps all of this by taking a single node per call and pointing
  * multi-node work at a separate download tool. Figwright accepts a batch — which is genuinely
@@ -149,8 +156,12 @@ export const screenshotContent = (
   if (deferred.length > 0 || oversized.length > 0) {
     // One instruction per cause, so every named id has a remedy that actually works for it.
     const remedies = [
+      // Two ways out, because the right one depends on why the batch was asked for. Splitting keeps
+      // full resolution per node; a smaller `scale` keeps the whole set in one response, which is
+      // what a side-by-side comparison actually needs. The model knows its own intent — offer both.
       deferred.length > 0
-        ? `Re-request ${deferred.join(', ')} in a follow-up call with fewer ids per call.`
+        ? `Re-request ${deferred.join(', ')} in a follow-up call with fewer ids, or repeat the ` +
+          'whole call with a smaller `scale` to fit every node in one response at lower detail.'
         : '',
       oversized.length > 0
         ? `${oversized.join(', ')} exceeded the whole budget alone, so splitting the call will ` +
@@ -159,11 +170,15 @@ export const screenshotContent = (
         : '',
     ].filter(part => part !== '');
     const missed = deferred.length + oversized.length;
+    // Count against what was actually exported, not what was asked for: a node that produced
+    // nothing is reported on its own line and was never a candidate for inlining, so folding it
+    // into this denominator would overstate how much the budget withheld.
+    const exported = result.images.filter(img => img.base64 !== null).length;
     blocks.push({
       type: 'text',
       text:
-        `⚠ ${missed} of ${result.images.length} export(s) were not inlined. Sending them would ` +
-        'have exceeded what an MCP client can read in one response and closed the connection. ' +
+        `⚠ ${missed} of ${exported} export(s) were not inlined. Sending them would have exceeded ` +
+        'what an MCP client can read in one response and closed the connection. ' +
         remedies.join(' '),
     });
   }

--- a/packages/mcp/src/tools/get-screenshot.ts
+++ b/packages/mcp/src/tools/get-screenshot.ts
@@ -16,7 +16,10 @@ export const getScreenshotTool: ToolSpec = {
     'the most a vision model resolves: past that the model sees the identical pixels, so the extra ' +
     'bytes buy no detail — use save_screenshots when you need a full-res file on disk. Past 20 ' +
     'nodes in one call the whole batch drops to a 2000px long edge, which is what providers require ' +
-    'of many-image requests; ask for fewer nodes when you need the detail. ' +
+    'of many-image requests; ask for fewer nodes when you need the detail. A batch is also capped ' +
+    'by total size, not just resolution: a full-page frame is ~2.4MB, so roughly 3 of them fill one ' +
+    'response. Past that the remaining nodes come back labelled but not inlined, with a note naming ' +
+    'them — re-request those ids in a follow-up call, or use save_screenshots for many nodes at once. ' +
     'Each raster label reports the exported width×height px and the ' +
     'scale, the anchor for mapping raster px back to design px. base64 is null for missing or ' +
     'non-exportable nodes. Nodes that are fully clipped or off-canvas (carousels, masks, off-screen ' +
@@ -44,12 +47,59 @@ export type ScreenshotContent =
 const RASTER_MIME: Partial<Record<string, string>> = { PNG: 'image/png', JPG: 'image/jpeg' };
 
 /**
+ * How many bytes of inlined payload one result may carry.
+ *
+ * An MCP client reads each stdio message into a bounded buffer — 10 MB by default since SDK 1.30.0,
+ * on both the v1 and v2 lines. Exceeding it is not a failed call: the client's transport throws,
+ * closes the connection, and every later call answers "Not connected" until the user reconnects the
+ * server by hand. It cannot resynchronize instead, because stdio framing is newline-delimited and
+ * the discarded remainder of an oversized message has no findable boundary.
+ *
+ * This is the only Figwright tool that can get near it. Text results are held far below by the
+ * client's own output cap (Claude Code: ~25k tokens ≈ 100k chars), but image blocks are not counted
+ * as text, so they are the one payload that reaches the transport unmetered — measured at ~2.4 MB
+ * for a single 1440×3140 frame, so four frames pass Claude Desktop's 1 MB content limit and ten
+ * pass the transport's 10 MB.
+ *
+ * The budget is derived from that limit rather than picked, and deliberately sits just under it
+ * rather than comfortably under it. A budget lower than it needs to be would withhold exports the
+ * transport could have carried perfectly well — turning a working single-node call into a deferred
+ * one, which is a regression, not a safeguard. The margin only has to cover what rides alongside
+ * the payloads (labels, the closing note, the JSON-RPC envelope), and that measures under 1 KB;
+ * half a megabyte is three orders of magnitude more than it needs.
+ *
+ * Figma's own MCP server sidesteps all of this by taking a single node per call and pointing
+ * multi-node work at a separate download tool. Figwright accepts a batch — which is genuinely
+ * useful for comparing screens in one round trip — and a batch is exactly what makes this budget
+ * necessary rather than optional.
+ */
+const CLIENT_READ_BUFFER_BYTES = 10 * 1024 * 1024;
+export const INLINE_IMAGE_BUDGET_BYTES = CLIENT_READ_BUFFER_BYTES - 512 * 1024;
+
+/** Serialized size of a content block as the transport will count it. */
+const blockBytes = (block: ScreenshotContent): number =>
+  Buffer.byteLength(JSON.stringify(block), 'utf8');
+
+/**
  * Turn a get_screenshot result into MCP content blocks so the model can actually _see_ raster
  * exports (PNG/JPG as image blocks) instead of receiving an opaque base64 string. SVG is returned
  * as readable markup text; missing/non-exportable nodes become a short text note.
+ *
+ * Payloads are inlined only while they fit {@linkcode INLINE_IMAGE_BUDGET_BYTES}. Past that, the
+ * remaining nodes keep their labels — so the model still knows what it asked for and can re-request
+ * them — and a closing note names them and says how to get them. Nothing is ever dropped silently.
  */
-export const screenshotContent = (result: GetScreenshotResult): ScreenshotContent[] => {
+export const screenshotContent = (
+  result: GetScreenshotResult,
+  budgetBytes = INLINE_IMAGE_BUDGET_BYTES,
+): ScreenshotContent[] => {
   const blocks: ScreenshotContent[] = [];
+  /** Fit nowhere in the remaining budget, but would fit a call of their own. */
+  const deferred: string[] = [];
+  /** Exceed the whole budget alone — a follow-up call would fail identically. */
+  const oversized: string[] = [];
+  let spent = 0;
+
   for (const img of result.images) {
     if (img.base64 === null) {
       blocks.push({ type: 'text', text: `${img.nodeId}: not exportable` });
@@ -67,14 +117,57 @@ export const screenshotContent = (result: GetScreenshotResult): ScreenshotConten
         ? ` ${img.width}×${img.height}px${img.scale !== undefined ? ` @${img.scale}x` : ''}`
         : '';
     const mimeType = RASTER_MIME[img.format];
-    if (mimeType === undefined) {
-      const markup = Buffer.from(img.base64, 'base64').toString('utf8');
-      blocks.push({ type: 'text', text: `${img.nodeId} (${img.format})${emptyNote}:\n${markup}` });
-    } else {
-      blocks.push({ type: 'text', text: `${img.nodeId} (${img.format}${dims})${emptyNote}` });
-      blocks.push({ type: 'image', data: img.base64, mimeType });
+    // SVG carries its payload in the label block itself; rasters split into label + image. Either
+    // way the label is emitted unconditionally and only the payload is subject to the budget.
+    const payload: ScreenshotContent =
+      mimeType === undefined
+        ? {
+            type: 'text',
+            text: `${img.nodeId} (${img.format})${emptyNote}:\n${Buffer.from(img.base64, 'base64').toString('utf8')}`,
+          }
+        : { type: 'image', data: img.base64, mimeType };
+
+    const size = blockBytes(payload);
+    if (spent + size > budgetBytes) {
+      // Distinguish *why* it did not fit. One that overflows an empty budget is oversized on its
+      // own, so re-requesting it alone would fail identically — telling the model to split the call
+      // there would send it round a loop. One that merely did not fit the remainder is fine alone.
+      (size > budgetBytes ? oversized : deferred).push(img.nodeId);
+      blocks.push({
+        type: 'text',
+        text: `${img.nodeId} (${img.format}${dims})${emptyNote} — not inlined, see note below`,
+      });
+      continue;
     }
+    spent += size;
+    if (mimeType !== undefined) {
+      blocks.push({ type: 'text', text: `${img.nodeId} (${img.format}${dims})${emptyNote}` });
+    }
+    blocks.push(payload);
   }
+
+  if (deferred.length > 0 || oversized.length > 0) {
+    // One instruction per cause, so every named id has a remedy that actually works for it.
+    const remedies = [
+      deferred.length > 0
+        ? `Re-request ${deferred.join(', ')} in a follow-up call with fewer ids per call.`
+        : '',
+      oversized.length > 0
+        ? `${oversized.join(', ')} exceeded the whole budget alone, so splitting the call will ` +
+          'not help — re-request with a smaller `scale`, or use `save_screenshots` to write the ' +
+          'full-resolution file to disk and read it from there.'
+        : '',
+    ].filter(part => part !== '');
+    const missed = deferred.length + oversized.length;
+    blocks.push({
+      type: 'text',
+      text:
+        `⚠ ${missed} of ${result.images.length} export(s) were not inlined. Sending them would ` +
+        'have exceeded what an MCP client can read in one response and closed the connection. ' +
+        remedies.join(' '),
+    });
+  }
+
   if (blocks.length === 0) blocks.push({ type: 'text', text: 'No nodes exported.' });
   return blocks;
 };

--- a/packages/mcp/test/tools/get-screenshot.test.ts
+++ b/packages/mcp/test/tools/get-screenshot.test.ts
@@ -1,7 +1,7 @@
 import type { GetScreenshotResult } from '@figwright/shared';
 import { describe, expect, it } from 'vitest';
 
-import { screenshotContent } from '../../src/tools/get-screenshot.js';
+import { INLINE_IMAGE_BUDGET_BYTES, screenshotContent } from '../../src/tools/get-screenshot.js';
 
 describe('screenshotContent', () => {
   it('emits a label + image block for raster formats with the right mime type', () => {
@@ -63,5 +63,132 @@ describe('screenshotContent', () => {
     expect(screenshotContent({ images: [] })).toEqual([
       { type: 'text', text: 'No nodes exported.' },
     ]);
+  });
+
+  describe('batch size budget', () => {
+    /** A raster whose base64 payload is `kb` kilobytes. */
+    const raster = (n: number, kb: number): GetScreenshotResult['images'][number] => ({
+      nodeId: `1:${n}`,
+      format: 'PNG',
+      base64: 'A'.repeat(kb * 1024),
+      width: 100,
+      height: 200,
+      scale: 1,
+    });
+    const imagesIn = (blocks: ReturnType<typeof screenshotContent>): string[] =>
+      blocks.flatMap(b => (b.type === 'image' ? [b.data] : []));
+    const noteIn = (blocks: ReturnType<typeof screenshotContent>): string =>
+      blocks.findLast(b => b.type === 'text')?.text ?? '';
+
+    it('inlines every export when the batch fits, with no note', () => {
+      const blocks = screenshotContent({ images: [raster(1, 1), raster(2, 1)] });
+      expect(imagesIn(blocks)).toHaveLength(2);
+      expect(noteIn(blocks)).not.toContain('not inlined');
+    });
+
+    it('stops inlining at the budget but still labels every node', () => {
+      // 10 KB each against a budget that fits two payloads.
+      const blocks = screenshotContent(
+        { images: [raster(1, 10), raster(2, 10), raster(3, 10)] },
+        25 * 1024,
+      );
+      expect(imagesIn(blocks)).toHaveLength(2);
+      // Every requested node is still named — that is what lets the model re-request the rest.
+      for (const id of ['1:1', '1:2', '1:3']) {
+        expect(blocks.some(b => b.type === 'text' && b.text.startsWith(`${id} (PNG`))).toBe(true);
+      }
+      // The deferred one says so on its own label, not only in the note.
+      expect(
+        blocks.some(
+          b => b.type === 'text' && b.text.includes('1:3') && b.text.includes('not inlined'),
+        ),
+      ).toBe(true);
+    });
+
+    it('names the deferred ids and tells the model to split the call', () => {
+      const blocks = screenshotContent({ images: [raster(1, 10), raster(2, 10)] }, 15 * 1024);
+      const note = noteIn(blocks);
+      expect(note).toContain('1 of 2');
+      expect(note).toContain('1:2');
+      expect(note).toContain('fewer ids per call');
+      expect(note).not.toContain('smaller `scale`');
+    });
+
+    it('gives different advice when one export is oversized on its own', () => {
+      // Splitting the call cannot help here, so telling the model to split would send it in a loop.
+      const blocks = screenshotContent({ images: [raster(1, 100)] }, 10 * 1024);
+      expect(imagesIn(blocks)).toHaveLength(0);
+      const note = noteIn(blocks);
+      expect(note).toContain('splitting the call will not help');
+      expect(note).toContain('smaller `scale`');
+      expect(note).toContain('save_screenshots');
+      expect(note).not.toContain('fewer ids per call');
+    });
+
+    it('gives each cause its own remedy when a batch mixes both', () => {
+      // One export oversized on its own plus one that merely ran out of room. Telling the model to
+      // split the call would loop forever on the first; telling it to scale down is wrong for the
+      // second. Both ids must appear against advice that actually works for them.
+      const blocks = screenshotContent(
+        { images: [raster(1, 8), raster(2, 30), raster(3, 15)] },
+        20 * 1024,
+      );
+      const note = noteIn(blocks);
+      expect(note).toContain('2 of 3');
+      // 1:2 is oversized alone → scale/save advice, named against it.
+      expect(note).toMatch(/1:2[^.]*exceeded the whole budget alone/);
+      expect(note).toContain('smaller `scale`');
+      // 1:3 merely did not fit → split advice, named against it.
+      expect(note).toMatch(/Re-request 1:3/);
+      expect(note).toContain('fewer ids per call');
+    });
+
+    it('never lets the inlined payload exceed the budget', () => {
+      const blocks = screenshotContent(
+        { images: [raster(1, 40), raster(2, 40), raster(3, 40)] },
+        100 * 1024,
+      );
+      const inlined = blocks
+        .filter(b => b.type === 'image')
+        .reduce((n, b) => n + Buffer.byteLength(JSON.stringify(b), 'utf8'), 0);
+      expect(inlined).toBeLessThanOrEqual(100 * 1024);
+    });
+
+    it('applies the budget to SVG markup too, which rides in its own text block', () => {
+      const svg = `<svg>${'x'.repeat(20 * 1024)}</svg>`;
+      const big = {
+        nodeId: '2:1',
+        format: 'SVG' as const,
+        base64: Buffer.from(svg).toString('base64'),
+      };
+      const blocks = screenshotContent({ images: [big] }, 5 * 1024);
+      expect(blocks.some(b => b.type === 'text' && b.text.includes('<svg>'))).toBe(false);
+      expect(noteIn(blocks)).toContain('2:1');
+    });
+
+    it('does not spend budget on nodes that produced nothing', () => {
+      const blocks = screenshotContent(
+        { images: [{ nodeId: '9:9', format: 'PNG', base64: null }, raster(1, 10)] },
+        15 * 1024,
+      );
+      // The unexportable node costs nothing, so the real export still fits.
+      expect(imagesIn(blocks)).toHaveLength(1);
+      expect(noteIn(blocks)).not.toContain('not inlined');
+    });
+
+    it('sets a default budget that fits the transport limit without wasting it', () => {
+      // Under the 10 MB client read buffer, but close to it: a budget lower than it needs to be
+      // would defer exports the transport could have carried, which is a regression, not a guard.
+      expect(INLINE_IMAGE_BUDGET_BYTES).toBeLessThan(10 * 1024 * 1024);
+      expect(INLINE_IMAGE_BUDGET_BYTES).toBeGreaterThan(9 * 1024 * 1024);
+    });
+
+    it('still inlines a single large export that the transport can carry', () => {
+      // The regression guard for the common case: one node, one big image. Before any budget
+      // existed this was delivered; anything under the transport limit must keep being delivered.
+      const blocks = screenshotContent({ images: [raster(1, 9 * 1024)] });
+      expect(imagesIn(blocks)).toHaveLength(1);
+      expect(noteIn(blocks)).not.toContain('not inlined');
+    });
   });
 });

--- a/packages/mcp/test/tools/get-screenshot.test.ts
+++ b/packages/mcp/test/tools/get-screenshot.test.ts
@@ -105,13 +105,15 @@ describe('screenshotContent', () => {
       ).toBe(true);
     });
 
-    it('names the deferred ids and tells the model to split the call', () => {
+    it('names what was withheld and offers both ways to get it', () => {
       const blocks = screenshotContent({ images: [raster(1, 10), raster(2, 10)] }, 15 * 1024);
       const note = noteIn(blocks);
       expect(note).toContain('1 of 2');
       expect(note).toContain('1:2');
-      expect(note).toContain('fewer ids per call');
-      expect(note).not.toContain('smaller `scale`');
+      // Splitting keeps full resolution per node; a smaller scale keeps the whole set in one
+      // response. Which is right depends on why the batch was asked for, so both are offered.
+      expect(note).toContain('fewer ids');
+      expect(note).toContain('smaller `scale`');
     });
 
     it('gives different advice when one export is oversized on its own', () => {
@@ -122,7 +124,9 @@ describe('screenshotContent', () => {
       expect(note).toContain('splitting the call will not help');
       expect(note).toContain('smaller `scale`');
       expect(note).toContain('save_screenshots');
-      expect(note).not.toContain('fewer ids per call');
+      // Suggesting a smaller batch here would send the model round a loop: the export fails
+      // identically on its own, so a call containing only it fails too.
+      expect(note).not.toContain('fewer ids');
     });
 
     it('gives each cause its own remedy when a batch mixes both', () => {
@@ -140,7 +144,7 @@ describe('screenshotContent', () => {
       expect(note).toContain('smaller `scale`');
       // 1:3 merely did not fit → split advice, named against it.
       expect(note).toMatch(/Re-request 1:3/);
-      expect(note).toContain('fewer ids per call');
+      expect(note).toContain('fewer ids');
     });
 
     it('never lets the inlined payload exceed the budget', () => {
@@ -174,6 +178,19 @@ describe('screenshotContent', () => {
       // The unexportable node costs nothing, so the real export still fits.
       expect(imagesIn(blocks)).toHaveLength(1);
       expect(noteIn(blocks)).not.toContain('not inlined');
+    });
+
+    it('counts withheld exports against what was exported, not what was asked for', () => {
+      // A node that produced nothing was never a candidate for inlining and reports itself on its
+      // own line, so counting it here would overstate what the budget withheld.
+      const blocks = screenshotContent(
+        {
+          images: [{ nodeId: '9:9', format: 'PNG', base64: null }, raster(1, 10), raster(2, 10)],
+        },
+        15 * 1024,
+      );
+      expect(noteIn(blocks)).toContain('1 of 2');
+      expect(blocks.some(b => b.type === 'text' && b.text === '9:9: not exportable')).toBe(true);
     });
 
     it('sets a default budget that fits the transport limit without wasting it', () => {


### PR DESCRIPTION
## The failure

An MCP client reads each stdio message into a bounded buffer — **10 MB by default since SDK 1.30.0**, on both the v1 and v2 lines. Going over it is not a failed call:

```
transport onerror → ReadBuffer exceeded maximum size of 10485760 bytes
transport onclose
callTool          → MCP error -32000: Connection closed
ping              → Not connected
```

The connection is gone until the user reconnects the server by hand, and nothing in the result says why. It cannot resynchronize instead: stdio framing is newline-delimited, so the discarded remainder of an oversized message has no findable boundary — the second `onerror` above is that failed resync, parsing the payload's tail as a message.

**`get_screenshot` is the only Figwright tool that can reach it.** Text results are held far below by the client's own output cap (Claude Code: ~25k tokens ≈ 100k chars), but image blocks are not counted as text, so they arrive at the transport unmetered.

Measured against a real design file:

| call | size | before |
| --- | --- | --- |
| 1 frame | 2.39 MB | fine |
| 5 frames | 8.12 MB | fine |
| **10 frames** | **13.51 MB** | **session dead** |

Reproduced end to end with a real client, not inferred.

## The gap

The tool already degraded on **resolution** — past 20 nodes the whole batch drops to a 2000px long edge — but never on **total size**. Its description invited batching and mentioned only the resolution cost. Both halves are fixed here.

This is the batch-level twin of a cap the sandbox already applies per image: `capScaleForVision` bounds one raster's pixels partly because a single image has its own provider ceiling (10 MB base64 on the Claude API, 5 MB on Bedrock/Vertex). That bounds bytes only indirectly, through resolution, and says nothing about how many images share one response. The two ceilings are independent and the code now says so.

## The fix

Payloads are inlined only while they fit. Past that, **nothing is dropped silently**: every node keeps its label — including exported dimensions — so the model still knows what it asked for, and a closing note names what was withheld.

The remedy is split by cause, because the wrong one loops:

- **ran out of room** → re-request those ids in a smaller batch, *or* repeat the whole call at a smaller `scale` to fit every node in one response
- **oversized alone** → deliberately does **not** suggest splitting (a call containing only that export fails identically) — smaller `scale`, or `save_screenshots` to disk

Both remedies are verified to work: `capScaleForVision` caps upward only (`Math.min(scale, maxScale)`), so a sub-1 scale passes through untouched, and `save_screenshots` takes the same `nodeIds` array and returns paths rather than bytes.

## Budget

Derived from the transport limit, not picked:

```ts
const CLIENT_READ_BUFFER_BYTES = 10 * 1024 * 1024;
export const INLINE_IMAGE_BUDGET_BYTES = CLIENT_READ_BUFFER_BYTES - 512 * 1024;
```

An earlier draft used a comfortable 8 MB and that was **wrong**: it would have withheld a single 8.5 MB export the transport could have carried, turning a working call into a deferred one — a regression, not a safeguard. The margin only covers labels, the note and the JSON-RPC envelope, measured together at under 1 KB. A regression test pins that a single large export still goes out whole.

## Equal-or-better, verified

Live sweep against a real Figma file through a real client:

| case | images | labels | size | |
| --- | --- | --- | --- | --- |
| 1 node (dominant case) | 1 | 1 | 2.39 MB | unchanged |
| 3 nodes | 3 | 3 | 5.93 MB | unchanged |
| 5 nodes | 5 | 5 | 8.12 MB | unchanged |
| 10 nodes | 6 | 10 | 9.01 MB | was session death |
| 10 nodes @ `scale: 0.3` | **10** | 10 | 2.56 MB | all of them |
| SVG | — | 1 | 0.04 MB | unchanged |
| nonexistent node | — | — | — | unchanged |

Session alive at the end. All five pre-existing unit tests pass **untouched**, which is what proves the under-budget path is byte-identical.

**Grounding fidelity is structurally unaffected.** `screenshotContent` is called from exactly one place — the `get_screenshot` handler. The asset path (`save_screenshots`, `save_image_fills`) never reaches it, and the skills' verification loop is single-node render-and-diff. Checked live: the verify loop at default and at `scale: 2`, and an icon export at `scale: 2` and as SVG, all return whole with no withholding.

## Not a v2 issue

The limit arrived in **v1 1.30.0** ([PR #2239](https://github.com/modelcontextprotocol/typescript-sdk/pull/2239), merged 2026-06-02); 1.29.0 and earlier buffered unbounded. It is deliberate DoS hardening, not a bug, and it is not configurable from the server side — buffers protect the reader, and the client reads our responses. Proven by experiment: raising the server's own `maxBufferSize` to 100 MB changed nothing; raising the client's fixed it.

For context, Figma's own MCP server sidesteps this structurally — its `get_screenshot` takes a single node and multi-node work is pointed at a separate download tool. Figwright's batch is deliberate and useful for comparing screens in one round trip; this is the limit a batch makes necessary rather than optional.

## Scope

Two files. 16 unit tests (11 new), all six gates green.