### PR TITLE
chore(release): pick the version from a menu instead of typing it by hand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,11 +80,16 @@ Figwright's moat is **grounding fidelity and generality** — how accurately and
 
 ## Releasing
 
-Versioning and changelog are driven by Conventional Commits via **changelogen**:
+Versioning and changelog are driven by Conventional Commits via **changelogen**, behind `scripts/release.mjs`:
 
 ```bash
-pnpm release            # bump @figwright/mcp, write the root CHANGELOG.md, commit + tag vX.Y.Z
-git push --follow-tags  # the tag triggers .github/workflows/release.yml
+pnpm release            # pick the version from a menu, then bump @figwright/mcp,
+                        # write the root CHANGELOG.md, commit + tag vX.Y.Z, and
+                        # offer to push (the push triggers release.yml)
 ```
+
+The menu exists because **changelogen demotes every bump while the version is `0.x`** — its `bumpVersion()` turns major into minor _and_ minor into patch, so a release full of features lands on `0.3.1` and even `changelogen --release --minor` does. An explicit `-r <version>` is the only way to override that before 1.0, which is what the script passes. It re-infers the bump from the same commit set changelogen would changelog, keeps the half of the pre-1.0 rule that is actually conventional (breaking → minor, since 0.x promises no stability), and offers that as the default; `1.0.0` stays in the menu but has to be chosen. It refuses to run on a dirty tree — changelogen only stages `CHANGELOG.md` and `packages/mcp/package.json`, so the tag would otherwise point at a commit missing whatever else is in flight — and on a tag that already exists. There is **no flag or argument that picks the version for you** — cutting a release is meant to be a hands-on act, so the script takes no arguments and refuses to run without a tty rather than falling back to a guess.
+
+The **push is a separate prompt that defaults to no**, because it is the irreversible half: the tag landing on GitHub starts `release.yml`, and npm refuses to reuse a version even after an unpublish. Until you answer it the tag is local, so a wrong version is still `git tag -d` + `git reset --hard HEAD~1` away (the script prints exactly that on decline). Answering yes runs `git push --follow-tags` with an inherited tty, so git can still prompt for your SSH passphrase; if the push fails the tag stays local and the retry command is printed.
 
 The release workflow builds and tests, publishes `@figwright/mcp` to npm (OIDC trusted publishing + provenance), creates the GitHub Release from the changelog, and attaches the Figma plugin as a downloadable zip (manifest + built `dist`) for manual import in Figma dev mode.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "oxlint --deny-warnings .",
     "lint:fix": "oxlint --fix .",
     "postinstall": "node scripts/sync-skills.mjs",
