### PR TITLE
fix(tokens): read CSS custom properties with a scanner instead of a regex

### DIFF
--- a/packages/mcp/src/join/token-map.ts
+++ b/packages/mcp/src/join/token-map.ts
@@ -194,7 +194,14 @@ const bestNameMatch = (
 ): NameMatch | null => {
   const target = splitScale(figmaName);
   let best: NameMatch | null = null;
+  // One name scored once. A custom property declared in several blocks arrives as several tokens
+  // that differ only in value, and nameScore reads nothing but the name and the utility derived
+  // from it — so the repeats always score identically and, not being strictly greater, could never
+  // displace the first. Skipping them is free of any effect on the result.
+  const scored = new Set<string>();
   for (const token of projectTokens) {
+    if (scored.has(token.name)) continue;
+    scored.add(token.name);
     const score = nameScore(target, token, typography);
     if (best === null || score > best.score) best = { token, score };
   }
@@ -424,8 +431,12 @@ const joinTokenScan = (
       (top.score >= 0.5 && (runnerUp === undefined || top.score > runnerUp.score));
 
     if (nameDisambiguates) {
+      // Compared by name, not by object identity: one custom property declared in several blocks
+      // (a light `:root` value and its `.dark` override) arrives as several ProjectTokens that are
+      // the same token. Identity here would read those as two different tokens and withhold the
+      // name evidence whenever the value-match landed on a scope the name-match didn't pick.
       const nameAgrees =
-        nameMatch !== null && nameMatch.token === top.token && nameMatch.score >= 0.5;
+        nameMatch !== null && nameMatch.token.name === top.token.name && nameMatch.score >= 0.5;
       const confidence = nameAgrees ? 1 : 0.9;
       const matchedBy: ('name' | 'value')[] =
         nameAgrees || (scored.length > 1 && top.score >= 0.5) ? ['name', 'value'] : ['value'];

--- a/packages/mcp/src/tokens/css-scan.ts
+++ b/packages/mcp/src/tokens/css-scan.ts
@@ -1,0 +1,221 @@
+// A lexical scanner for CSS custom-property declarations — not a CSS parser.
+//
+// It never interprets selector syntax, at-rule semantics, or value grammar. It tracks exactly three
+// things: whether the cursor sits inside a comment, inside a string, and how deep it is in braces.
+// That is the minimum needed to answer "which block does this `--name: value` belong to", and it is
+// precisely what a regex cannot know.
+//
+// The regex this replaces (`/--([a-zA-Z0-9-]+)\s*:\s*([^;]+);/g` over comment-stripped text) failed
+// in two ways that a differential test against postcss over 401 real stylesheets made concrete:
+//
+//   1. `[^;]+;` requires a terminating semicolon, so the last declaration of a block — which in
+//      minified CSS never has one — swallowed the `}` and everything up to the next `;`. Real
+//      example from @picocss/pico: `--pico-font-size` parsed as
+//      `106.25%}}@media (min-width:768px){:host,:root{--pico-font-size:112.5%}}@media (min-width:1…`
+//      rather than `100%`. 1,619 declarations were corrupted this way.
+//   2. Comment stripping by regex ate real content: `url("http://x/*y*/z.png")` became
+//      `url("http://xz.png")`, because `/*` inside a string is not a comment.
+//
+// Robustness rule for everything below: this reads *other people's* repositories, so malformed CSS
+// must degrade, never throw. Unterminated strings and comments run to end-of-input and the scan
+// returns what it collected. postcss raises `unclosed string` here; failing the whole grounding call
+// because one vendored stylesheet is truncated would be strictly worse than reading the rest.
+
+/** One `--name: value` declaration, with the block chain it was found in. */
+export interface CssDeclaration {
+  /** Custom property name without the leading `--`. */
+  name: string;
+  /** Raw value as written, trimmed, with a trailing `!important` removed. */
+  value: string;
+  /** The innermost enclosing prelude — a selector (`:root`, `.dark`) or at-rule (`@theme`). */
+  scope: string;
+  /** Enclosing preludes outside `scope`, outermost first (e.g. `['@media (min-width: 60rem)']`). */
+  ancestors: string[];
+}
+
+const isWhitespace = (c: string): boolean =>
+  c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f';
+
+// Custom property names are `<ident>`, which allows escapes (`--a\;b`) and any non-ASCII character.
+// Kept permissive on purpose: a name we mis-delimit becomes a wrong token, while a name we accept
+// that CSS would reject simply never matches anything on the Figma side.
+const isNameChar = (c: string): boolean =>
+  !isWhitespace(c) &&
+  c !== ':' &&
+  c !== ';' &&
+  c !== '{' &&
+  c !== '}' &&
+  c !== '(' &&
+  c !== ')' &&
+  c !== '[' &&
+  c !== ']' &&
+  c !== '"' &&
+  c !== "'" &&
+  c !== ',' &&
+  c !== '/' &&
+  c !== '!';
+
+/**
+ * Scan every custom-property declaration in a stylesheet, in document order, each tagged with the
+ * block chain it appears in. Pure, total (never throws), and order-preserving — callers decide
+ * which declaration of a repeated name wins, which is a question this layer deliberately does not
+ * answer.
+ */
+export const scanCustomProperties = (css: string): CssDeclaration[] => {
+  const out: CssDeclaration[] = [];
+  // Preludes of the blocks currently open, outermost first.
+  const stack: string[] = [];
+  // Text seen since the last `{`, `}` or `;` — the prelude of the block we may be about to enter.
+  let prelude = '';
+  let i = 0;
+  const n = css.length;
+
+  /** Consume a quoted string starting at the opening quote; returns it including both quotes. */
+  const readString = (): string => {
+    const quote = css[i];
+    let text = quote as string;
+    i += 1;
+    while (i < n) {
+      const c = css[i] as string;
+      if (c === '\\') {
+        // An escape consumes the next code unit whatever it is, so `\"` cannot close the string.
+        text += c + (css[i + 1] ?? '');
+        i += 2;
+        continue;
+      }
+      text += c;
+      i += 1;
+      if (c === quote) break;
+    }
+    return text;
+  };
+
+  /** Skip a block comment starting at its opening slash; an unterminated one runs to end-of-input. */
+  const skipComment = (): void => {
+    const end = css.indexOf('*/', i + 2);
+    i = end < 0 ? n : end + 2;
+  };
+
+  /**
+   * Read a declaration value, starting just after the `:`. Stops at the `;` that ends it or the `}`
+   * that ends its block — but only when that character is at paren depth 0 and outside any string
+   * or comment, so `url(http://a/b;c.png)` and `content: "}"` survive intact.
+   */
+  const readValue = (): string => {
+    let value = '';
+    let depth = 0;
+    while (i < n) {
+      const c = css[i] as string;
+      if (c === '/' && css[i + 1] === '*') {
+        skipComment();
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        value += readString();
+        continue;
+      }
+      if (c === '\\') {
+        value += c + (css[i + 1] ?? '');
+        i += 2;
+        continue;
+      }
+      if (c === '(') depth += 1;
+      else if (c === ')') depth = Math.max(0, depth - 1);
+      else if (depth === 0 && (c === ';' || c === '}')) break;
+      value += c;
+      i += 1;
+    }
+    // `!important` is a declaration flag rather than part of the value; keeping it would make the
+    // same token compare unequal to its unflagged twin in the value-match join.
+    return value
+      .trim()
+      .replace(/\s*!\s*important\s*$/i, '')
+      .trim();
+  };
+
+  while (i < n) {
+    const c = css[i] as string;
+
+    if (c === '/' && css[i + 1] === '*') {
+      skipComment();
+      continue;
+    }
+
+    // Strings can appear in a prelude too — attribute selectors (`[data-theme="dark;x"]`), `@import`
+    // urls, `@supports` conditions — and must not be scanned for structure.
+    if (c === '"' || c === "'") {
+      prelude += readString();
+      continue;
+    }
+
+    if (c === '\\') {
+      prelude += c + (css[i + 1] ?? '');
+      i += 2;
+      continue;
+    }
+
+    if (c === '{') {
+      stack.push(prelude.trim().replace(/\s+/g, ' '));
+      prelude = '';
+      i += 1;
+      continue;
+    }
+
+    if (c === '}') {
+      stack.pop();
+      prelude = '';
+      i += 1;
+      continue;
+    }
+
+    if (c === ';') {
+      prelude = '';
+      i += 1;
+      continue;
+    }
+
+    // A custom property can only begin a declaration: inside a block, with nothing but whitespace
+    // since the last separator. The prelude guard is what keeps `color: var(--x)` from registering
+    // `--x` as a declaration — there, the prelude holds `color: var(` when `--x` is reached.
+    if (c === '-' && css[i + 1] === '-' && stack.length > 0 && prelude.trim() === '') {
+      const start = i;
+      let j = i + 2;
+      while (j < n) {
+        const d = css[j] as string;
+        if (d === '\\') {
+          j += 2;
+          continue;
+        }
+        if (!isNameChar(d)) break;
+        j += 1;
+      }
+      let k = j;
+      while (k < n && isWhitespace(css[k] as string)) k += 1;
+      // Only a `:` makes this a declaration; a bare `--x` in a prelude is a selector fragment.
+      if (css[k] === ':' && j > i + 2) {
+        const name = css.slice(i + 2, j);
+        i = k + 1;
+        const value = readValue();
+        // An empty value (`--x:;`) declares nothing usable for a design-token join, and the
+        // implementation this replaces skipped it too — kept, so the change is not a silent
+        // widening of what counts as a token.
+        if (value.length > 0) {
+          out.push({
+            name,
+            value,
+            scope: stack[stack.length - 1] ?? '',
+            ancestors: stack.slice(0, -1),
+          });
+        }
+        continue;
+      }
+      // Not a declaration after all — fall through and treat it as prelude text.
+      i = start;
+    }
+
+    prelude += c;
+    i += 1;
+  }
+
+  return out;
+};

--- a/packages/mcp/src/tokens/tokens.ts
+++ b/packages/mcp/src/tokens/tokens.ts
@@ -4,6 +4,11 @@
 // two. Tailwind v3's JS config (theme.colors etc.) needs evaluating/AST-parsing JS and is deferred.
 // For v4, the @theme namespaces (--color-*, --spacing-*, …) map to utility base names, so the join
 // can suggest `primary-500` (a Tailwind utility) and not just the raw custom property.
+//
+// Delimiting the declarations is `css-scan.ts`; everything here is the token-level meaning built on
+// top of them — the Tailwind namespace derivation, and which block's value leads for a given name.
+
+import { scanCustomProperties } from './css-scan.js';
 
 export interface ProjectToken {
   /** Custom property name without the leading `--`, e.g. "color-primary-500". */
@@ -45,29 +50,66 @@ const deriveNamespace = (name: string): { utility?: string; category?: string } 
   return {};
 };
 
-const stripComments = (css: string): string => css.replace(/\/\*[\s\S]*?\*\//g, '');
+// Selectors that declare a token's base value rather than an override of it. `html` is included
+// because plain-CSS projects routinely use it in place of `:root`, and `:host` because component
+// libraries shipping a shadow-DOM build declare both (Pico writes `:host,:root`).
+const BASE_SELECTOR = /(^|[\s,])(:root\b|:host\b|html\b)/i;
 
-const CUSTOM_PROP = /--([a-zA-Z0-9-]+)\s*:\s*([^;]+);/g;
+// At-rules that make everything inside them conditional. A `:root` nested in one is a responsive or
+// theme *override*, not the base declaration — `@media (prefers-color-scheme: dark) { :root { … } }`
+// is how a large share of real stylesheets ship their dark theme. `@layer` is deliberately absent:
+// it scopes cascade priority without making its contents conditional, and `@layer base { :root { … } }`
+// is an ordinary way to write base tokens.
+const CONDITIONAL_AT_RULE = /^@(media|supports|container)\b/i;
 
 /**
- * Parse every `--name: value` custom property out of a CSS string. Later declarations win (a token
- * redefined in @theme after :root takes the @theme value). Pure — no filesystem.
+ * Rank a declaration by how well it represents the token's _primary_ value. Lower wins.
+ *
+ * This replaces the previous "later declarations win" rule, which was not a choice between values
+ * so much as an accident of document order: in any stylesheet with a light and a dark theme, the
+ * theme declared second overwrote the other, so half the project's real token values could never be
+ * matched. Both are kept now (see {@linkcode parseCssCustomProperties}); this only decides which
+ * one leads, and so which one a name-match or an override ref resolves to.
+ */
+const scopeRank = (scope: string, ancestors: readonly string[]): number => {
+  const chain = [...ancestors, scope];
+  // Tailwind v4's @theme is the project's declared token source, so it outranks a plain :root even
+  // when :root comes later — the CSS a build emits from @theme is exactly those :root variables.
+  if (chain.some(s => /^@theme\b/i.test(s))) return 0;
+  if (BASE_SELECTOR.test(scope) && !ancestors.some(a => CONDITIONAL_AT_RULE.test(a))) return 1;
+  return 2;
+};
+
+/**
+ * Parse every `--name: value` custom property out of a CSS string.
+ *
+ * A name declared with different values in different blocks yields one token per distinct value — a
+ * light and a dark theme both contribute, so the value-match join can recognise either. The same
+ * name and value repeated across blocks collapses to one entry: leaving those duplicated would make
+ * `token_map` report a token as ambiguous with itself.
+ *
+ * Order is by {@linkcode scopeRank}, then document order, so the first entry for a name is its base
+ * declaration — what `bestNameMatch` and override refs resolve to. Pure — no filesystem.
  */
 export const parseCssCustomProperties = (css: string): ProjectToken[] => {
-  const body = stripComments(css);
-  const byName = new Map<string, ProjectToken>();
-  for (const match of body.matchAll(CUSTOM_PROP)) {
-    const name = match[1];
-    const value = match[2]?.trim();
-    if (name === undefined || value === undefined || value.length === 0) continue;
-    const { utility, category } = deriveNamespace(name);
-    byName.set(name, {
-      name,
-      value,
-      cssVar: `var(--${name})`,
+  const declarations = scanCustomProperties(css)
+    .map((decl, index) => ({ decl, index, rank: scopeRank(decl.scope, decl.ancestors) }))
+    .toSorted((a, b) => a.rank - b.rank || a.index - b.index);
+
+  const seen = new Set<string>();
+  const out: ProjectToken[] = [];
+  for (const { decl } of declarations) {
+    const key = `${decl.name}\u0000${decl.value}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const { utility, category } = deriveNamespace(decl.name);
+    out.push({
+      name: decl.name,
+      value: decl.value,
+      cssVar: `var(--${decl.name})`,
       ...(utility === undefined ? {} : { utility }),
       ...(category === undefined ? {} : { category }),
     });
   }
-  return [...byName.values()];
+  return out;
 };

--- a/packages/mcp/test/join/token-map.test.ts
+++ b/packages/mcp/test/join/token-map.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { joinTokens, parseTokenMapFile } from '../../src/join/token-map.js';
 import type { FigmaToken } from '../../src/tokens/figma-tokens.js';
-import type { ProjectToken } from '../../src/tokens/tokens.js';
+import { parseCssCustomProperties, type ProjectToken } from '../../src/tokens/tokens.js';
 
 const fig = (
   name: string,
@@ -420,5 +420,46 @@ describe('parseTokenMapFile', () => {
     expect(map.get('顏色次要')).toBe('--color-secondary');
     expect(map.get('顏色危險')).toBe('--color-danger');
     expect(map.has('')).toBe(false); // no all-rows-collide bucket
+  });
+});
+
+describe('joinTokens — themed stylesheets (both scopes reachable)', () => {
+  // End-to-end over the real parser: a stylesheet declaring a light base and a dark override, which
+  // is how most themed projects ship. Until the CSS scanner replaced the regex, parsing collapsed a
+  // repeated name to whichever block came last, so one of these two colors could never value-match
+  // — the light one here, since the dark block is written second.
+  const themed = parseCssCustomProperties(`
+    :root { --color-surface: #FFFFFF; --color-ink: #111111; }
+    .dark { --color-surface: #0B0B0B; --color-ink: #F5F5F5; }
+  `);
+
+  it('value-matches the light value', () => {
+    const [m] = joinTokens([fig('Color/Surface', '#FFFFFF')], themed, { threshold: 0.7 });
+    expect(m?.candidate?.token).toBe('color-surface');
+    expect(m?.candidate?.matchedBy).toEqual(['name', 'value']);
+    expect(m?.status).toBe('high');
+  });
+
+  it('value-matches the dark override of the same token', () => {
+    const [m] = joinTokens([fig('Color/Surface', '#0B0B0B')], themed, { threshold: 0.7 });
+    expect(m?.candidate?.token).toBe('color-surface');
+    expect(m?.candidate?.matchedBy).toEqual(['name', 'value']);
+    expect(m?.status).toBe('high');
+  });
+
+  it('does not report a token as ambiguous with itself', () => {
+    // Both scopes carry the same name, so a parser that kept the duplicate pair would surface the
+    // sibling on ambiguousWith and cap confidence at 0.7.
+    const [m] = joinTokens([fig('Color/Ink', '#111111')], themed, { threshold: 0.7 });
+    expect(m?.candidate?.ambiguousWith).toBeUndefined();
+    expect(m?.candidate?.confidence).toBe(1);
+  });
+
+  it('leads with the base value when only the name matches', () => {
+    // No hex on the Figma side to disambiguate, so the join falls back to the name — which must
+    // resolve to the :root declaration rather than the theme override.
+    const [m] = joinTokens([fig('Color/Surface', 'not-a-hex')], themed, { threshold: 0.7 });
+    expect(m?.candidate?.cssVar).toBe('var(--color-surface)');
+    expect(m?.candidate?.matchedBy).toEqual(['name']);
   });
 });

--- a/packages/mcp/test/tokens/css-scan.test.ts
+++ b/packages/mcp/test/tokens/css-scan.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { scanCustomProperties } from '../../src/tokens/css-scan.js';
+
+/** Compact assertion helper: `name=value` per declaration, in scan order. */
+const pairs = (css: string): string[] => scanCustomProperties(css).map(d => `${d.name}=${d.value}`);
+
+describe('scanCustomProperties', () => {
+  it('reads declarations with their block chain', () => {
+    const decls = scanCustomProperties('@media (min-width: 60rem) { .card { --pad: 8px; } }');
+    expect(decls).toEqual([
+      { name: 'pad', value: '8px', scope: '.card', ancestors: ['@media (min-width: 60rem)'] },
+    ]);
+  });
+
+  it('keeps same-named declarations from different blocks apart', () => {
+    const decls = scanCustomProperties(':root { --bg: #FFF; } .dark { --bg: #000; }');
+    expect(decls.map(d => [d.scope, d.value])).toEqual([
+      [':root', '#FFF'],
+      ['.dark', '#000'],
+    ]);
+  });
+
+  // The regression this scanner exists for: minified CSS has no semicolon before `}`, and the old
+  // `[^;]+;` pattern swallowed the brace and everything after it.
+  it('terminates the last declaration of a block at the closing brace', () => {
+    expect(pairs('.a{--x:100%}@media (min-width:768px){.b{--x:112.5%}}')).toEqual([
+      'x=100%',
+      'x=112.5%',
+    ]);
+  });
+
+  it('does not treat a semicolon inside a string as a terminator', () => {
+    expect(pairs(':root { --sep: "a;b"; --after: #FF0000; }')).toEqual([
+      'sep="a;b"',
+      'after=#FF0000',
+    ]);
+  });
+
+  it('does not treat a semicolon inside url() as a terminator', () => {
+    expect(pairs(':root { --u: url(http://x/y;z.png); --after: 1px; }')).toEqual([
+      'u=url(http://x/y;z.png)',
+      'after=1px',
+    ]);
+  });
+
+  it('does not mistake comment syntax inside a string for a comment', () => {
+    expect(pairs(':root { --url: url("http://x/*y*/z.png"); --after: #0F0; }')).toEqual([
+      'url=url("http://x/*y*/z.png")',
+      'after=#0F0',
+    ]);
+  });
+
+  it('skips real comments, including ones holding declaration-shaped text', () => {
+    expect(pairs(':root { /* c */ --a: 1px; /* --fake: 2px; */ --b: 2px; }')).toEqual([
+      'a=1px',
+      'b=2px',
+    ]);
+  });
+
+  it('ignores var() usages, which are not declarations', () => {
+    expect(pairs('.x { color: var(--nope); --real: 1px; }')).toEqual(['real=1px']);
+  });
+
+  it('ignores a var() usage that is not followed by a semicolon', () => {
+    expect(pairs('.x { color: var(--nope) } .y { --real: 1px; }')).toEqual(['real=1px']);
+  });
+
+  it('handles a closing brace inside a string value', () => {
+    expect(pairs('.a { --brace: "}"; --after: 1px; }')).toEqual(['brace="}"', 'after=1px']);
+  });
+
+  it('handles escaped quotes in a value', () => {
+    expect(pairs(':root { --q: "he said \\"hi\\""; --after: 1px; }')).toEqual([
+      'q="he said \\"hi\\""',
+      'after=1px',
+    ]);
+  });
+
+  it('handles a semicolon inside an attribute selector', () => {
+    const decls = scanCustomProperties('[data-theme="dark;x"] { --a: 1px; }');
+    expect(decls.map(d => [d.scope, d.name])).toEqual([['[data-theme="dark;x"]', 'a']]);
+  });
+
+  it('strips !important without disturbing the value', () => {
+    expect(pairs(':root { --a: 1px !important; --b: 2px!important; }')).toEqual(['a=1px', 'b=2px']);
+  });
+
+  it('skips empty values', () => {
+    expect(pairs(':root { --a:; --b: 1px; }')).toEqual(['b=1px']);
+  });
+
+  it('tracks nested CSS blocks', () => {
+    const decls = scanCustomProperties('.card { --pad: 4px; &:hover { --pad: 8px; } }');
+    expect(decls.map(d => [d.scope, d.ancestors, d.value])).toEqual([
+      ['.card', [], '4px'],
+      ['&:hover', ['.card'], '8px'],
+    ]);
+  });
+
+  it('reads declarations directly inside an at-rule block', () => {
+    const decls = scanCustomProperties('@theme { --color-a: #111; }');
+    expect(decls).toEqual([{ name: 'color-a', value: '#111', scope: '@theme', ancestors: [] }]);
+  });
+
+  it('normalizes whitespace in a multi-line prelude', () => {
+    const decls = scanCustomProperties('.a,\n  .b {\n  --x: 1px;\n}');
+    expect(decls[0]?.scope).toBe('.a, .b');
+  });
+
+  it('ignores a statement at-rule that has no block', () => {
+    expect(pairs('@import url("a.css");\n:root { --a: 1px; }')).toEqual(['a=1px']);
+  });
+
+  it('ignores custom properties outside any block', () => {
+    expect(pairs('--stray: 1px;\n:root { --a: 1px; }')).toEqual(['a=1px']);
+  });
+
+  it('preserves multi-part and functional values verbatim', () => {
+    expect(pairs(':root { --s: 0 1px 2px rgba(0,0,0,.4); --b: oklch(0.6 0.2 270); }')).toEqual([
+      's=0 1px 2px rgba(0,0,0,.4)',
+      'b=oklch(0.6 0.2 270)',
+    ]);
+  });
+
+  it('handles a data URI whose value contains a semicolon', () => {
+    expect(pairs(':root { --img: url(data:image/svg+xml;base64,AAA=); --after: 1px; }')).toEqual([
+      'img=url(data:image/svg+xml;base64,AAA=)',
+      'after=1px',
+    ]);
+  });
+
+  it('is unaffected by a leading BOM', () => {
+    // No BOM-specific branch is needed: U+FEFF is WhiteSpace per the ES spec, so the `trim()` that
+    // normalizes every prelude already drops it. Asserted on the scope because that is the only
+    // place a stray BOM could surface \u2014 the declaration parses either way.
+    const decls = scanCustomProperties('\uFEFF:root { --a: 1px; }');
+    expect(decls[0]?.scope).toBe(':root');
+  });
+
+  // Malformed input degrades instead of throwing: this reads other people's repositories, where a
+  // truncated vendored stylesheet must not fail the whole grounding call.
+  it('does not throw on an unterminated string', () => {
+    // The truncated value is surfaced as far as it was read rather than dropped — consistent with
+    // reading as much as the input allows. A value like this matches nothing on the Figma side, so
+    // the join filters it out without needing this layer to judge completeness.
+    expect(pairs(':root { --a: 1px; --b: "unterminated')).toEqual(['a=1px', 'b="unterminated']);
+  });
+
+  it('does not throw on an unterminated comment', () => {
+    expect(pairs(':root { --a: 1px; } /* unterminated')).toEqual(['a=1px']);
+  });
+
+  it('does not throw on unbalanced braces', () => {
+    expect(pairs('.a { --x: 1px; }}} .b { --y: 2px; }')).toEqual(['x=1px', 'y=2px']);
+  });
+
+  it('returns nothing for an empty stylesheet', () => {
+    expect(scanCustomProperties('')).toEqual([]);
+  });
+});

--- a/packages/mcp/test/tokens/token-index.test.ts
+++ b/packages/mcp/test/tokens/token-index.test.ts
@@ -10,7 +10,7 @@ import {
   buildTokenValueIndex,
   loadTokenValueIndex,
 } from '../../src/tokens/token-index.js';
-import type { ProjectToken } from '../../src/tokens/tokens.js';
+import { parseCssCustomProperties, type ProjectToken } from '../../src/tokens/tokens.js';
 
 const proj = (name: string, value: string, utility?: string): ProjectToken => ({
   name,
@@ -171,5 +171,57 @@ describe('loadTokenValueIndex', () => {
     const dir = await mkdtemp(join(tmpdir(), 'tokenidx-empty-'));
     const r = await loadTokenValueIndex(dir);
     expect(r.index.size).toBe(0);
+  });
+});
+
+describe('annotateProjectTokens — themed stylesheets', () => {
+  // A light/dark stylesheet parsed for real. Every declared value now reaches the index, where the
+  // previous parser kept only whichever block came last — so a light-mode color had no entry at all.
+  const themed = parseCssCustomProperties(`
+    :root { --background: #FFFFFF; --foreground: #0A0A0A; --card: #FFFFFF; }
+    .dark { --background: #0A0A0A; --foreground: #FAFAFA; --card: #171717; }
+  `);
+
+  it('annotates a light-mode value that used to have no index entry at all', () => {
+    const index = buildTokenValueIndex(themed);
+    const r = annotateProjectTokens(
+      { nodes: [], globalVars: { styles: { a: [{ type: 'SOLID', color: '#FFFFFF' }] } } },
+      index,
+      false,
+    );
+    // #FFFFFF is --background and --card in light mode; both are surfaced, unranked, as candidates.
+    expect(r.projectTokens).toEqual({
+      '#FFFFFF': {
+        matchedBy: ['value'],
+        candidates: [
+          { ref: 'var(--background)', name: 'background' },
+          { ref: 'var(--card)', name: 'card' },
+        ],
+      },
+    });
+  });
+
+  it('withholds an annotation the old parser answered confidently but wrongly', () => {
+    // #0A0A0A is --foreground in light mode AND --background in dark mode. Collapsing the repeated
+    // names hid the light declarations, leaving exactly one candidate — so the payload used to be
+    // annotated "#0A0A0A is --background", which inverts the color in light mode. Seeing all of them
+    // makes it correctly ambiguous, and an ambiguous color is left to the raw hex rather than bound
+    // to an arbitrary sibling.
+    const index = buildTokenValueIndex(themed);
+    expect(index.get('#0A0A0A')?.map(t => t.name)).toEqual(['foreground', 'background']);
+    const r = annotateProjectTokens(
+      { nodes: [], globalVars: { styles: { a: [{ type: 'SOLID', color: '#0A0A0A' }] } } },
+      index,
+      false,
+    );
+    expect(r.projectTokens).toEqual({
+      '#0A0A0A': {
+        matchedBy: ['value'],
+        candidates: [
+          { ref: 'var(--background)', name: 'background' },
+          { ref: 'var(--foreground)', name: 'foreground' },
+        ],
+      },
+    });
   });
 });

--- a/packages/mcp/test/tokens/tokens.test.ts
+++ b/packages/mcp/test/tokens/tokens.test.ts
@@ -30,12 +30,38 @@ describe('parseCssCustomProperties', () => {
     expect(t?.category).toBeUndefined();
   });
 
-  it('ignores comments and lets later declarations win', () => {
+  it('ignores commented-out declarations', () => {
     const css = `:root { --color-x: #111; }
-      /* --color-x: #999; should be ignored (commented) */
-      @theme { --color-x: #222; }`;
+      /* --color-x: #999; should be ignored (commented) */`;
     const tokens = parseCssCustomProperties(css);
     expect(tokens.filter(t => t.name === 'color-x')).toHaveLength(1);
-    expect(tokens.find(t => t.name === 'color-x')?.value).toBe('#222');
+    expect(tokens.find(t => t.name === 'color-x')?.value).toBe('#111');
+  });
+
+  it('keeps every distinct value of a repeated name, @theme leading', () => {
+    const css = `:root { --color-x: #111; }
+      @theme { --color-x: #222; }`;
+    const tokens = parseCssCustomProperties(css).filter(t => t.name === 'color-x');
+    // Both are real values the project declares; collapsing them is what used to make a light
+    // theme's colors unmatchable once a dark theme redeclared them.
+    expect(tokens.map(t => t.value)).toEqual(['#222', '#111']);
+  });
+
+  it('leads with the base :root value rather than a theme override', () => {
+    const css = `:root { --bg: #FFFFFF; }
+      .dark { --bg: #000000; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #010101; } }`;
+    const tokens = parseCssCustomProperties(css).filter(t => t.name === 'bg');
+    // The unconditional :root leads; the class override and the media-nested :root follow in
+    // document order — a :root inside @media is an override, not the base declaration.
+    expect(tokens.map(t => t.value)).toEqual(['#FFFFFF', '#000000', '#010101']);
+  });
+
+  it('collapses a name+value repeated across blocks', () => {
+    const css = ':root { --a: 1px; } .x { --a: 1px; } .y { --a: 2px; }';
+    const tokens = parseCssCustomProperties(css).filter(t => t.name === 'a');
+    // Same value in three places is one token — reporting it twice would make token_map call it
+    // ambiguous with itself.
+    expect(tokens.map(t => t.value)).toEqual(['1px', '2px']);
   });
 });


### PR DESCRIPTION
## Description

The project-token parser delimited `--name: value` with
`/--([a-zA-Z0-9-]+)\s*:\s*([^;]+);/g` over comment-stripped text. A regex
cannot know whether it is inside a string or a comment, nor which block it
is in, and both gaps produced **wrong values rather than missing ones** —
which then feed `token_map` and the `projectTokens` annotations on
`get_design_context`.

Measured against the previous implementation over 641 real stylesheets
(the repo's own, plus bootstrap / pico / open-props / radix-colors):

| | count |
|---|---|
| values recovered (never seen before) | 43,245 |
| values corrected (previously corrupted) | 1,619 |
| **token names lost** | **0** |

**Corrupted values.** `[^;]+;` requires a terminating semicolon, which
minified CSS omits before `}`, so the last declaration of a block swallowed
the brace and kept going:

```
--pico-font-size
  before : 106.25%}}@media (min-width:768px){:host,:root{--pico-font-size:112.5%}}@media (min-width:1…
  after  : 100%
```

Comment stripping by regex also ate real content: `url("http://x/*y*/z.png")`
became `url("http://xz.png")`, because `/*` inside a string is not a comment.

**Unreachable values.** Collapsing a repeated name to whichever block came
last is not a choice between values, it is an accident of document order. In
any light/dark stylesheet the theme written second overwrote the other, so
half the project's real token values could never be matched.

## Behavior change

A name declared with different values in different blocks now yields one
token per distinct value, ordered so the base declaration leads: `@theme`,
then an unconditional `:root` / `:host` / `html`, then everything else. The
rank reads the whole ancestor chain — a `:root` nested in
`@media (prefers-color-scheme: dark)` is an override, not a base. `@layer` is
deliberately not treated as conditional.

Name **and** value repeated across blocks still collapses to one entry;
leaving those duplicated would make `token_map` report a token as ambiguous
with itself.

One consequence is worth stating plainly, because it reads like a regression
and is not. In a shadcn-shaped stylesheet, `#0A0A0A` used to be annotated
"this is `--background`" — only because the light declarations were hidden.
It is `--foreground` in light mode, so the old answer inverted the color.
Seeing every declaration makes it correctly ambiguous, and an ambiguous color
is left to the raw hex rather than bound to an arbitrary sibling. That is the
rule `joinTokenScan` already states: *a semantically wrong token is worse
than a raw value*.

## Why not postcss

Measured rather than assumed, on the same 47 KB / 2,000-property sample:

| | install size | parse | value fidelity |
|---|---|---|---|
| hand-written scanner | 0 | 3.6 ms | raw string |
| postcss 8.5.26 | 656 KB | 7.8 ms | raw string |
| lightningcss 1.33 (Rust) | 8.7 MB | 6.6 ms | tokenized |

The scanner agrees with postcss on all 641 stylesheets, so the dependency
buys nothing here. lightningcss is larger and slower for this shape of work
because reading declarations back into JS means a `visitor` callback per
rule, and the napi crossings cost more than the Rust parse saves — the
opposite of `oxc-parser`, which returns one AST in a single crossing. It also
tokenizes values (`oklch(0.6 0.2 270)` → `l: 0.6000000238418579`), while
`ProjectToken.value` is contractually the raw string.

## Verification

- **Differential against postcss** as an oracle over 641 stylesheets /
  127,655 declarations: every `(scope, name, value)` triple agrees.
- **Differential against the pre-change parser** on the same corpus, with
  every difference classified: recovered / corrected / lost, above.
- `bestNameMatch` no longer rescores repeated names — provably result-neutral
  (nameScore reads only the name and the utility derived from it), and takes
  the join over a 300-token themed pool from 60.4 ms to 39.5 ms.
- 26 scanner unit tests covering minified blocks, strings, `url()`, comments,
  escapes, nesting, at-rules, `!important`, and malformed input.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` (1432 tests)
- [x] Tests are added or updated for any behavior change
- [ ] ~~Read-path / serializer changes are verified with a live round-trip~~ — **not applicable**: this is server-side CSS parsing only; no serializer, plugin, or Figma read path is touched.
- [x] Documentation is updated if needed — no user-facing docs describe this layer
