### PR TITLE
fix(mcp): exit when the stdio transport dies instead of lingering deaf

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -181,7 +181,43 @@ for (const prompt of PROMPTS) {
   );
 }
 
-const transport = new StdioServerTransport();
+/**
+ * A stdio transport that reports its own death.
+ *
+ * The SDK closes this transport when a read fails fatally — reachably today when an inbound message
+ * exceeds the 10MB read buffer, which `import_image`'s base64 `data` can do. Closing only detaches
+ * the stdin listeners and pauses the stream: it emits neither 'end' nor 'close', so none of
+ * wireShutdown's triggers fire. The process then survives as a leader that can no longer hear its
+ * client while still holding the relay port — a follower behind it can never take over, and nothing
+ * is logged. Reporting the close routes that silent dead end into the ordinary shutdown path, after
+ * which the port frees and a follower is promoted on its next tick.
+ *
+ * Overriding close() rather than onclose is deliberate: whoever owns the connection assigns onclose
+ * for its own bookkeeping, so it is not ours to take.
+ */
+class SelfReportingStdioTransport extends StdioServerTransport {
+  constructor(private readonly onClosed: () => void) {
+    super();
+  }
+
+  override async close(): Promise<void> {
+    await super.close();
+    this.onClosed();
+  }
+}
+
+// Deferred because the trigger only exists once wireShutdown has run, and that needs the transport.
+let triggerShutdown = (): void => {};
+const transport = new SelfReportingStdioTransport(() => {
+  triggerShutdown();
+});
+// Assigned before connect, which chains rather than replaces it. Without this a transport-level
+// failure is discarded entirely — the SDK's own default is to forward to a handler nobody set — so
+// the one message naming the cause (e.g. "ReadBuffer exceeded maximum size of 10485760 bytes")
+// never reaches the stderr the user is reading.
+transport.onerror = (error: Error): void => {
+  log(`[figwright] stdio transport error: ${error.message}`);
+};
 await mcp.connect(transport);
 
 const roleDetail = node.isLeader()
@@ -198,12 +234,14 @@ const shutdown = async (): Promise<void> => {
   await node.stop();
   process.exit(0);
 };