-    "release": "pnpm -C packages/mcp exec changelogen --release --no-github --output ../../CHANGELOG.md",
+    "release": "node scripts/release.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,253 @@
+// Pick the next version, then hand it to changelogen.
+//
+// changelogen infers the bump from Conventional Commits, but `bumpVersion()`
+// demotes every bump while the version is still `0.x` — major becomes minor,
+// minor becomes patch. So on 0.3.0 a `feat:` release lands on 0.3.1, and even
+// `changelogen --release --minor` does, which is why the version used to be
+// typed by hand as `-r 0.4.0`. Passing an explicit `-r` is the only way to
+// override that before 1.0, so this script asks for it instead: it re-infers
+// the bump from the same commits, keeps only the pre-1.0 rule worth keeping
+// (breaking → minor, see below), and runs the same command that was in the
+// `release` script before.
+//
+// It writes CHANGELOG.md, commits and tags locally, then offers to push. The
+// push is what triggers .github/workflows/release.yml, so it is a separate
+// prompt that defaults to no — see the comment above it.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+import { clearScreenDown, emitKeypressEvents, moveCursor } from 'node:readline';
+import { createInterface } from 'node:readline/promises';
+import { fileURLToPath } from 'node:url';
+import { styleText } from 'node:util';
+
+import { determineSemverChange, getGitDiff, loadChangelogConfig, parseCommits } from 'changelogen';
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/;
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgDir = join(repoRoot, 'packages', 'mcp');
+
+function fail(message) {
+  console.error(styleText('red', `✖ ${message}`));
+  process.exit(1);
+}
+
+function git(...args) {
+  const { status, stdout } = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+  if (status !== 0) fail(`git ${args.join(' ')} failed`);
+  return stdout.trim();
+}
+
+// Mirrors semver.inc(): on a prerelease, the bump it is already heading for
+// just drops the tag (1.0.0-beta.1 → major → 1.0.0, not 2.0.0).
+function bump(version, type) {
+  const [core, pre] = version.split('-');
+  const [major, minor, patch] = core.split('.').map(Number);
+  if (type === 'major') return pre && minor === 0 && patch === 0 ? core : `${major + 1}.0.0`;
+  if (type === 'minor') return pre && patch === 0 ? core : `${major}.${minor + 1}.0`;
+  return pre ? core : `${major}.${minor}.${patch + 1}`;
+}
+
+async function selectFromMenu(items, initial) {
+  // Releasing is deliberately hands-on: there is no flag that picks the version
+  // for you, so without a terminal there is nothing to fall back to.
+  if (!process.stdin.isTTY) fail('`pnpm release` needs an interactive terminal');
+
+  let index = initial;
+  const draw = redraw => {
+    if (redraw) moveCursor(process.stdout, 0, -items.length);
+    clearScreenDown(process.stdout);
+    for (const [i, item] of items.entries()) {
+      const active = i === index;
+      const line = `${active ? '❯' : ' '} ${item.label}`;
+      process.stdout.write(`${active ? styleText('cyan', line) : line}\n`);
+    }
+  };
+
+  draw(false);
+
+  return new Promise(resolve => {
+    emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+
+    const done = () => {
+      process.stdin.off('keypress', onKey);
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      resolve(items[index]);
+    };
+
+    const onKey = (str, key) => {
+      if (key.name === 'return') return done();
+      if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
+        process.stdin.setRawMode(false);
+        fail('aborted');
+      } else if (key.name === 'up' || key.name === 'k') {
+        index = (index - 1 + items.length) % items.length;
+      } else if (key.name === 'down' || key.name === 'j') {
+        index = (index + 1) % items.length;
+      } else if (/^[1-9]$/.test(str ?? '') && Number(str) <= items.length) {
+        index = Number(str) - 1;
+        draw(true);
+        return done();
+      } else {
+        return;
+      }
+      draw(true);
+    };
+
+    process.stdin.on('keypress', onKey);
+  });
+}
+
+async function ask(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return ((await rl.question(question)) ?? '').trim();
+  } finally {
+    rl.close();
+  }
+}
+
+const current = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')).version;
+if (!SEMVER_RE.test(current))
+  fail(`packages/mcp/package.json holds an unparseable version: ${current}`);
+
+// changelogen only stages CHANGELOG.md and package.json, so a dirty tree would
+// leave the tag pointing at a commit that misses whatever else is in flight.
+const dirty = git('status', '--porcelain');
+if (dirty) fail(`working tree is not clean:\n${dirty}`);
+
+// The same commit set changelogen itself would changelog, so the suggestion
+// below matches the release you are about to cut.
+const config = await loadChangelogConfig(pkgDir, {});
+const commits = [];
+for (const commit of parseCommits(await getGitDiff(config.from, config.to, config.cwd), config)) {
+  const type = commit.type.toLowerCase();
+  if (!config.types[type]) continue;
+  if (type === 'chore' && commit.scope === 'deps' && !commit.isBreaking) continue;
+  commits.push({ ...commit, type });
+}
+const inferred = determineSemverChange(commits, config) ?? 'patch';
+
+// Pre-1.0 convention: a breaking change bumps the minor, because 0.x makes no
+// stability promise to break. changelogen goes one step further and demotes
+// minor → patch as well, which is the part worth overriding — it buries a
+// release full of features in a patch bump. Only 1.0.0 should be deliberate,
+// and it stays one keystroke away in the menu.
+const heldBelowOne = current.startsWith('0.') && inferred === 'major';
+const suggested = heldBelowOne ? 'minor' : inferred;
+
+const counts = new Map();
+for (const commit of commits) counts.set(commit.type, (counts.get(commit.type) ?? 0) + 1);
+const summary = [...counts]
+  .toSorted(([, a], [, b]) => b - a)
+  .map(([type, count]) => `${count} ${type}`)
+  .join(', ');
+
+console.log();
+console.log(`  current version  ${styleText('bold', `v${current}`)}`);
+console.log(
+  `  commits          ${styleText(
+    'dim',
+    `${summary || 'none releasable'} since ${config.from || 'the first commit'}`,
+  )}`,
+);
+console.log(
+  `  suggested        ${suggested}${
+    heldBelowOne ? styleText('dim', ' — breaking change, held below 1.0.0') : ''
+  }`,
+);
+console.log();
+
+const choices = [
+  ...['patch', 'minor', 'major'].map(type => ({
+    type,
+    version: bump(current, type),
+    label: `${type.padEnd(7)} ${bump(current, type).padEnd(10)}${
+      type === suggested ? styleText('dim', '(suggested)') : ''
+    }`,
+  })),
+  { type: 'custom', label: `${'custom'.padEnd(7)} …` },
+];
+
+const choice = await selectFromMenu(
+  choices,
+  choices.findIndex(c => c.type === suggested),
+);
+const version = choice.version ?? (await ask('  version: '));
+
+if (!SEMVER_RE.test(version)) fail(`not a valid version: ${version}`);
+if (version === current) fail(`already on ${current}`);
+const tag = `v${version}`;
+if (git('tag', '--list', tag)) fail(`tag ${tag} already exists`);
+
+// Same command this script replaced; --no-github because the GitHub Release is
+// created by .github/workflows/release.yml once the tag is pushed.
+const args = [
+  '-C',
+  'packages/mcp',
+  'exec',
+  'changelogen',
+  '--release',
+  '-r',
+  version,
+  '--no-github',
+  '--output',
+  '../../CHANGELOG.md',
+];
+
+console.log();
+console.log(`  ${styleText('dim', `pnpm ${args.join(' ')}`)}`);
+console.log(`  commits and tags ${styleText('bold', tag)} locally — nothing is published yet.`);
+console.log();
+
+const confirmed = await ask(`  Continue? ${styleText('dim', '(y/N)')} `);
+if (!/^y(es)?$/i.test(confirmed)) fail('aborted');
+
+const { status } = spawnSync('pnpm', args, { cwd: repoRoot, stdio: 'inherit' });
+if (status !== 0) process.exit(status ?? 1);
+
+// The push is the irreversible half: the tag landing on GitHub starts
+// release.yml, which publishes to npm — and npm forbids reusing a version even
+// after an unpublish. So it gets its own prompt, defaulting to no, and the tag
+// sits locally (deletable, retaggable) until that prompt is answered.
+const branch = git('rev-parse', '--abbrev-ref', 'HEAD');
+
+console.log();
+console.log(
+  `  ${styleText('green', '✔')} ${styleText('bold', tag)} is committed and tagged locally.`,
+);
+console.log(
+  `  Pushing ${branch} + ${tag} starts the release workflow: ${styleText(
+    'bold',
+    'it publishes @figwright/mcp to npm',
+  )}.`,
+);
+console.log();
+
+const pushConfirmed = await ask(`  Push now? ${styleText('dim', '(y/N)')} `);
+if (!/^y(es)?$/i.test(pushConfirmed)) {
+  console.log();
+  console.log(`  Not pushed. When you are ready:  ${styleText('bold', 'git push --follow-tags')}`);
+  console.log(
+    `  ${styleText('dim', `To undo instead:  git tag -d ${tag} && git reset --hard HEAD~1`)}`,
+  );
+  console.log();
+  process.exit(0);
+}
+
+// stdio: 'inherit' so git can prompt for the SSH key passphrase on your tty.
+const push = spawnSync('git', ['push', '--follow-tags'], { cwd: repoRoot, stdio: 'inherit' });
+if (push.status !== 0) {
+  fail(`git push failed — ${tag} is still local. Retry with \`git push --follow-tags\`.`);
+}
+
+console.log();
+console.log(`  ${styleText('green', '✔')} pushed. release.yml is building ${tag}:`);
+console.log(`    ${styleText('bold', 'https://github.com/awdr74100/figwright/actions')}`);
+console.log();


