### PR TITLE
fix(scan): read SFC script blocks with a scanner instead of a regex

### DIFF
--- a/packages/mcp/src/scan/scan.ts
+++ b/packages/mcp/src/scan/scan.ts
@@ -4,6 +4,7 @@ import { basename, dirname, extname, join } from 'node:path';
 import { parseSync } from 'oxc-parser';
 
 import { walkRepoFiles } from '../repo-walk.js';
+import { type ScriptLang, scanSfcScripts } from './sfc-blocks.js';
 
 // Component scanner — finds the project's existing components so component_map can join Figma names
 // against them. The guiding principle: never pattern-match the directory layout (feature-based, atomic,
@@ -764,26 +765,14 @@ const sveltePropNames = (program: any, table: TypeTable): PropsResult => {
 
 const REACT_EXTS = new Set(['.tsx', '.jsx']);
 
-// Pull every <script> / <script setup> body out of an SFC. lang="ts" (or its absence) decides the
-// parser dialect; a .vue/.svelte file with no script block is a genuinely prop-less template.
-const SCRIPT_BLOCK = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
-// Whether the file opens a script at all. "No blocks extracted" only means "prop-less template"
-// when this is false; when it's true the block exists but didn't close (or closed inside a string),
-// so its props are unread rather than absent.
-const SCRIPT_OPEN = /<script\b/i;
-
-interface ScriptBlock {
-  body: string;
-  ts: boolean;
-}
-
-const extractScriptBlocks = (code: string): ScriptBlock[] => {
-  const out: ScriptBlock[] = [];
-  for (const m of code.matchAll(SCRIPT_BLOCK)) {
-    const attrs = m[1] ?? '';
-    out.push({ body: m[2] ?? '', ts: /\blang=["']ts["']/.test(attrs) });
-  }
-  return out;
+// The virtual source name handed to oxc: it is what selects the dialect, so a block's `lang` has to
+// reach it intact. `sfc.tsx` parses both `defineProps<{…}>()` and JSX, which is why lang="tsx" gets
+// its own entry rather than collapsing onto `ts`.
+const VIRTUAL_SOURCE: Record<ScriptLang, string> = {
+  js: 'sfc.js',
+  jsx: 'sfc.jsx',
+  ts: 'sfc.ts',
+  tsx: 'sfc.tsx',
 };
 
 /**
@@ -794,10 +783,14 @@ const extractScriptBlocks = (code: string): ScriptBlock[] => {
  * PropsExtracted distinguishes "[] = genuinely no props" from "[] = unknown" so the join won't
  * invent extension TODOs. It's true when we read the props, or the file is a script-less (so
  * genuinely prop-less) template. It stays false when a script is present but the props couldn't be
- * fully read — a parse error, a prop type imported from another file, or a declaration style we
+ * fully read — a parse error, a prop type imported from another file, a `lang` we have no parser
+ * for, a `src=` block whose source is another file, an unclosed block, or a declaration style we
  * don't recognize (conservative: the join then suppresses matched/unmatched rather than asserting
- * prop gaps we can't actually see). oxc doesn't throw on bad input, so a parse failure surfaces
- * here simply as "no props found".
+ * prop gaps we can't actually see).
+ *
+ * A block that fails to parse still contributes whatever oxc recovered — dropping it would narrow
+ * detection — but it flips propsExtracted to false, because a recovered AST is exactly the case
+ * where claiming a complete list would be the false claim the field exists to prevent.
  */
 export const extractSfcComponent = (
   filePath: string,
@@ -810,22 +803,36 @@ export const extractSfcComponent = (
     exportKind: 'default' as const,
     framework,
   };
-  const scripts = extractScriptBlocks(code);
-  if (scripts.length === 0) {
-    // A template with no script really has no props; a script we failed to delimit has props we
-    // simply didn't read, and saying "none" there is the same false claim as an empty parse.
-    return [{ ...base, propNames: [], propsExtracted: !SCRIPT_OPEN.test(code) }];
+  const { blocks, unterminated } = scanSfcScripts(code, { templateIsBlock: framework === 'vue' });
+  // Set when a props declaration was found but couldn't be fully resolved (an imported type), so an
+  // empty/partial list is never reported as a complete one. A file the scanner could not fully
+  // delimit starts it true: content went unread, and saying "none" there is the same false claim
+  // as an empty parse.
+  let unresolved = unterminated;
+
+  if (blocks.length === 0) {
+    // A template with no script really has no props.
+    return [{ ...base, propNames: [], propsExtracted: !unresolved }];
   }
 
   // Parse every block first: a type is routinely declared in `<script>` and consumed in `<script
   // setup>`, so the type table has to span the whole SFC before any block is read for props.
   const programs: any[] = [];
-  for (const script of scripts) {
-    try {
-      // Name the virtual source so oxc picks the right dialect (TS enables defineProps<...>()).
-      programs.push(parseSync(`sfc.${script.ts ? 'ts' : 'js'}`, script.body).program);
-    } catch {
+  for (const block of blocks) {
+    // `src` puts the real source in another file and `lang: null` is a dialect we have no parser
+    // for. Either way the block's props are unread, and its (empty) body would say "none".
+    if (block.external || block.lang === null) {
+      unresolved = true;
       continue;
+    }
+    try {
+      const parsed = parseSync(VIRTUAL_SOURCE[block.lang], block.body);
+      if (parsed.errors.length > 0) unresolved = true;
+      programs.push(parsed.program);
+    } catch {
+      // oxc recovers rather than throwing, but this reads other people's repositories — a block we
+      // cannot parse at all is unread, never "prop-less".
+      unresolved = true;
     }
   }
   const table: TypeTable = new Map();
@@ -833,9 +840,6 @@ export const extractSfcComponent = (
     for (const [name, decl] of collectTypeDeclarations(program)) table.set(name, decl);
 
   const names = new Set<string>();
-  // Set when a props declaration was found but couldn't be fully resolved (an imported type), so an
-  // empty/partial list is never reported as a complete one.
-  let unresolved = false;
   for (const program of programs) {
     if (framework === 'vue') {
       for (const call of collectCalls(program)) {

--- a/packages/mcp/src/scan/sfc-blocks.ts
+++ b/packages/mcp/src/scan/sfc-blocks.ts
@@ -1,0 +1,349 @@
+// A lexical scanner for the top-level `<script>` blocks of a single-file component — not an HTML
+// parser. Same shape, and the same reason, as tokens/css-scan.ts: it tracks only what is needed to
+// answer "which top-level blocks does this file declare, and what dialect is each written in", and
+// that is precisely what a regex cannot know.
+//
+// The regex this replaces (`/<script\b([^>]*)>([\s\S]*?)<\/script>/gi`) failed in four ways that an
+// end-to-end run of extractSfcComponent made concrete:
+//
+//   1. `[^>]*` stops at the first `>`, including one inside a quoted attribute value. Vue 3.3+
+//      `<script setup lang="ts" generic="T extends Record<string, unknown>">` therefore yielded a
+//      body beginning `">`, which does not parse — so every generic component's props read as
+//      absent. (Exactly the components a design system needs variant axes from.)
+//   2. `lang` was matched as `/\blang=["']ts["']/`, so `lang="tsx"` and the unquoted `lang=ts` both
+//      fell back to the JS dialect, where `defineProps<{…}>()` is a syntax error.
+//   3. It has no notion of comments, so a commented-out `<!-- <script setup>…</script> -->` was
+//      extracted as a live block and its `defineProps` names merged into the result — a phantom
+//      prop reported with propsExtracted: true.
+//   4. It has no notion of nesting, so a `<script>` inside Vue's `<template>` (a JSON-LD block, for
+//      instance) was read as a top-level block.
+//
+// Robustness rule, inherited from css-scan: this reads *other people's* repositories, so malformed
+// input must degrade, never throw. Unterminated tags, strings and comments run to end-of-input and
+// the scan returns what it collected.
+//
+// One thing it deliberately does NOT model: a `</script>` inside a string literal in the script
+// body still ends the block. That is not a bug — `<script>` is raw text, and Vue's and Svelte's own
+// parsers end the block there too, which is why the escape `"<\/script>"` exists.
+
+/** The parser dialect a block is written in, decided by its `lang` attribute. */
+export type ScriptLang = 'ts' | 'tsx' | 'js' | 'jsx';
+
+export interface SfcScriptBlock {
+  /** Raw text between the open tag and its end tag. Empty for a `src=` or self-closed block. */
+  body: string;
+  /**
+   * Null when the block declares a `lang` we have no parser for (`coffee`, `pug`, …). Its props are
+   * unread rather than absent, which is a different claim — see extractSfcComponent.
+   */
+  lang: ScriptLang | null;
+  /** True when `src` points the real source at another file, so `body` is not the source. */
+  external: boolean;
+}
+
+export interface SfcScriptScan {
+  blocks: SfcScriptBlock[];
+  /**
+   * The file could not be fully delimited: a `<script>`, `<style>`, `<template>`, comment or open
+   * tag ran to end-of-input without closing. The scan still returns what it collected — but the
+   * caller must not read "no blocks" as "genuinely no script", because content went unread.
+   */
+  unterminated: boolean;
+}
+
+export interface SfcScanOptions {
+  /**
+   * Whether a top-level `<template>` wraps markup that must not be searched for script blocks. True
+   * for Vue (the SFC's markup lives in that block); false for Svelte, whose markup _is_ the top
+   * level and where `<template>` carries no special meaning.
+   */
+  templateIsBlock: boolean;
+}
+
+// HTML whitespace, which is not the same set as JS whitespace.
+const isSpace = (c: string | undefined): boolean =>
+  c === ' ' || c === '\t' || c === '\n' || c === '\f' || c === '\r';
+
+const isAsciiAlpha = (c: string | undefined): boolean => {
+  if (c === undefined) return false;
+  const n = c.charCodeAt(0);
+  return (n >= 65 && n <= 90) || (n >= 97 && n <= 122);
+};
+
+/**
+ * Case-insensitive ASCII compare of `name` against src at `i`, without lowercasing the source —
+ * String.toLowerCase can change a string's length (İ → i̇), which would desync every index.
+ */
+const matchesNameAt = (src: string, i: number, name: string): boolean => {
+  if (i + name.length > src.length) return false;
+  for (let k = 0; k < name.length; k++) {
+    const c = src.charCodeAt(i + k);
+    if ((c >= 65 && c <= 90 ? c + 32 : c) !== name.charCodeAt(k)) return false;
+  }
+  return true;
+};
+
+/** Index just past the next `>`, or end-of-input when the tag never closes. */
+const skipToGt = (src: string, from: number): number => {
+  const at = src.indexOf('>', from);
+  return at === -1 ? src.length : at + 1;
+};
+
+interface OpenTag {
+  /** Lowercased tag name. */
+  name: string;
+  /** Lowercased attribute names → raw values (empty string for a valueless attribute). */
+  attrs: Map<string, string>;
+  /** Index just past the tag's `>`, or end-of-input when it never closed. */
+  end: number;
+  selfClosing: boolean;
+  /** False when the tag ran to end-of-input — an unterminated attribute value, typically. */
+  closed: boolean;
+}
+
+/**
+ * Parse an open tag beginning at the `<` at `start`. Returns null when that `<` does not begin a
+ * tag (bare `<` in text). Attribute values are read with their quoting, so a `>` inside one — the
+ * `generic="T extends Record<string, unknown>"` case — does not end the tag.
+ */
+const readOpenTag = (src: string, start: number): OpenTag | null => {
+  let i = start + 1;
+  if (!isAsciiAlpha(src[i])) return null;
+  const nameStart = i;
+  while (i < src.length && !isSpace(src[i]) && src[i] !== '>' && src[i] !== '/') i++;
+  const name = src.slice(nameStart, i).toLowerCase();
+
+  const attrs = new Map<string, string>();
+  let selfClosing = false;
+  let closed = false;
+  while (i < src.length) {
+    while (i < src.length && isSpace(src[i])) i++;
+    if (i >= src.length) break;
+    if (src[i] === '>') {
+      i++;
+      closed = true;
+      break;
+    }
+    if (src[i] === '/') {
+      if (src[i + 1] === '>') {
+        selfClosing = true;
+        closed = true;
+        i += 2;
+        break;
+      }
+      i++;
+      continue;
+    }
+    const attrStart = i;
+    while (
+      i < src.length &&
+      !isSpace(src[i]) &&
+      src[i] !== '=' &&
+      src[i] !== '>' &&
+      src[i] !== '/'
+    ) {
+      i++;
+    }
+    // No progress means a character none of the branches above consume; step over it so a malformed
+    // tag can never spin forever.
+    if (i === attrStart) {
+      i++;
+      continue;
+    }
+    const attrName = src.slice(attrStart, i).toLowerCase();
+    while (i < src.length && isSpace(src[i])) i++;
+    let value = '';
+    if (src[i] === '=') {
+      i++;
+      while (i < src.length && isSpace(src[i])) i++;
+      const quote = src[i];
+      if (quote === '"' || quote === "'") {
+        i++;
+        const close = src.indexOf(quote, i);
+        if (close === -1) {
+          value = src.slice(i);
+          i = src.length;
+        } else {
+          value = src.slice(i, close);
+          i = close + 1;
+        }
+      } else {
+        const valueStart = i;
+        while (i < src.length && !isSpace(src[i]) && src[i] !== '>') i++;
+        value = src.slice(valueStart, i);
+      }
+    }
+    attrs.set(attrName, value);
+  }
+  return { name, attrs, end: i, selfClosing, closed };
+};
+
+/**
+ * Index of the `<` beginning the raw-text end tag for `name`, per the HTML rule that the name must
+ * be followed by whitespace, `/` or `>` — so `</scriptx>` does not close a `<script>`, and
+ * `</script >` does. -1 when the block never closes.
+ */
+const findRawTextEnd = (src: string, from: number, name: string): number => {
+  for (let i = from; i < src.length; i++) {
+    if (src[i] !== '<' || src[i + 1] !== '/') continue;
+    if (!matchesNameAt(src, i + 2, name)) continue;
+    const after = src[i + 2 + name.length];
+    if (after !== undefined && (isSpace(after) || after === '>' || after === '/')) return i;
+  }
+  return -1;
+};
+
+/** Index just past `<!-- … -->`. `closed` is false when the comment ran to end-of-input. */
+const skipComment = (src: string, from: number): { end: number; closed: boolean } => {
+  const end = src.indexOf('-->', from + 4);
+  return end === -1 ? { end: src.length, closed: false } : { end: end + 3, closed: true };
+};
+
+/**
+ * Index just past the end tag matching an element already opened at `from`, counting same-name
+ * nesting (`<template #header>` inside Vue's `<template>`). Raw-text children are jumped wholesale,
+ * so text inside a nested `<script>`/`<style>` can't be mistaken for an end tag.
+ */
+const skipElement = (src: string, from: number, name: string): { end: number; closed: boolean } => {
+  let depth = 1;
+  let i = from;
+  while (i < src.length) {
+    if (src[i] !== '<') {
+      i++;
+      continue;
+    }
+    if (src.startsWith('<!--', i)) {
+      const comment = skipComment(src, i);
+      if (!comment.closed) return { end: comment.end, closed: false };
+      i = comment.end;
+      continue;
+    }
+    if (src[i + 1] === '/') {
+      const after = src[i + 2 + name.length];
+      if (
+        matchesNameAt(src, i + 2, name) &&
+        after !== undefined &&
+        (isSpace(after) || after === '>' || after === '/')
+      ) {
+        depth--;
+        i = skipToGt(src, i);
+        if (depth === 0) return { end: i, closed: true };
+        continue;
+      }
+      i = skipToGt(src, i);
+      continue;
+    }
+    const tag = readOpenTag(src, i);
+    if (tag === null) {
+      i++;
+      continue;
+    }
+    if (tag.name === 'script' || tag.name === 'style') {
+      const rawEnd = findRawTextEnd(src, tag.end, tag.name);
+      if (rawEnd === -1) return { end: src.length, closed: false };
+      i = skipToGt(src, rawEnd);
+      continue;
+    }
+    if (!tag.closed) return { end: src.length, closed: false };
+    if (tag.name === name && !tag.selfClosing) depth++;
+    i = tag.end;
+  }
+  return { end: src.length, closed: false };
+};
+
+// Both Vue and Svelte spell TypeScript `ts`; `typescript` and `javascript` are accepted because
+// being forgiving here costs nothing — a lang we map wrong reads as a parse failure, which is the
+// conservative outcome anyway.
+const LANGS: Record<string, ScriptLang> = {
+  '': 'js',
+  js: 'js',
+  javascript: 'js',
+  jsx: 'jsx',
+  ts: 'ts',
+  tsx: 'tsx',
+  typescript: 'ts',
+};
+
+const langOf = (attrs: Map<string, string>): ScriptLang | null => {
+  const raw = attrs.get('lang');
+  if (raw === undefined) return 'js';
+  return LANGS[raw.trim().toLowerCase()] ?? null;
+};
+
+/**
+ * Collect every top-level `<script>` block in a `.vue` / `.svelte` file, in document order. Pure,
+ * total (never throws), and order-preserving.
+ */
+export const scanSfcScripts = (code: string, opts: SfcScanOptions): SfcScriptScan => {
+  const blocks: SfcScriptBlock[] = [];
+  let i = 0;
+  // Every `break` below is a delimitation failure: content past this point went unread, so the
+  // caller must not turn "no blocks" into a positive "this component declares no props".
+  let unterminated = false;
+  while (i < code.length) {
+    if (code[i] !== '<') {
+      i++;
+      continue;
+    }
+    if (code.startsWith('<!--', i)) {
+      const comment = skipComment(code, i);
+      if (!comment.closed) {
+        unterminated = true;
+        break;
+      }
+      i = comment.end;
+      continue;
+    }
+    // A markup declaration / processing instruction / stray end tag carries no block; skip the tag.
+    if (code[i + 1] === '!' || code[i + 1] === '?' || code[i + 1] === '/') {
+      i = skipToGt(code, i);
+      continue;
+    }
+    const tag = readOpenTag(code, i);
+    if (tag === null) {
+      i++;
+      continue;
+    }
+    if (!tag.closed) {
+      unterminated = true;
+      break;
+    }
+    if (tag.name === 'script') {
+      const src = tag.attrs.get('src');
+      const external = src !== undefined && src !== '';
+      if (tag.selfClosing) {
+        blocks.push({ body: '', lang: langOf(tag.attrs), external });
+        i = tag.end;
+        continue;
+      }
+      const rawEnd = findRawTextEnd(code, tag.end, 'script');
+      if (rawEnd === -1) {
+        unterminated = true;
+        break;
+      }
+      blocks.push({ body: code.slice(tag.end, rawEnd), lang: langOf(tag.attrs), external });
+      i = skipToGt(code, rawEnd);
+      continue;
+    }
+    if (tag.name === 'style') {
+      const rawEnd = findRawTextEnd(code, tag.end, 'style');
+      if (rawEnd === -1) {
+        unterminated = true;
+        break;
+      }
+      i = skipToGt(code, rawEnd);
+      continue;
+    }
+    if (opts.templateIsBlock && tag.name === 'template' && !tag.selfClosing) {
+      const skipped = skipElement(code, tag.end, 'template');
+      if (!skipped.closed) {
+        unterminated = true;
+        break;
+      }
+      i = skipped.end;
+      continue;
+    }
+    i = tag.end;
+  }
+  return { blocks, unterminated };
+};

--- a/packages/mcp/test/scan/scan.test.ts
+++ b/packages/mcp/test/scan/scan.test.ts
@@ -393,6 +393,66 @@ describe('extractSfcComponent (Vue / Svelte props)', () => {
     const [s] = extractSfcComponent('C.svelte', svelte, 'svelte');
     expect(s?.propsExtracted).toBe(false);
   });
+
+  // Four ways the block-delimiting regex this replaced lost or invented props. Each was confirmed
+  // end-to-end before it was fixed; the first is the only one observed in shipped library code.
+  it('reads the props of a Vue generic component whose type parameter contains `>`', () => {
+    const code =
+      '<script setup lang="ts" generic="T extends Record<string, unknown>">\nconst p = defineProps<{ items: T[]; label: string }>()\n</script>';
+    const [c] = extractSfcComponent('List.vue', code, 'vue');
+    expect(c?.propNames).toEqual(['items', 'label']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it.each([
+    ['lang="tsx"', '<script setup lang="tsx">const p = defineProps<{ size: string }>()</script>'],
+    ['lang="jsx"', `<script setup lang="jsx">const p = defineProps(['size'])</script>`],
+    [
+      'an unquoted lang=ts',
+      '<script setup lang=ts>const p = defineProps<{ size: string }>()</script>',
+    ],
+  ])('reads the props of a block declaring %s', (_label, code) => {
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propNames).toEqual(['size']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it('does not take props from a commented-out script block', () => {
+    // The worst of the four: a phantom prop reported with propsExtracted: true, so the join reads
+    // a Figma variant axis as already supported and codegen emits an attribute that does nothing.
+    const code =
+      '<!--\n<script setup lang="ts">const old = defineProps<{ ghost: string }>()</script>\n-->\n<script setup lang="ts">const p = defineProps<{ real: string }>()</script>';
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propNames).toEqual(['real']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it("does not take props from a <script> nested in Vue's <template>", () => {
+    const code =
+      '<script setup lang="ts">const p = defineProps<{ title: string }>()</script>\n<template><script type="application/ld+json">{"@context":"https://schema.org"}</script></template>';
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propNames).toEqual(['title']);
+    expect(c?.propsExtracted).toBe(true);
+  });
+
+  it.each([
+    ['a src= block, whose source is another file', '<script src="./C.ts" lang="ts"></script>'],
+    ['a lang we have no parser for', '<script lang="coffee">a = 1</script>'],
+    ['a file that could not be delimited', '<!-- <script setup lang="ts">defineProps<{ a: 1 }>()'],
+  ])('marks props NOT extracted for %s', (_label, code) => {
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propsExtracted).toBe(false);
+  });
+
+  it('keeps a partially recovered block honest without narrowing what it found', () => {
+    // A block oxc could only recover from still contributes its names — dropping them would lose
+    // detection — but the result stops claiming the list is complete.
+    const code =
+      '<script setup lang="ts">const p = defineProps<{ size: string }>()</script>\n<script lang="ts">const = = =</script>';
+    const [c] = extractSfcComponent('C.vue', code, 'vue');
+    expect(c?.propNames).toEqual(['size']);
+    expect(c?.propsExtracted).toBe(false);
+  });
 });
 
 describe('extractAngularComponents (pure)', () => {

--- a/packages/mcp/test/scan/sfc-blocks.test.ts
+++ b/packages/mcp/test/scan/sfc-blocks.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import { scanSfcScripts } from '../../src/scan/sfc-blocks.js';
+
+const vue = (code: string) => scanSfcScripts(code, { templateIsBlock: true });
+const svelte = (code: string) => scanSfcScripts(code, { templateIsBlock: false });
+
+describe('scanSfcScripts — block delimitation', () => {
+  // The regex this replaced used `[^>]*` for the attribute list, so the first `>` inside a quoted
+  // value ended the tag and the body began mid-attribute. Vue 3.3+ generic components are exactly
+  // where that `>` shows up, and they are the components a design system needs variant axes from.
+  it('does not end the open tag at a `>` inside a quoted attribute value', () => {
+    const { blocks } = vue(
+      '<script setup lang="ts" generic="T extends Record<string, unknown>">\nconst a = 1\n</script>',
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.body).toBe('\nconst a = 1\n');
+    expect(blocks[0]?.lang).toBe('ts');
+  });
+
+  it.each([
+    ['single quotes', `<script lang='ts' data-x='a>b'>X</script>`],
+    ['unquoted value', '<script lang=ts data-x=ab>X</script>'],
+    ['spaces around equals', '<script lang = "ts" >X</script>'],
+    ['attributes across newlines', '<script\n  setup\n  lang="ts"\n>X</script>'],
+    ['uppercase tag and attributes', '<SCRIPT SETUP LANG="TS">X</SCRIPT>'],
+  ])('reads the block through %s', (_label, code) => {
+    const { blocks } = vue(code);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.body).toBe('X');
+    expect(blocks[0]?.lang).toBe('ts');
+  });
+
+  it('ignores a script block that is commented out', () => {
+    // A live regex over the raw text extracted this one and merged its defineProps names into the
+    // result — a prop the component does not declare, reported as a complete list.
+    const { blocks } = vue(
+      '<!--\n<script setup lang="ts">const dead = 1</script>\n-->\n<script setup lang="ts">const live = 1</script>',
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.body).toBe('const live = 1');
+  });
+
+  it("ignores a <script> nested in Vue's <template> (a JSON-LD block, say)", () => {
+    const { blocks } = vue(
+      '<script setup lang="ts">const a = 1</script>\n<template><script type="application/ld+json">{"a":1}</script></template>',
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.body).toBe('const a = 1');
+  });
+
+  it('counts nested <template> so a slot template does not end the block early', () => {
+    const { blocks } = vue(
+      '<template><div><template #head><b/></template></div></template>\n<script setup lang="ts">const a = 1</script>',
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.body).toBe('const a = 1');
+  });
+
+  it('is not fooled by end tags appearing inside attribute values or raw text', () => {
+    expect(
+      vue('<template><div title="</template>"><b/></div></template><script>A</script>').blocks[0]
+        ?.body,
+    ).toBe('A');
+    expect(
+      vue('<style>.a::after{content:"</script>"}</style><script>B</script>').blocks[0]?.body,
+    ).toBe('B');
+    expect(vue('<script lang="ts" data-x="</script>">C</script>').blocks[0]?.body).toBe('C');
+  });
+
+  it('applies the raw-text end-tag rule: a delimiter must follow the name', () => {
+    // `</scriptx>` does not close a `<script>`; `</script >` does.
+    expect(vue('<script>a</scriptx>b</script>').blocks[0]?.body).toBe('a</scriptx>b');
+    expect(vue('<script>a</script >').blocks[0]?.body).toBe('a');
+    expect(vue('<script>a</script\n>').blocks[0]?.body).toBe('a');
+  });
+
+  it('keeps every top-level block, in document order', () => {
+    const { blocks } = vue(
+      '<script lang="ts">FIRST</script>\n<script setup lang="ts">SECOND</script>',
+    );
+    expect(blocks.map(b => b.body)).toEqual(['FIRST', 'SECOND']);
+  });
+});
+
+describe('scanSfcScripts — dialect', () => {
+  it.each([
+    ['', 'js'],
+    [' lang="js"', 'js'],
+    [' lang="javascript"', 'js'],
+    [' lang="jsx"', 'jsx'],
+    [' lang="ts"', 'ts'],
+    [' lang=ts', 'ts'],
+    [` lang='ts'`, 'ts'],
+    [' lang="TS"', 'ts'],
+    [' lang="typescript"', 'ts'],
+    [' lang="tsx"', 'tsx'],
+    [' lang=""', 'js'],
+    [' lang', 'js'],
+  ])('maps%s to the %s dialect', (attr, expected) => {
+    expect(vue(`<script${attr}>X</script>`).blocks[0]?.lang).toBe(expected);
+  });
+
+  it('reports a dialect it has no parser for as null rather than guessing JS', () => {
+    // Parsing CoffeeScript as JavaScript would report "no props" for a block whose props are
+    // simply unread — the false claim propsExtracted exists to prevent.
+    expect(vue('<script lang="coffee">a = 1</script>').blocks[0]?.lang).toBeNull();
+  });
+});
+
+describe('scanSfcScripts — external sources', () => {
+  it('flags a src= block, whose body is not the source', () => {
+    const { blocks } = vue('<script src="./C.ts" lang="ts"></script>');
+    expect(blocks[0]?.external).toBe(true);
+    expect(blocks[0]?.body).toBe('');
+  });
+
+  it('flags a self-closed src= block without swallowing the rest of the file', () => {
+    const { blocks } = vue('<script src="./C.ts" lang="ts" />\n<template><b/></template>');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.external).toBe(true);
+  });
+
+  it('does not flag an ordinary block as external', () => {
+    expect(vue('<script lang="ts">X</script>').blocks[0]?.external).toBe(false);
+  });
+});
+
+describe('scanSfcScripts — delimitation failures', () => {
+  // Each of these leaves content unread. Reporting `unterminated` is what stops the caller from
+  // turning "no blocks found" into a positive "this component declares no props".
+  it.each([
+    ['an unclosed script', '<script setup lang="ts">const a = 1'],
+    ['an unclosed comment', '<!-- <script lang="ts">const a = 1</script>'],
+    ['an unterminated attribute value', '<script lang="ts" x="oops>const a = 1</script>'],
+    ['an unclosed template', '<template><div><template #a></template><script>A</script>'],
+    ['an unclosed style', '<style>.a{}<script>A</script>'],
+  ])('reports %s as unterminated', (_label, code) => {
+    expect(vue(code).unterminated).toBe(true);
+  });
+
+  it.each([
+    ['an empty file', ''],
+    ['plain text', 'hello world'],
+    ['a script-less template', '<template><b/></template>'],
+    ['a complete file', '<script lang="ts">A</script><template><b/></template><style>.a{}</style>'],
+  ])('does not report %s as unterminated', (_label, code) => {
+    expect(vue(code).unterminated).toBe(false);
+  });
+});
+
+describe('scanSfcScripts — Svelte', () => {
+  it('finds both the module and the instance block, in either spelling', () => {
+    for (const attr of [' module', ' context="module"']) {
+      const { blocks } = svelte(
+        `<script${attr} lang="ts">MODULE</script><script lang="ts">INSTANCE</script>`,
+      );
+      expect(blocks.map(b => b.body)).toEqual(['MODULE', 'INSTANCE']);
+    }
+  });
+
+  it('treats <template> as ordinary markup, not as a block to skip', () => {
+    // Vue's markup lives in a <template> block; Svelte's markup *is* the top level, where
+    // <template> carries no special meaning.
+    const { blocks } = svelte('<template><b/></template><script lang="ts">A</script>');
+    expect(blocks.map(b => b.body)).toEqual(['A']);
+  });
+});
+
+describe('scanSfcScripts — totality', () => {
+  // The contract this module inherits from css-scan: it reads *other people's* repositories, so
+  // malformed input must degrade, never throw. Property-checked rather than case-checked, because
+  // the inputs that break a hand-written scanner are the ones nobody thought to write down.
+  const mulberry = (seed: number) => () => {
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  const PIECES = [
+    '<script',
+    '</script',
+    '<script setup lang="ts">',
+    '</script>',
+    '<template>',
+    '</template>',
+    '<!--',
+    '-->',
+    '<style>',
+    '</style>',
+    '"',
+    "'",
+    '>',
+    '<',
+    '/',
+    '=',
+    'lang',
+    'generic',
+    'src',
+    '<template #a>',
+    '<script src="x"/>',
+    '\n',
+    '\r\n',
+    '\t',
+    ' ',
+    '\u{1f4a5}',
+    'İ',
+  ];
+
+  it('never throws on structural noise', () => {
+    const rand = mulberry(20260812);
+    for (let n = 0; n < 4000; n++) {
+      let code = '';
+      for (let k = 1 + Math.floor(rand() * 14); k > 0; k--) {
+        code += PIECES[Math.floor(rand() * PIECES.length)];
+      }
+      expect(() => vue(code)).not.toThrow();
+      expect(() => svelte(code)).not.toThrow();
+    }
+  });
+
+  it('never throws on any prefix or single-character edit of a realistic SFC', () => {
+    // A truncated file is the realistic failure — a half-written component, a partial read.
+    const real =
+      '<!-- note -->\n<script lang="ts">\nexport interface P { a: string }\n</script>\n<script setup lang="ts" generic="T extends Record<string, unknown>">\nconst p = defineProps<P>()\n</script>\n<template><div><template #x><b/></template></div></template>\n<style>.a{}</style>\n';
+    for (let i = 0; i <= real.length; i++) {
+      expect(() => vue(real.slice(0, i))).not.toThrow();
+    }
+    for (let i = 0; i < real.length; i++) {
+      expect(() => vue(real.slice(0, i) + real.slice(i + 1))).not.toThrow();
+      expect(() => vue(real.slice(0, i) + String(real[i]) + real.slice(i))).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
The `.vue` / `.svelte` side of the component scanner delimited its `<script>` blocks with

```
/<script\b([^>]*)>([\s\S]*?)<\/script>/gi
```

which is the same mistake [#137](https://github.com/awdr74100/figwright/pull/137) took out of the CSS token scanner, in the other file that reads other people's source. Replaced with a lexical scanner (`src/scan/sfc-blocks.ts`) that tracks what a regex cannot: whether the cursor is inside a comment, inside a quoted attribute value, or inside a nested element.

## The four bugs

Each was confirmed end-to-end against `extractSfcComponent` before it was fixed — not inferred from reading the pattern.

| | before | after |
|---|---|---|
| **A** `generic="T extends Record<string, unknown>"` | `[]` / `false` | `["items","label"]` / `true` |
| **B** `lang="tsx"` | `[]` / `false` | `["size"]` / `true` |
| **C** unquoted `lang=ts` | `[]` / `false` | `["size"]` / `true` |
| **D** commented-out `<script>` | `["ghost","real"]` / **`true`** | `["real"]` / `true` |

**A** — `[^>]*` stops at the first `>`, including one inside a quoted attribute value, so a Vue 3.3+ generic component's body began `">` and did not parse. Generic components (typed lists, tables, selects) are exactly the ones a design system needs variant axes from. This one fires on shipped library code — `reka-ui`'s `Tree/TreeItem.vue` and `Tree/TreeRoot.vue`:

```
OLD regex   [1] bodyStarts="\">\nimport type { PrimitiveProps } ..."
NEW scanner [1] bodyStarts="\nimport type { PrimitiveProps } ..."
```

Worth being precise about the blast radius: on those two files the end result does not change, because `TreeItemProps<T> extends PrimitiveProps` has an imported base type and so already took the unresolvable path. The bad slice was masked by a second, independent limitation.

**B/C** — `lang` was matched as `/\blang=["']ts["']/`, so `lang="tsx"` and the (legal) unquoted `lang=ts` fell back to the JS dialect, where `defineProps<{…}>()` is a syntax error. The dialect now reaches oxc intact through an `sfc.ts|tsx|js|jsx` virtual source name.

**D is the serious one.** Names accumulate across every extracted block, so a commented-out `<script setup>` contributed a phantom prop *and* the result still reported `propsExtracted: true` — "this list is complete and real". That is the inverse of the failure the field was built to prevent: `invariant #2` guarded a false `[]` becoming a wrong extension TODO, but nothing guarded a prop that does not exist. The join then reads a Figma variant axis as already supported and codegen emits an attribute that does nothing.

## Three more honest falses

The edge-case pass turned up a case with no guard at all: an unclosed nested `<template>`, an unterminated comment, or an unterminated attribute value left the scanner with zero blocks, and the caller read "no blocks" as "this component genuinely declares no props" — a positive claim made precisely when delimitation had failed. `propsExtracted` now also goes false for:

- a `src=` block, whose source is another file (previously it silently contributed an empty set)
- a `lang` there is no parser for (`coffee`, …)
- a file that could not be fully delimited

A block that only partially parses still contributes whatever oxc recovered — dropping it would narrow detection — but it stops the result claiming the list is complete.

## Evidence

| corpus | result |
|---|---|
| 7,848 generated SFC shapes (lang × generic × props form × comments × template nesting × end-tag form) | **4,475 fixed / 0 regressions / 0 still-wrong** |
| 1,975 real `.vue` / `.svelte` files — primevue, bits-ui, carbon-components-svelte, flowbite-svelte, reka-ui, vitepress, @nuxt/ui | 0 differences, 0 throws |
| 31 adversarial edge cases | all correct |
| 16,790 fuzzed inputs (piece salads, random code points, every prefix and single-character edit of a realistic SFC) | 0 throws |

The first real-world pass reported 0/1,237 triggers, which turned out to say more about the corpus than the bug — only 13 of its 430 `.vue` files used `<script setup lang="ts">` at all, and `generic=` can only appear there. The modern Vue corpus (738 files, 675 with `<script setup>`) is where the two genuine hits came from.

`@vue/compiler-sfc` was measured and rejected: it does not bundle (39 esbuild errors, pulls in `ejs` via its template preprocessors). No new dependency.

## Gates

`typecheck` · `lint` · `format:check` · `knip` · `build` · `test` — all green, 184 files / 1,483 tests (+52).