-// Exit on SIGINT/SIGTERM and on stdin EOF. stdin closes when the client that spawned us goes away
-// (including a crash that sends no signal); without this the process would linger holding the relay
-// port as a stale "zombie" leader serving an old build. wireShutdown runs shutdown at most once.
-// hardExit is the backstop for the graceful path itself stalling (e.g. a close waiting on
-// connections that never drain) — exit code 1 marks the forced, non-clean variant.
-wireShutdown({
+// Exit on SIGINT/SIGTERM, on stdin EOF, and on the transport dying under us. stdin closes when the
+// client that spawned us goes away (including a crash that sends no signal); without this the
+// process would linger holding the relay port as a stale "zombie" leader serving an old build.
+// wireShutdown runs shutdown at most once, so the transport trigger is safe to fire during our own
+// shutdown — which closes that same transport. hardExit is the backstop for the graceful path
+// itself stalling (e.g. a close waiting on connections that never drain) — exit code 1 marks the
+// forced, non-clean variant.
+triggerShutdown = wireShutdown({
   proc: process,
   stdin: process.stdin,
   shutdown,

--- a/packages/mcp/src/lifecycle.ts
+++ b/packages/mcp/src/lifecycle.ts
@@ -35,6 +35,11 @@ export interface ShutdownWiring {
  * lingers as a zombie even though shutdown "ran". hardExit is the backstop for that second zombie
  * class — armed when the trigger fires, it force-exits after hardExitDelayMs unless the graceful
  * path exited first.
+ *
+ * Returns the trigger itself, because stdin EOF is not the only way to lose the client. A transport
+ * that dies on its own — the SDK closes it when a read fails fatally — detaches from stdin without
+ * ending it, so none of the triggers above ever fire. The caller wires that in through the returned
+ * function so it shares this one "at most once" guard with the rest.
  */
 export const wireShutdown = ({
   proc,
@@ -42,7 +47,7 @@ export const wireShutdown = ({
   shutdown,
   hardExit,
   hardExitDelayMs,
-}: ShutdownWiring): void => {
+}: ShutdownWiring): (() => void) => {
   let triggered = false;
   const once = (): void => {
     if (triggered) return;
@@ -57,4 +62,5 @@ export const wireShutdown = ({
   proc.on('SIGTERM', once);
   stdin.on('end', once);
   stdin.on('close', once);
+  return once;
 };

--- a/packages/mcp/test/e2e/process-lifecycle.test.ts
+++ b/packages/mcp/test/e2e/process-lifecycle.test.ts
@@ -49,6 +49,8 @@ const spawnServer = (port: number): Server => {
   child.on('exit', code => {
     exit = { code };
   });
+  // Once the server exits, writing to its stdin raises EPIPE. Tests here deliberately provoke that.
+  child.stdin?.on('error', () => {});
   const s: Server = { child, stderr: () => stderr, exited: () => exit };
   servers.push(s);
   return s;
@@ -95,6 +97,60 @@ describe.skipIf(!existsSync(DIST_ENTRY))('process lifecycle (built dist)', () =>
       follower.child.stdin?.end();
       await waitFor(() => follower.exited() !== null, 'promoted follower exit', 8_000);
       expect(follower.exited()?.code).toBe(0);
+    },
+  );
+
+  it(
+    'exits and frees the port when the transport dies under it, and a follower takes over',
+    { timeout: 20_000 },
+    async () => {
+      // The third way to lose the client, and the one nothing covered. A read that fails fatally —
+      // reachable today because import_image carries base64 bytes as an *input* — makes the SDK
+      // close the transport. Closing detaches the stdin listeners and pauses the stream without
+      // ending it, so no 'end'/'close' fires and the process survives as a leader that can no
+      // longer hear anyone, still holding the relay port. Before this was wired, a follower waited
+      // behind it forever and the user had to kill the process by hand.
+      const port = await freePort();
+
+      const leader = spawnServer(port);
+      await waitFor(() => leader.stderr().includes('ready as leader'), 'leader ready', 8_000);
+      const follower = spawnServer(port);
+      await waitFor(() => follower.stderr().includes('ready as follower'), 'follower ready', 8_000);
+
+      const send = (msg: unknown): void => {
+        leader.child.stdin?.write(`${JSON.stringify(msg)}\n`, () => {});
+      };
+      send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'transport-death', version: '0' },
+        },
+      });
+      await new Promise<void>(resolve => setTimeout(resolve, 500));
+
+      // One inbound message past the transport's 10 MB read buffer.
+      send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'import_image',
+          arguments: { data: 'A'.repeat(12 * 1024 * 1024), x: 0, y: 0 },
+        },
+      });
+
+      await waitFor(() => leader.exited() !== null, 'leader exit after transport death', 9_000);
+      expect(leader.exited()?.code).toBe(0);
+      // Silence is what made this unrecoverable in practice: the user saw a server that answered
+      // nothing and no reason why.
+      expect(leader.stderr()).toContain('stdio transport error');
+
+      await waitFor(() => follower.stderr().includes('became LEADER'), 'follower takeover', 9_000);
+      expect(follower.exited()).toBeNull();
     },
   );
 });

--- a/packages/mcp/test/lifecycle.test.ts
+++ b/packages/mcp/test/lifecycle.test.ts
@@ -41,6 +41,52 @@ describe('wireShutdown', () => {
 
     expect(calls).toBe(0);
   });