### PR DESCRIPTION
## What

`pnpm release` no longer asks you to type the version. It opens a menu:

```
  current version  v0.3.0
  commits          12 fix, 11 chore, 4 feat, 4 refactor, 3 ci, 2 test, 2 docs since v0.3.0
  suggested        minor — breaking change, held below 1.0.0

  patch   0.3.1
❯ minor   0.4.0     (suggested)
  major   1.0.0
  custom  …
```

Arrow keys / `j` `k`, number keys to jump, Enter to pick. The command it ends up running is the same one that was in the `release` script before.

## Why the version had to be typed at all

Not a UX oversight — changelogen cannot be talked into the right version before 1.0. `bumpVersion()` (`changelogen/dist/shared/changelogen.Ck48ZmxS.mjs`) does this:

```js
if (currentVersion.startsWith("0.")) {
  if (type === "major") type = "minor";
  else if (type === "minor") type = "patch";
}
```

So on `0.3.0` a `feat:` release infers minor, gets demoted, and lands on `0.3.1`. `changelogen --release --minor` lands there too — the demotion runs after the explicit type. **An explicit `-r <version>` is the only override**, which is why the script had `-r 0.4.0` hardcoded and why every release meant editing `package.json` first.

The script still passes `-r`. It just works out the value instead of having it typed.

