### PR TITLE
fix(plugin): restore the Activity list's bottom gap and make the whole row open

### DIFF
--- a/packages/plugin/ui/App.vue
+++ b/packages/plugin/ui/App.vue
@@ -77,10 +77,20 @@ const embedded = computed(() => context.value !== null && isEmbeddedInPanel(cont
       <PanelTabs v-model="tab" class="mt-2.5" />
     </header>
 
-    <section class="flex-1 overflow-x-hidden overflow-y-auto px-2 py-2">
+    <!-- The bottom gap belongs to the scrolled panel, not to this scroller: Chromium leaves
+         `padding-bottom` out of a scroll container's scrollable overflow, so a `py-2` here reads as
+         three-sided the moment the list is long enough to scroll — the last row ends up flush
+         against the footer.
+
+         The panel is `min-h-full`, not `h-full`, for a second reason that looks identical until it
+         isn't: under border-box `h-full` pins the panel to the viewport height, so its padding is
+         carved out of the content box rather than trailing the content, and overflowing content
+         scrolls straight past it. `min-h-full` still fills a short panel (the empty states center
+         against it) but lets a long one grow, which is what puts the padding after the last row. -->
+    <section class="flex-1 overflow-x-hidden overflow-y-auto px-2 pt-2">
       <!-- `leave: 0` keeps a tab switch instant; only the incoming panel animates. -->
       <Transition name="tab" mode="out-in" :duration="{ enter: 150, leave: 0 }">
-        <div :key="tab" class="h-full">
+        <div :key="tab" class="flex min-h-full flex-col pb-2">
           <TabActivity
             v-if="tab === 'activity'"
             :activity="state.activity"

--- a/packages/plugin/ui/components/TabActivity.vue
+++ b/packages/plugin/ui/components/TabActivity.vue
@@ -16,7 +16,10 @@ defineProps<{
     <TabActivityRow v-for="entry in activity" :key="entry.id" :entry="entry" />
   </TransitionGroup>
 
-  <div v-else class="flex h-full flex-col items-center justify-center gap-1.5 px-6 text-center">
+  <!-- `flex-1`, not `h-full`: the scrolled panel this sits in is `min-h-full` so that a long list
+       can grow past the viewport, and a percentage height resolves against nothing under a parent
+       whose height is only a minimum. Filling the flex line centers this against the same box. -->
+  <div v-else class="flex flex-1 flex-col items-center justify-center gap-1.5 px-6 text-center">
     <Radio class="mb-0.5 size-6 text-faint" />
     <p class="font-medium text-dim">
       {{ connected ? 'Connected and idle' : 'Waiting for the MCP client' }}

--- a/packages/plugin/ui/components/TabActivityRow.vue
+++ b/packages/plugin/ui/components/TabActivityRow.vue
@@ -52,15 +52,25 @@ const durationTone = computed(() =>
 <template>
   <li>
     <!-- The row is a container, not a control: the expand toggle and the reveal button have to be
-         siblings, since a button can't legally nest inside another one. -->
+         siblings, since a button can't legally nest inside another one. That split leaves gaps
+         belonging to no child — the `gap-2` between the two icons, this element's own padding — and
+         the whole row lights up on hover, so those gaps read as clickable and aren't. Toggling here
+         too closes them: clicks that reached a child have already been handled, and Reveal stops
+         its own from bubbling, so this only ever fires for the space between them. The keyboard
+         path is unaffected — this is a div, and the real button inside still carries the semantics
+         and the tab stop. -->
     <div
       class="group flex w-full items-center gap-2 rounded-md px-1.5 py-1 transition-colors duration-150"
       :class="expandable ? 'hover:bg-hover' : ''"
+      @click="expandable && (expanded = !expanded)"
     >
+      <!-- Still a real button when there is something to open: it carries the semantics, the tab
+           stop, and the focus ring, and its activation — pointer or keyboard — bubbles to the
+           handler on the row. -->
       <component
         :is="expandable ? 'button' : 'div'"
         class="flex min-w-0 flex-1 items-center gap-2 text-left"
-        @click="expandable && (expanded = !expanded)"
+        :aria-expanded="expandable ? expanded : undefined"
       >
         <span
           class="grid size-3 shrink-0 place-items-center"
@@ -92,19 +102,27 @@ const durationTone = computed(() =>
       </component>
 
       <!-- Reveal stays out of the way until the row is hovered — it's a secondary action, and the
-           list is long. The slot is always present so the columns keep aligning. -->
+           list is long. The slot is always present so the columns keep aligning, and when this call
+           named no nodes it is left empty — clicks there reach the row's handler like any other
+           gap, so it opens the row instead of being a dead cell the eye can't predict. Reveal is
+           the one thing here that is NOT the row's toggle, so it stops its click from reaching it —
+           otherwise jumping the canvas would expand the row on the way out. -->
       <span class="grid size-3 shrink-0 place-items-center">
         <button
           v-if="revealable"
           class="text-faint opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:text-fg focus-visible:opacity-100"
           :aria-label="`Reveal the nodes ${entry.method} touched`"
           title="Select and zoom to the nodes this call touched"
-          @click="reveal"
+          @click.stop="reveal"
         >
           <Crosshair class="size-3" />
         </button>
       </span>
 
+      <!-- Purely the open/closed indicator, and deliberately not a control of its own: it needs no
+           handler now that the row itself toggles, and no hover treatment either — the Crosshair
+           beside it is the only distinct action here, and its hover is what says so. Give both a
+           hover and the row reads as two buttons sitting side by side. -->
       <span class="grid size-3 shrink-0 place-items-center text-faint">
         <ChevronRight
           v-if="expandable"


### PR DESCRIPTION
Two things the panel showed but did not do, both found by using it.

## The bottom padding vanished once the list scrolled

The tab body carried `py-2`, but it read as three-sided. Chromium leaves `padding-bottom` out of a scroll container's scrollable overflow, so the gap was there right up until the list was long enough to scroll — then the last row sat flush against the footer.

Moving the gap onto the scrolled panel isn't enough on its own. The panel was `h-full`, and under border-box that pins it to the viewport height, so its padding gets carved out of the content box rather than trailing the content — overflowing rows scroll straight past it. (This is the version I shipped first; it looked identical and fixed nothing.)

`min-h-full` is what actually works: a short panel still fills the box, so the empty states stay centered (now via `flex-1`, since a percentage height resolves against nothing under a min-height parent), and a long one grows, which puts the padding after the last row.

It sits on the wrapper the three tabs share, so **Context and Debug get it too**.

## Half the row wasn't clickable

The chevron is the row's strongest "this opens" affordance and had **no handler at all** — clicking it landed on nothing. What made that read as broken rather than decorative is the `Crosshair` beside it, which really is a button.

The same structural split caused more of it. The row is a container so its two buttons can be siblings (a button can't nest), which leaves the `gap-2` between the icons and the row's own padding belonging to no child — while the whole row lights up on hover. Those gaps looked clickable and weren't.

Handling the toggle on the container closes all of it at once:

| | before | after |
|---|---|---|
| row body button | own `@click` | bubbles to the row; keeps semantics, tab stop, `aria-expanded` |
| chevron | inert `<span>` | plain indicator — no handler, no hover of its own |
| gaps / padding | dead | open the row |
| empty Reveal cell | dead | opens the row |
| Reveal | `@click` | `@click.stop` |

`.stop` is load-bearing: without it, jumping the canvas would expand the row on the way out. Reveal keeps its hover because it's the only distinct action here — give the chevron one too and the row reads as two buttons side by side.

## Testing

`pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` — green, 1432 tests across 183 files.

Live in Figma: the bottom gap survives a scrolling list (~18 calls), and the whole row opens on click — the gaps between the icons included.
