### PR TITLE
fix(variables): read EASING values as curves instead of a fabricated color

### DIFF
--- a/packages/mcp/src/tokens/figma-tokens.ts
+++ b/packages/mcp/src/tokens/figma-tokens.ts
@@ -1,6 +1,7 @@
 import {
   type GetStylesResult,
   type GetVariableDefsResult,
+  type SerializedMotionEasing,
   type SerializedVariable,
   type SerializedVariableCollection,
   type SerializedVariableValue,
@@ -23,7 +24,7 @@ export interface FigmaToken {
   name: string;
   /** Resolved value at the collection's default mode. */
   value: FigmaTokenValue;
-  /** Figma resolvedType: COLOR | FLOAT | STRING | BOOLEAN. */
+  /** Figma resolvedType: COLOR | FLOAT | STRING | BOOLEAN | EASING | TIMING. */
   type: string;
   /**
    * Display name of the variable's collection, e.g. "font" / "color" / "size". Lets the join
@@ -52,6 +53,26 @@ const isRgba = (
   val: SerializedVariableValue,
 ): val is { r: number; g: number; b: number; a: number } =>
   typeof val === 'object' && val !== null && 'r' in val && 'g' in val && 'b' in val;
+
+/**
+ * An EASING variable's curve flattened to a scalar, since a token value is one. A custom bezier
+ * becomes the CSS `cubic-bezier(...)` literal — lossless and what a code-side easing token actually
+ * looks like — and a custom spring keeps its bounce rather than dropping it. Every other curve is a
+ * named Figma preset, so the name is the whole value.
+ *
+ * Preset names stay as Figma spells them instead of being mapped onto CSS keywords: only a few have
+ * a real CSS counterpart (BOUNCY, GENTLE, HOLD and the BACK curves have none), and inventing one
+ * would assert an equivalence Figma never stated. The name join still matches on the variable
+ * name.
+ */
+const formatEasing = (val: SerializedMotionEasing): string => {
+  const bezier = val.easingFunctionCubicBezier;
+  if (bezier !== undefined) {
+    return `cubic-bezier(${bezier.x1}, ${bezier.y1}, ${bezier.x2}, ${bezier.y2})`;
+  }
+  if (val.easingFunctionSpring !== undefined) return `spring(${val.easingFunctionSpring.bounce})`;
+  return val.type;
+};
 
 /** The mode being resolved, carried across alias hops so Light keeps chasing Light. */
 interface ModeContext {
@@ -115,6 +136,8 @@ export const resolveFigmaTokens = (defs: GetVariableDefsResult): FigmaToken[] =>
       return target === undefined ? null : resolve(target, ctx, seen);
     }
     if (isRgba(raw)) return toHex(raw, raw.a);
+    // The only object-shaped value left is an EASING curve — flatten it to a scalar token value.
+    if (typeof raw === 'object' && raw !== null) return formatEasing(raw);
     return raw;
   };
 

--- a/packages/mcp/src/tools/create-variable.ts
+++ b/packages/mcp/src/tools/create-variable.ts
@@ -6,10 +6,16 @@ export const CREATE_VARIABLE_TOOL_NAME = 'create_variable';
 
 export const createVariableTool: ToolSpec = {
   name: CREATE_VARIABLE_TOOL_NAME,
+  // EASING / TIMING are intentionally absent from the enum: Figma's createVariable rejects them
+  // outright, so listing them would only steer an agent into a call that cannot succeed. The
+  // description still names them so an agent that sees such a variable knows why it can't make one.
+  // See the note in the sandbox handler (packages/plugin/src/handlers/create-variable.ts).
   description:
     'Create a variable in a collection with resolvedType BOOLEAN / FLOAT / STRING / COLOR. The ' +
     'variable starts empty — set per-mode values with set_variable_value, then attach it with ' +
-    'bind_variable_to_node or bind_variable_to_paint. Returns { ok, variableId, name }.',
+    'bind_variable_to_node or bind_variable_to_paint. EASING and TIMING variables cannot be created ' +
+    'by plugins at all — Figma rejects it; they can only be made in the Figma UI. Returns ' +
+    '{ ok, variableId, name }.',
   inputSchema: z.object({
     name: z.string().describe('Variable name, e.g. "color/primary"'),
     collectionId: z.string().describe('Variable collection id'),

--- a/packages/mcp/src/tools/get-variable-defs.ts
+++ b/packages/mcp/src/tools/get-variable-defs.ts
@@ -9,7 +9,8 @@ export const getVariableDefsTool: ToolSpec = {
   description:
     "Return the document's local variables as { collections, variables }. Each collection lists its modes " +
     'and defaultModeId; each variable lists its resolvedType and valuesByMode (primitives, RGBA colors, ' +
-    'or { type: "VARIABLE_ALIAS", id } references to other variables).',
+    '{ type: "VARIABLE_ALIAS", id } references to other variables, or — for an EASING variable — an ' +
+    'easing curve { type, easingFunctionCubicBezier?, easingFunctionSpring? }).',
   inputSchema: z.object({}),
   kind: 'read',
 };

--- a/packages/mcp/src/tools/set-variable-value.ts
+++ b/packages/mcp/src/tools/set-variable-value.ts
@@ -17,16 +17,31 @@ const variableValue = z
     z.string(),
     z.looseObject({ r: z.number(), g: z.number(), b: z.number(), a: z.number().optional() }),
     z.looseObject({ type: z.literal('VARIABLE_ALIAS'), id: z.string() }),
+    // An EASING variable's curve. Figma refuses to edit EASING variables at all today, so this
+    // member exists to let such a call through to that explicit error rather than bounce off a
+    // schema mismatch. It must stay after the alias member: both are objects keyed by `type`, and
+    // this one accepts any string, so it would otherwise swallow aliases.
+    z.looseObject({
+      type: z.string(),
+      easingFunctionCubicBezier: z
+        .looseObject({ x1: z.number(), y1: z.number(), x2: z.number(), y2: z.number() })
+        .optional(),
+      easingFunctionSpring: z.looseObject({ bounce: z.number() }).optional(),
+    }),
   ])
-  .describe('boolean | number | string | { r,g,b,a } | { type:"VARIABLE_ALIAS", id }');
+  .describe(
+    'boolean | number | string | { r,g,b,a } | { type:"VARIABLE_ALIAS", id } | { type: easing }',
+  );
 
 export const setVariableValueTool: ToolSpec = {
   name: SET_VARIABLE_VALUE_TOOL_NAME,
   description:
     "Set a variable's value for one mode (modeId comes from the variable's collection). value must " +
     'match the variable resolvedType: a boolean, a number (FLOAT), a string, a color { r, g, b, a } ' +
-    '(0–1), or an alias { type: "VARIABLE_ALIAS", id } pointing at another variable. Create the ' +
-    'variable first with create_variable. Returns { ok, variableId, name }.',
+    '(0–1), or an alias { type: "VARIABLE_ALIAS", id } pointing at another variable. EASING and ' +
+    'TIMING variables are read-only to plugins — Figma rejects editing them, so read them with ' +
+    'get_variable_defs and change them in the Figma UI instead. Create the variable first with ' +
+    'create_variable. Returns { ok, variableId, name }.',
   inputSchema: z.object({
     variableId: z.string().describe('Variable id'),
     modeId: z.string().describe('Mode id (from the collection)'),

--- a/packages/mcp/test/tokens/figma-tokens.test.ts
+++ b/packages/mcp/test/tokens/figma-tokens.test.ts
@@ -39,6 +39,39 @@ describe('resolveFigmaTokens', () => {
     expect(result[0]?.collection).toBe('Tokens'); // collection name carried through for the join
   });
 
+  // An EASING variable's value is an object, but a token value is a scalar — it must be flattened
+  // rather than handed through (which used to be a type error) or fed to the color path.
+  it('flattens EASING variables to a scalar token value', () => {
+    const mkVar = (id: string, value: unknown): GetVariableDefsResult['variables'][number] =>
+      ({
+        id,
+        name: `motion/${id}`,
+        key: `k${id}`,
+        resolvedType: 'EASING',
+        collectionId: 'col1',
+        valuesByMode: { m1: value },
+      }) as GetVariableDefsResult['variables'][number];
+
+    const result = resolveFigmaTokens(
+      defs({
+        variables: [
+          mkVar('preset', { type: 'EASE_IN_AND_OUT' }),
+          mkVar('bez', {
+            type: 'CUSTOM_CUBIC_BEZIER',
+            easingFunctionCubicBezier: { x1: 0.2, y1: 0, x2: 0.8, y2: 1 },
+          }),
+          mkVar('spring', { type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce: 0.4 } }),
+        ],
+      }),
+    );
+
+    expect(result[0]).toMatchObject({ type: 'EASING', value: 'EASE_IN_AND_OUT' });
+    // a custom bezier keeps every control point, in the CSS form a code-side token would use
+    expect(result[1]?.value).toBe('cubic-bezier(0.2, 0, 0.8, 1)');
+    // the spring's bounce survives instead of collapsing to the bare type name
+    expect(result[2]?.value).toBe('spring(0.4)');
+  });
+
   it('keeps FLOAT / STRING / BOOLEAN values as-is', () => {
     const result = resolveFigmaTokens(
       defs({

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -19,7 +19,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "^1.132.0",
+    "@figma/plugin-typings": "^1.133.0",
     "@figwright/shared": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugin/src/handlers/convert.ts
+++ b/packages/plugin/src/handlers/convert.ts
@@ -64,11 +64,15 @@ export const toFigmaLineHeight = (lh: SerializedLineHeight): LineHeight => {
   return { unit: lh.unit as 'PIXELS' | 'PERCENT', value: lh.value };
 };
 
-/** Wire variable value → Figma VariableValue (alias / color / primitive). */
+/** Wire variable value → Figma VariableValue (alias / color / easing / primitive). */
 export const toFigmaVariableValue = (value: SerializedVariableValue): VariableValue => {
   if (typeof value === 'object' && value !== null) {
     if ('r' in value) return { r: value.r, g: value.g, b: value.b, a: value.a };
-    return { type: 'VARIABLE_ALIAS', id: value.id };
+    // Only an alias carries `id`; an EASING value carries its own `type` (EASE_IN / CUSTOM_SPRING /
+    // …) instead. Keying on `id` rather than falling through keeps an easing curve from being turned
+    // into an alias with `id: undefined`, which Figma would reject.
+    if ('id' in value) return { type: 'VARIABLE_ALIAS', id: value.id };
+    return value as unknown as VariableValue;
   }
   return value;
 };

--- a/packages/plugin/src/handlers/create-variable.ts
+++ b/packages/plugin/src/handlers/create-variable.ts
@@ -2,6 +2,15 @@ import type { VariableResult } from '@figwright/shared';
 
 import type { SandboxToolHandler } from '../dispatcher.js';
 
+// A subset of Figma's VariableResolvedDataType, which plugin-typings 1.133 widened with EASING and
+// TIMING. Those two are deliberately left out: Figma's own createVariable refuses them —
+// "EASING and TIMING variable creation is not currently available" — measured 2026-08-08 against an
+// up-to-date editor, so offering them would only be a guaranteed failure.
+//
+// The whole write side is gated, not just creation: setValueForMode likewise answers "EASING
+// variable editing is not supported". Such variables *can* be made in the Figma UI and read back
+// fine (get-variable-defs serializes their curves), so plugins see them as read-only for now.
+// Re-add both here and in the MCP tool's enum once Figma opens writing up.
 const RESOLVED_TYPES = ['BOOLEAN', 'FLOAT', 'STRING', 'COLOR'] as const;
 type ResolvedType = (typeof RESOLVED_TYPES)[number];
 

--- a/packages/plugin/src/handlers/get-variable-defs.ts
+++ b/packages/plugin/src/handlers/get-variable-defs.ts
@@ -1,13 +1,35 @@
-import { type GetVariableDefsResult, type SerializedVariableValue, toHex } from '@figwright/shared';
+import {
+  type GetVariableDefsResult,
+  type SerializedMotionEasing,
+  type SerializedVariableValue,
+  toHex,
+} from '@figwright/shared';
 
 import type { SandboxToolHandler } from '../dispatcher.js';
 import { serializeCodeSyntax } from '../serializer.js';
+
+const serializeMotionEasing = (easing: MotionEasing): SerializedMotionEasing => {
+  const out: SerializedMotionEasing = { type: easing.type };
+  const bezier = easing.easingFunctionCubicBezier;
+  if (bezier !== undefined) {
+    out.easingFunctionCubicBezier = { x1: bezier.x1, y1: bezier.y1, x2: bezier.x2, y2: bezier.y2 };
+  }
+  if (easing.easingFunctionSpring !== undefined) {
+    out.easingFunctionSpring = { bounce: easing.easingFunctionSpring.bounce };
+  }
+  return out;
+};
 
 const serializeVariableValue = (value: VariableValue): SerializedVariableValue => {
   if (typeof value === 'object' && value !== null) {
     if ('type' in value && value.type === 'VARIABLE_ALIAS') {
       return { type: 'VARIABLE_ALIAS', id: value.id };
     }
+    // An EASING variable's value is a MotionEasing: it carries a `type` but no color channels, so it
+    // has to be caught before the color fallback below. That fallback casts whatever is left to RGB,
+    // which for an easing curve yields r/g/b: undefined and a "#NANNANNAN" hex — a fabricated color
+    // rather than a missing field, which no gate would flag downstream.
+    if ('type' in value) return serializeMotionEasing(value);
     const color = value as RGB | RGBA;
     const a = 'a' in color ? color.a : 1;
     // hex mirrors get_design_context's globalVars (#RRGGBB / #RRGGBBAA) so a bound color resolves in

--- a/packages/plugin/src/handlers/set-variable-value.ts
+++ b/packages/plugin/src/handlers/set-variable-value.ts
@@ -23,15 +23,19 @@ const coerceToResolvedType = (raw: unknown, resolvedType: VariableResolvedDataTy
       throw new TypeError(`set_variable_value: "${raw}" is not valid JSON`);
     }
   }
-  if (resolvedType === 'FLOAT') {
+  // TIMING is a duration, so it coerces exactly like FLOAT — a bare string can only mean a number.
+  // Figma currently rejects writing TIMING/EASING at all (see create-variable.ts), so these two
+  // arms only shape the value on its way to that rejection; they are here for when it opens up.
+  if (resolvedType === 'FLOAT' || resolvedType === 'TIMING') {
     const n = Number(raw);
     if (Number.isNaN(n)) throw new TypeError(`set_variable_value: "${raw}" is not a number`);
     return n;
   }
   if (resolvedType === 'BOOLEAN') return raw === 'true';
-  if (resolvedType === 'COLOR') {
-    // A COLOR value must arrive as a JSON object (RGBA or alias); a bare string is invalid.
-    throw new TypeError(`set_variable_value: COLOR value "${raw}" is not valid JSON`);
+  if (resolvedType === 'COLOR' || resolvedType === 'EASING') {
+    // COLOR (RGBA or alias) and EASING (a MotionEasing curve) must both arrive as a JSON object —
+    // the branch above already returned for anything that parsed, so a bare string here is invalid.
+    throw new TypeError(`set_variable_value: ${resolvedType} value "${raw}" is not valid JSON`);
   }
   return raw; // STRING
 };

--- a/packages/plugin/test/handlers/create-variable.test.ts
+++ b/packages/plugin/test/handlers/create-variable.test.ts
@@ -37,6 +37,30 @@ describe('create_variable handler', () => {
     expect(result).toEqual({ ok: true, variableId: 'V:0', name: 'color/primary' });
   });
 
+  // plugin-typings 1.133 widened VariableResolvedDataType with EASING/TIMING, but Figma's own
+  // createVariable still refuses them ("not currently available"), so they stay out of the allowlist
+  // and are rejected here rather than sent on to fail. Delete this test when Figma opens creation up.
+  it('rejects the motion resolvedTypes Figma cannot create yet', async () => {
+    for (const resolvedType of ['EASING', 'TIMING']) {
+      const createVariable = vi.fn<() => unknown>();
+      const f = {
+        variables: {
+          getVariableCollectionByIdAsync: async () => ({ id: 'VC:0' }),
+          createVariable,
+        },
+      } as unknown as typeof figma;
+      // eslint-disable-next-line no-await-in-loop -- two fixed cases, sequential is fine
+      await expect(
+        createCreateVariableHandler(f)({
+          name: 'motion/enter',
+          collectionId: 'VC:0',
+          resolvedType,
+        }),
+      ).rejects.toThrow(/resolvedType/);
+      expect(createVariable).not.toHaveBeenCalled();
+    }
+  });
+
   it('throws on bad resolvedType, missing collection, or bad input', async () => {
     await expect(
       createCreateVariableHandler(withCollection({ id: 'VC:0' }))({

--- a/packages/plugin/test/handlers/get-variable-defs.test.ts
+++ b/packages/plugin/test/handlers/get-variable-defs.test.ts
@@ -145,6 +145,48 @@ describe('get_variable_defs handler', () => {
     expect(result.variables[2]?.codeSyntax).toBeUndefined();
   });
 
+  it('serializes an EASING value as a curve, not as a color', async () => {
+    const handler = createGetVariableDefsHandler(
+      fakeFigma(
+        [],
+        [
+          {
+            id: 'V:5',
+            name: 'motion/enter',
+            key: 'vk5',
+            resolvedType: 'EASING',
+            variableCollectionId: 'VC:1',
+            valuesByMode: {
+              preset: { type: 'EASE_IN_AND_OUT' },
+              bezier: {
+                type: 'CUSTOM_CUBIC_BEZIER',
+                easingFunctionCubicBezier: { x1: 0.2, y1: 0, x2: 0.8, y2: 1 },
+              },
+              spring: { type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce: 0.4 } },
+            },
+          },
+        ],
+      ),
+    );
+    const result = (await handler(undefined)) as GetVariableDefsResult;
+    const values = result.variables[0]?.valuesByMode;
+
+    // The pre-1.133 code had no easing branch: every one of these fell through to the color cast and
+    // came out as { a: 1, hex: '#NANNANNAN' } with undefined channels.
+    expect(values?.preset).toEqual({ type: 'EASE_IN_AND_OUT' });
+    expect(values?.bezier).toEqual({
+      type: 'CUSTOM_CUBIC_BEZIER',
+      easingFunctionCubicBezier: { x1: 0.2, y1: 0, x2: 0.8, y2: 1 },
+    });
+    expect(values?.spring).toEqual({
+      type: 'CUSTOM_SPRING',
+      easingFunctionSpring: { bounce: 0.4 },
+    });
+    // the optional payloads stay absent rather than being emitted as undefined
+    expect(values?.preset).not.toHaveProperty('easingFunctionCubicBezier');
+    expect(values?.preset).not.toHaveProperty('easingFunctionSpring');
+  });
+
   it('passes primitive values through unchanged', async () => {
     const handler = createGetVariableDefsHandler(
       fakeFigma(

--- a/packages/plugin/test/handlers/set-variable-value.test.ts
+++ b/packages/plugin/test/handlers/set-variable-value.test.ts
@@ -88,6 +88,35 @@ describe('set_variable_value handler', () => {
     expect(setValueForMode).toHaveBeenCalledWith('M:0', { type: 'VARIABLE_ALIAS', id: 'V:9' });
   });
 
+  // An EASING curve is an object with a `type` but no `id`. Before 1.133 the converter treated every
+  // non-color object as an alias, which turned this into { type: 'VARIABLE_ALIAS', id: undefined }.
+  // Real Figma rejects writing EASING/TIMING today, so this covers the conversion only — the value
+  // reaching setValueForMode intact is what we control; whether Figma accepts it is not.
+  it('passes an EASING curve through instead of mangling it into an alias', async () => {
+    const setValueForMode = vi.fn<() => void>();
+    const handler = createSetVariableValueHandler(
+      fakeFigma({ id: 'V:0', name: 'motion/enter', resolvedType: 'EASING', setValueForMode }),
+    );
+    await handler({
+      variableId: 'V:0',
+      modeId: 'M:0',
+      value: { type: 'CUSTOM_SPRING', easingFunctionSpring: { bounce: 0.4 } },
+    });
+    expect(setValueForMode).toHaveBeenCalledWith('M:0', {
+      type: 'CUSTOM_SPRING',
+      easingFunctionSpring: { bounce: 0.4 },
+    });
+  });
+
+  it('coerces a stringified TIMING value to a number, like FLOAT', async () => {
+    const setValueForMode = vi.fn<() => void>();
+    const handler = createSetVariableValueHandler(
+      fakeFigma({ id: 'V:0', name: 'motion/duration', resolvedType: 'TIMING', setValueForMode }),
+    );
+    await handler({ variableId: 'V:0', modeId: 'M:0', value: '250' });
+    expect(setValueForMode).toHaveBeenCalledWith('M:0', 250);
+  });
+
   it('rejects a stringified FLOAT that is not a number', async () => {
     const variable = {
       id: 'V:0',

--- a/packages/shared/src/variables.ts
+++ b/packages/shared/src/variables.ts
@@ -18,9 +18,40 @@ export const SerializedVariableColorSchema = SerializedRGBASchema.extend({
   hex: z.string().optional(),
 });
 
+/** A cubic-bezier control pair — Figma's EasingFunctionBezier, present only for CUSTOM_CUBIC_BEZIER. */
+export const SerializedEasingBezierSchema = z.object({
+  x1: z.number(),
+  y1: z.number(),
+  x2: z.number(),
+  y2: z.number(),
+});
+
+/** A normalised spring — Figma's NormalizedSpring (0–1 bounce), present only for CUSTOM_SPRING. */
+export const SerializedEasingSpringSchema = z.object({ bounce: z.number() });
+
 /**
- * A resolved value for one mode: primitive, color (RGB normalised to RGBA + hex), or an alias to
- * another variable.
+ * An EASING variable's value. plugin-typings 1.133 widened VariableValue to admit MotionEasing, so
+ * a variable can now hold an easing curve rather than only primitives/colors/aliases.
+ *
+ * Mirrored field-for-field on purpose: what get_variable_defs emits can be handed straight back to
+ * set_variable_value. `type` stays a plain string rather than an enum of the 14 members Figma
+ * currently ships — this file is a hand-written mirror with no compile-time coupling to the
+ * typings, so a narrow enum here would silently reject any easing type a future release adds.
+ */
+export const SerializedMotionEasingSchema = z.object({
+  type: z.string(),
+  easingFunctionCubicBezier: SerializedEasingBezierSchema.optional(),
+  easingFunctionSpring: SerializedEasingSpringSchema.optional(),
+});
+export type SerializedMotionEasing = z.infer<typeof SerializedMotionEasingSchema>;
+
+/**
+ * A resolved value for one mode: primitive, color (RGB normalised to RGBA + hex), an alias to
+ * another variable, or an easing curve.
+ *
+ * Order matters: the alias member must be tried before the easing member. Both are objects carrying
+ * a `type`, and easing's `type` is a permissive string, so an alias reaching the easing member
+ * first would match it and lose its `id`.
  */
 export const SerializedVariableValueSchema = z.union([
   z.boolean(),
@@ -28,6 +59,7 @@ export const SerializedVariableValueSchema = z.union([
   z.string(),
   SerializedVariableColorSchema,
   SerializedVariableAliasSchema,
+  SerializedMotionEasingSchema,
 ]);
 export type SerializedVariableValue = z.infer<typeof SerializedVariableValueSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@figma/plugin-typings':
-        specifier: ^1.132.0
-        version: 1.132.0
+        specifier: ^1.133.0
+        version: 1.133.0
       '@figwright/shared':
         specifier: workspace:*
         version: link:../shared
@@ -157,8 +157,8 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@figma/plugin-typings@1.132.0':
-    resolution: {integrity: sha512-yzFtPhAc/o1iQ/vjwFKFNBob1giUJC1E539XGvqBCXgChp3SYbivcIm1fXeEqIPIEmUWseBIr2NnX45acKUKXQ==}
+  '@figma/plugin-typings@1.133.0':
+    resolution: {integrity: sha512-MAM1zACY7JB18gO6B0ZaMquCk/xPhbk4Dkug3KGTN7H/M3fO2tZ0h/05b1umDiKA/P1ZEXbLraNyffaVFkFpXw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2303,7 +2303,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@figma/plugin-typings@1.132.0': {}
+  '@figma/plugin-typings@1.133.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
## What

Upgrades `@figma/plugin-typings` 1.132.0 → 1.133.0 and absorbs what that release exposes.

The whole release is one thing: variables gained `EASING` and `TIMING`. `VariableDataType` and `VariableResolvedDataType` widened, and `VariableValue` now admits `MotionEasing`. `index.d.ts` is unchanged.

**No breaking changes.** The sandbox sources were type-checked against both versions in isolation (probe `tsconfig` with `types: []`, real `packages/plugin/src`): 1.132.0 exit 0, 1.133.0 exit 0. A clean baseline is what makes that meaningful.

## The bug this fixes

`packages/shared/src/variables.ts` is a hand-written Zod mirror with no compile-time coupling to the typings, so nothing flagged the missing member. `get_variable_defs` had exactly two object branches — is it a `VARIABLE_ALIAS`, otherwise treat it as a color — and cast whatever was left to `RGB`.

An `EASING` variable therefore serialized as:

```json
{ "a": 1, "hex": "#NANNANNAN" }
```

That is a **fabricated color, not a missing field**. Downstream has no way to tell it apart from a real one, and every gate stays green.

The write direction had the mirror-image defect: `toFigmaVariableValue` treated every non-color object as an alias, turning an easing curve into `{ type: 'VARIABLE_ALIAS', id: undefined }`.

## What changed

- **`shared`** — `SerializedMotionEasingSchema` mirrors `MotionEasing` field-for-field, added to the value union. The alias member must be tried first (both are objects keyed by `type`, and easing's is a permissive string) — noted in the code.
- **`get_variable_defs`** — easing branch ahead of the color fallback.
- **`convert.ts`** — alias detection keys on `id` rather than falling through.
- **`token_map`** — the widened union surfaced a fourth consumer `tsc` caught: `FigmaTokenValue` is a scalar. Easing flattens to `cubic-bezier(0.2, 0, 0.8, 1)` for a custom curve, `spring(0.4)` keeps the bounce, and presets keep Figma's own names — deliberately **not** mapped onto CSS keywords, since `BOUNCY`/`GENTLE`/`HOLD`/the `*_BACK` curves have no counterpart and inventing one would assert an equivalence Figma never stated.

## Verified against real Figma

Not just unit tests:

| Action | Result |
| --- | --- |
| Create in the Figma UI | works |
| `get_variable_defs` | correct — all four bezier control points survive |
| `createVariable` | `EASING and TIMING variable creation is not currently available` |
| `setValueForMode` | `EASING variable editing is not supported` |

So Figma treats these as **read-only for plugins** today (measured 2026-08-08 on an up-to-date editor). That error text is also what proves the plugin actually reloaded — it is Figma's, not our allowlist's.

Consequently `EASING`/`TIMING` stay out of `create_variable`'s enum, and the tool descriptions say plainly that plugins cannot write them. Agent-facing schemas describe only what works today; internal sandbox and shared plumbing stays forward-compatible, so re-enabling is a one-line change in two files plus a test flip when Figma opens it up.

The read path also ran over ~120 real `COLOR`/`FLOAT`/`STRING` variables with no regression — hex output unchanged, including 8-digit alpha forms.

## Tests

5 added. Each new guard was mutation-tested — broken on purpose to confirm the test goes red, then restored:

- remove the easing branch in `get_variable_defs`
- make `convert.ts` treat every non-color object as an alias again
- drop `EASING`/`TIMING` handling from the coercion
- collapse `formatEasing` to the bare type name

All six gates green: `typecheck`, `lint`, `format:check`, `knip`, `build`, `test` (1345 passing).