## How the suggestion is derived

It re-runs changelogen's own inference over the same commit set changelogen would changelog (same `loadChangelogConfig`, same `parseCommits`, same `chore(deps)` filter), then applies **one** rule rather than changelogen's two:

- **breaking → minor** is kept. 0.x promises no stability, so a breaking change bumping the minor is the conventional reading.
- **minor → patch** is dropped. That is the half that buries a release full of features in a patch bump.

Concretely, on this branch's backlog `determineSemverChange` returns `major` (from `feat(mcp)!:` in 0fd9b78). The menu suggests `0.4.0` — matching what was typed by hand last time — and labels why. `1.0.0` is still right there, but it has to be chosen.

## Guards

- **Dirty tree → refuses.** changelogen stages only `CHANGELOG.md` and `packages/mcp/package.json`, so the tag would otherwise point at a commit missing whatever else is in flight.
- **Existing tag → refuses.** Also validates the version string, including the `custom` entry.
- **No arguments, no flags.** There is deliberately nothing that picks the version for you; without a tty it fails rather than guessing.

## The push

Previously manual (`git push --follow-tags`); it is now offered, but as a **separate prompt defaulting to no**:

```
  ✔ v0.4.0 is committed and tagged locally.
  Pushing main + v0.4.0 starts the release workflow: it publishes @figwright/mcp to npm.

  Push now? (y/N)
```

The two halves differ in reversibility, which is why they are two questions. Before the push there is only a local commit and tag; after it, the tag starts `release.yml` and npm will not let that version be reused even after an unpublish. Declining prints both the resume and the undo command:

```
  Not pushed. When you are ready:  git push --follow-tags
  To undo instead:  git tag -d v0.4.0 && git reset --hard HEAD~1
```

Accepting runs `git push --follow-tags` with `stdio: 'inherit'`, so git can still prompt for the SSH key passphrase on your tty. A failed push leaves the tag local and prints the retry.

## Verification

Every run was done in a throwaway clone with `origin` repointed at a local bare repo — nothing here ever reached GitHub or npm, and the working repo stayed at `d6c6d45` / 3 tags / `0.3.0` throughout.

| Path | Result |
| --- | --- |
| Menu: arrows, `j`/`k`, number keys, Enter | correct selection |
| `custom` → `0.9.9`, `0.5.0-beta.1` | accepted |
| Invalid version (`0.4`), tag already exists, dirty tree | refused |
| Arguments passed anyway (`minor`) | ignored, menu still opens |
| No tty | refused with the interactive-terminal message |
| Full run, decline push | commit + tag created, bare remote still at **0 refs** |
| Full run, accept push | bare remote received `main` + `v0.4.0` |
| Push against a broken remote | tag stayed local, retry printed |

The real changelogen invocation ran in the probe too, producing `chore(release): v0.4.0`, the `v0.4.0` tag, `packages/mcp/package.json` at `0.4.0`, and the CHANGELOG entry with its compare link.

`lint`, `format:check` and `knip` are green. `typecheck`, `build` and `test` are untouched by this change — it adds one plain `.mjs` script outside every package's `tsconfig`, and knip confirms no unused dependency was introduced.

## Notes

- **No new dependency.** Node built-ins (`readline`, `util.styleText`) plus the changelogen already in devDependencies. bumpp was evaluated — it has the menu, but its `--execute` does not substitute the chosen version, so it would still need a glue script, and it would split release responsibility across two tools for a ninth transitive dependency.
- `AGENTS.md` records the 0.x demotion, since a future reader will otherwise reasonably assume `--minor` works.