+
+  it('returns a trigger for losses that stdin never reports', () => {
+    // A transport that dies on its own detaches from stdin without ending it, so none of the wired
+    // events fire. The caller needs a way in — otherwise the process survives deaf, still holding
+    // the relay port, which is the exact zombie this module exists to prevent.
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    let calls = 0;
+    const trigger = wireShutdown({ proc, stdin, shutdown: () => void calls++ });
+
+    trigger();
+    expect(calls).toBe(1);
+  });
+
+  it('shares one guard between the returned trigger and the wired events', () => {
+    // Shutdown closes the transport, which reports its close, which calls the trigger. That must
+    // not start a second shutdown on top of the one already running.
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    let calls = 0;
+    const trigger = wireShutdown({ proc, stdin, shutdown: () => void calls++ });
+
+    stdin.emit('end');
+    trigger();
+    trigger();
+    proc.emit('SIGTERM');
+    expect(calls).toBe(1);
+  });
+
+  it('arms the hardExit backstop when the trigger is what fired', () => {
+    vi.useFakeTimers();
+    const proc = new EventEmitter();
+    const stdin = new EventEmitter();
+    const hardExit = vi.fn<() => void>();
+    const trigger = wireShutdown({
+      proc,
+      stdin,
+      shutdown: () => new Promise<void>(() => {}),
+      hardExit,
+    });
+
+    trigger();
+    vi.advanceTimersByTime(DEFAULT_HARD_EXIT_DELAY_MS);
+    expect(hardExit).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
 });
 
 describe('wireShutdown hardExit backstop', () => {


### PR DESCRIPTION
There is a third way to lose the client, and nothing covered it.

## The failure

The SDK closes the stdio transport when a read fails fatally. That is reachable today: `import_image` carries base64 image bytes as an **input**, so a *request* can exceed the 10 MB read buffer the SDK has defaulted to since 1.30.0.

Closing that transport only detaches the stdin listeners and pauses the stream — it emits neither `'end'` nor `'close'`, so none of `wireShutdown`'s triggers fire. Measured before this change:

```
inbound tools/call with 12 MB of data
  → leader stops answering, does not exit, logs nothing
  → second server starts, stays a follower behind it
  → no takeover after 9s: the port is held by a process that will never reply
```

This is the exact zombie leader the repo already has three mechanisms to prevent — `wireShutdown`, the `hardExit` backstop, newest-build-wins abdication — reached by a path none of them watch. Recovery required finding and killing the process by hand, with nothing on stderr to say why.

## The fix

`wireShutdown` now returns its trigger, so a loss that stdin cannot report shares the same "at most once" guard as SIGINT / SIGTERM / EOF. The transport is a small subclass that reports its own close, routing that dead end into the ordinary shutdown path.

Overriding `close()` rather than `onclose` is deliberate — whoever owns the connection assigns `onclose` for its own bookkeeping, so it is not ours to take. It is also what makes the fix shape-independent: it works the same against `connect(transport)` here and against `serveStdio` on #127.

After:

```
leader exits 0 in ~150 ms → follower promoted ~120 ms later
```

A permanent hang becomes a sub-second handover.

The transport's `onerror` is wired to stderr as well. It was discarded entirely before — the SDK forwards to a handler nobody had set — so the one message naming the cause never reached the log the user actually reads:

```
[figwright] stdio transport error: ReadBuffer exceeded maximum size of 10485760 bytes
```

## What is deliberately not changed

**The threshold.** There is no evidence a legitimate `import_image` reaches 10 MB, and raising a limit that exists as DoS hardening on no evidence is the wrong direction. The new log is precisely what would produce that evidence if it happens.

**Malformed-frame handling.** The SDK closes only on buffer overflow (`_ondata`), not on parse errors (`processReadBuffer`), so a bad frame still does not kill the server — verified: four malformed frames in a row leave it alive, and all four now appear on stderr instead of none.

## Not a v2 issue

v1 and v2's server stdio are byte-identical here, and this branch is off v1 (`main`). Verified on both shapes:

| | exit | follower promoted | cause logged |
| --- | --- | --- | --- |
| v1 (`main`, this PR) | 0, 159 ms | 122 ms | yes |
| v2 (#127 + this) | 0, 158 ms | 121 ms | yes |

The merge into #127 has a conflict in `index.ts` (v1 `connect` vs v2 `serveStdio`); resolved and verified locally, full suite green at 1329 tests.

## Tests

The e2e test fails without the fix — `timed out waiting for leader exit after transport death` — while the pre-existing stdin-EOF test stays green, so it pins this path specifically. Unit tests cover the returned trigger, its shared once-guard, and that it arms the `hardExit` backstop.

Existing shutdown paths re-verified for regression: stdin EOF exits in 9 ms, SIGTERM in 6 ms, neither stalling nor double-shutting-down now that closing the transport re-enters the trigger.

Four files, 1317 tests, all six gates green.