### PR TITLE
chore(format): exclude the generated CHANGELOG from oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,6 +6,7 @@
     "**/build/**",
     "**/coverage/**",
     "**/*.tsbuildinfo",
+    "**/CHANGELOG.md",
     "pnpm-lock.yaml",
     ".claude/skills/**"
   ],


### PR DESCRIPTION
`main` is currently red on `pnpm format:check`, from the `chore(release): v0.4.0` commit:

```
CHANGELOG.md (197ms)
Format issues found in above 1 files.
```

## Cause

changelogen pads breaking-change entries with **two** spaces after the warning sign. It is a hard-coded constant in its source, compensating for the emoji's width — not a bug awaiting an upstream fix:

```js
// changelogen/dist/shared/changelogen.D-9f3HTX.mjs
(commit.isBreaking ? "⚠️  " : "") + upperFirst(commit.description)
```

oxfmt collapses that run of spaces when it formats Markdown. So the CHANGELOG failed `format:check` the moment changelogen wrote it, and changelogen had already committed it — `pnpm release` never runs the formatter.

v0.4.0 is simply the first release to carry a breaking change (#127, #134, #138): the whole file has one `Breaking Changes` section, and all six offending lines come from it. Every future release with a `!` commit would hit this again.

## Fix

Exclude the file. It is a build product of changelogen, and formatting a build product forks the repo's copy from what the tool emits — it would also add a fix-up step to the release path just to keep chasing it.

That is the norm for a generated changelog. **vite — also on oxfmt — leads its `ignorePatterns` with `packages/*/CHANGELOG.md`**; vue (`CHANGELOG*.md`), babel and astro all ignore it in `.prettierignore`. The projects that *do* format theirs, react and prettier, hand-write it.

## Verification

- `pnpm format:check` passes — 568 files → 567, CHANGELOG.md excluded
- `CHANGELOG.md` is untouched, still byte-for-byte what changelogen emitted
- `pnpm lint` clean