### PR TITLE
feat(tokens): tell the caller when a token build tool wrote the tokens somewhere pruned

### DIFF
--- a/packages/mcp/src/tokens/generated-tokens.ts
+++ b/packages/mcp/src/tokens/generated-tokens.ts
@@ -1,0 +1,74 @@
+import { fdir } from 'fdir';
+
+// Why this file exists: a design-token *build* tool emits perfectly readable CSS or SCSS, and then
+// writes it where every repo walk in this server refuses to look. `build/`, `dist/` and `out/` are
+// pruned at the directory level (see IGNORED_DIRS) because they are normally generated junk — but a
+// project that commits its token output there has put the one file we want inside the one place we
+// skip. Style Dictionary's own basic example uses `buildPath: "build/"`, so this is the documented
+// layout, not an unusual one.
+//
+// The result today is an empty pool under the note "no token source detected; pass tokenSource" —
+// technically the right advice, and useless: it does not say a token pipeline was found, or where
+// its output landed. That note is read by an agent, which can act on it by calling token_map again
+// with `tokenSource` — so naming the actual candidate files turns a dead end into one more call.
+//
+// Deliberately *naming* rather than reading. A `dist/` can hold a bundled vendor stylesheet that is
+// not this project's tokens at all; pointing at a file and letting the caller confirm keeps that
+// judgement where it belongs, and keeps the pruning that makes every other walk fast.
+
+/** Packages whose presence means "this project generates its design tokens into a file". */
+const TOKEN_BUILD_TOOLS: ReadonlyMap<string, string> = new Map([
+  ['style-dictionary', 'Style Dictionary'],
+  // The Tokens Studio → Style Dictionary bridge: a Figma plugin's export feeding a token build.
+  ['@tokens-studio/sd-transforms', 'Tokens Studio + Style Dictionary'],
+  ['@terrazzo/cli', 'Terrazzo'],
+  ['@cobalt-ui/cli', 'Cobalt'],
+  ['theo', 'Theo'],
+]);
+
+/** Pruned directories a build tool actually writes to. The rest hold no hand-referenced tokens. */
+const OUTPUT_DIRS = ['build', 'dist', 'out'] as const;
+
+const STYLESHEET_EXTENSIONS = ['.css', '.scss'] as const;
+
+/** Enough to name in a note; a caller picks one, so an exhaustive list helps nobody. */
+const MAX_NAMED = 8;
+
+/** Guard against a committed `dist/` of thousands of files — this runs only on an empty pool. */
+const CRAWL_CAP = 400;
+
+/** The display name of a token build tool in these dependencies, or null when there is none. */
+export const detectTokenBuildTool = (deps: Readonly<Record<string, unknown>>): string | null => {
+  for (const [pkg, label] of TOKEN_BUILD_TOOLS) if (pkg in deps) return label;
+  return null;
+};
+
+/**
+ * Stylesheets sitting in the conventionally-pruned output directories, repo-relative and sorted so
+ * the answer is stable. Never throws — a missing directory is simply no candidates.
+ */
+export const findGeneratedStylesheets = async (rootDir: string): Promise<string[]> => {
+  const found: string[] = [];
+  for (const dir of OUTPUT_DIRS) {
+    let files: string[] = [];
+    try {
+      // eslint-disable-next-line no-await-in-loop -- three fixed directories; clarity over batching
+      files = await new fdir()
+        .withRelativePaths()
+        .withPathSeparator('/')
+        .withMaxFiles(CRAWL_CAP)
+        .exclude(name => name.startsWith('.') || name === 'node_modules')
+        .filter(path => {
+          const base = path.slice(path.lastIndexOf('/') + 1);
+          return !base.startsWith('.') && STYLESHEET_EXTENSIONS.some(e => base.endsWith(e));
+        })
+        .crawl(`${rootDir}/${dir}`)
+        .withPromise();
+    } catch {
+      continue;
+    }
+    found.push(...files.map(rel => `${dir}/${rel}`));
+  }
+  // A minified bundle is not a token file; the shortest paths are the likeliest entry points.
+  return found.toSorted((a, b) => a.length - b.length || a.localeCompare(b)).slice(0, MAX_NAMED);
+};

--- a/packages/mcp/src/tokens/load.ts
+++ b/packages/mcp/src/tokens/load.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { ProjectProfile, StylingSystem } from '../profile/profile.js';
+import { type ProjectProfile, readProjectDeps, type StylingSystem } from '../profile/profile.js';
+import { detectTokenBuildTool, findGeneratedStylesheets } from './generated-tokens.js';
 import { parseTailwindConfig, parseUnoConfig } from './js-config.js';
 import { aggregateRepoCssTokens } from './repo-css.js';
 import { aggregateRepoScssTokens } from './repo-scss.js';
@@ -304,10 +305,35 @@ export const loadProjectTokens = async (
       refusal,
     );
   }
+  // Nothing anywhere. Before giving up, say whether this project *generates* its tokens: a build
+  // tool writes readable CSS/SCSS into build/ or dist/, which every walk here prunes, so the pool
+  // is empty for a project that has tokens and has committed them. The generic "pass tokenSource"
+  // does not say that, and this note is read by an agent that can act on it — naming the tool and
+  // the candidate files turns a dead end into one more call.
+  const emptyNote = await emptyPoolNote(rootDir, note);
   return withPrefixedNote(
-    { tokens, source: null, ...(note === undefined ? {} : { note }), files },
+    { tokens, source: null, ...(emptyNote === undefined ? {} : { note: emptyNote }), files },
     refusal,
   );
+};
+
+/**
+ * Why the pool came back empty, in the form most useful to the caller. Falls back to whatever
+ * `resolveTokenSource` said when no token build tool is involved.
+ */
+const emptyPoolNote = async (
+  rootDir: string,
+  detectionNote: string | undefined,
+): Promise<string | undefined> => {
+  const tool = detectTokenBuildTool(await readProjectDeps(rootDir));
+  if (tool === null) return detectionNote;
+
+  const candidates = await findGeneratedStylesheets(rootDir);
+  const where =
+    candidates.length === 0
+      ? 'its output directory (commonly build/ or dist/) holds no committed .css or .scss — run its build, or commit the generated stylesheet'
+      : `its generated stylesheet is not scanned, because build/, dist/ and out/ are skipped as build artefacts. Re-run this tool with tokenSource set to the right one: ${candidates.join(', ')}`;
+  return `${tool} generates this project's design tokens, and ${where}`;
 };
 
 /**

--- a/packages/mcp/test/tokens/generated-tokens.test.ts
+++ b/packages/mcp/test/tokens/generated-tokens.test.ts
@@ -1,0 +1,91 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectTokenBuildTool,
+  findGeneratedStylesheets,
+} from '../../src/tokens/generated-tokens.js';
+
+describe('detectTokenBuildTool', () => {
+  it('recognises the pipelines that generate design tokens into a file', () => {
+    expect(detectTokenBuildTool({ 'style-dictionary': '^5.5.1' })).toBe('Style Dictionary');
+    // The Figma Tokens Studio → Style Dictionary bridge, squarely this server's audience.
+    expect(detectTokenBuildTool({ '@tokens-studio/sd-transforms': '^1' })).toBe(
+      'Tokens Studio + Style Dictionary',
+    );
+    expect(detectTokenBuildTool({ react: '^18' })).toBeNull();
+    expect(detectTokenBuildTool({})).toBeNull();
+  });
+});
+
+describe('findGeneratedStylesheets', () => {
+  it('finds a stylesheet nested anywhere under an output directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gen-deep-'));
+    try {
+      await mkdir(join(dir, 'dist', 'a', 'b', 'c'), { recursive: true });
+      await writeFile(join(dir, 'dist', 'a', 'b', 'c', 'buried.css'), ':root{--a:1px}');
+      expect(await findGeneratedStylesheets(dir)).toEqual(['dist/a/b/c/buried.css']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('never reaches a root-level node_modules', async () => {
+    // The load-bearing property: this crawls `<root>/build|dist|out`, never `<root>` itself, so the
+    // dependency tree is not on any path it can take. A change that walked the root instead would
+    // put a five-figure file count on a request path.
+    const dir = await mkdtemp(join(tmpdir(), 'gen-nm-'));
+    try {
+      await mkdir(join(dir, 'node_modules', 'pkg'), { recursive: true });
+      await writeFile(join(dir, 'node_modules', 'pkg', 'vendor.css'), ':root{--v:1px}');
+      await mkdir(join(dir, 'build'), { recursive: true });
+      await writeFile(join(dir, 'build', 'variables.css'), ':root{--a:1px}');
+
+      expect(await findGeneratedStylesheets(dir)).toEqual(['build/variables.css']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not descend a node_modules nested inside an output directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gen-nested-nm-'));
+    try {
+      await mkdir(join(dir, 'out', 'node_modules', 'evil'), { recursive: true });
+      await writeFile(join(dir, 'out', 'node_modules', 'evil', 'a.css'), ':root{--e:1px}');
+      expect(await findGeneratedStylesheets(dir)).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('caps how many it names, shortest path first', async () => {
+    // The caller picks one, so an exhaustive list helps nobody — and the shallowest paths are the
+    // likeliest entry points rather than a chunk of a bundle.
+    const dir = await mkdtemp(join(tmpdir(), 'gen-cap-'));
+    try {
+      await mkdir(join(dir, 'build', 'nested', 'deeper'), { recursive: true });
+      await writeFile(join(dir, 'build', 'a.css'), 'x');
+      for (let i = 0; i < 20; i += 1) {
+        // eslint-disable-next-line no-await-in-loop -- fixture setup, order irrelevant
+        await writeFile(join(dir, 'build', 'nested', 'deeper', `chunk-${i}.css`), 'x');
+      }
+      const found = await findGeneratedStylesheets(dir);
+      expect(found).toHaveLength(8);
+      expect(found[0]).toBe('build/a.css');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns nothing rather than throwing when no output directory exists', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'gen-none-'));
+    try {
+      await expect(findGeneratedStylesheets(dir)).resolves.toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp/test/tokens/load.test.ts
+++ b/packages/mcp/test/tokens/load.test.ts
@@ -550,6 +550,66 @@ describe('resolveTokenSource', () => {
     }
   });
 
+  it('names the generated stylesheet when a token build tool wrote it somewhere pruned', async () => {
+    // Style Dictionary's own basic example uses `buildPath: "build/"`, which every walk here prunes
+    // as a build artefact — so a project that generates its tokens and commits them gets an empty
+    // pool under "no token source detected", which is true and useless. This note is read by an
+    // agent that can act on it, so it names the tool and the file to pass as tokenSource.
+    const dir = await mkdtemp(join(tmpdir(), 'load-generated-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ devDependencies: { 'style-dictionary': '^5.5.1' } }),
+      );
+      await mkdir(join(dir, 'build'), { recursive: true });
+      await writeFile(join(dir, 'build', 'variables.css'), ':root { --brand: #6266F0; }');
+
+      const profile = await analyzeProject(dir);
+      const loaded = await loadProjectTokens(dir, profile, undefined);
+      expect(loaded.tokens).toEqual([]);
+      expect(loaded.note).toMatch(/Style Dictionary/);
+      expect(loaded.note).toContain('build/variables.css');
+
+      // And the advice works: passing what the note names reads the tokens.
+      const followed = await loadProjectTokens(dir, profile, 'build/variables.css');
+      expect(followed.tokens.map(t => t.name)).toEqual(['brand']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('says the build has not run when the tool is there but the output is not', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'load-nobuild-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ devDependencies: { '@tokens-studio/sd-transforms': '^1' } }),
+      );
+      await mkdir(join(dir, 'tokens'), { recursive: true });
+      await writeFile(join(dir, 'tokens', 'color.json'), '{}');
+
+      const loaded = await loadProjectTokens(dir, await analyzeProject(dir), undefined);
+      expect(loaded.note).toMatch(/Tokens Studio/);
+      expect(loaded.note).toMatch(/run its build|commit the generated stylesheet/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the plain note when no token build tool is involved', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'load-plain-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ dependencies: { react: '^18' } }),
+      );
+      const loaded = await loadProjectTokens(dir, await analyzeProject(dir), undefined);
+      expect(loaded.note).toBe('no token source detected; pass tokenSource');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('caps the file list in a note instead of naming up to 200 paths', async () => {
     // A note is a diagnostic; naming every contributor buries the sentence that matters under a
     // wall of paths in the middle of a tool result.


### PR DESCRIPTION
## The gap, measured

A real Style Dictionary 5.5.1 project — `tokens.json` built to CSS **and** SCSS, output committed — returns **zero tokens**, in every arrangement:

```
產出 css + scss 都 commit   → 0 tokens
只 commit css               → 0 tokens
只 commit scss              → 0 tokens
只 commit scss + sass 依賴   → 0 tokens
產出被 gitignore             → 0 tokens
```

The cause has nothing to do with `tokens.json`. It is directory pruning: `build/`, `dist/` and `out/` are excluded at the traversal level as build artefacts, and Style Dictionary's own basic example uses `buildPath: "build/"`. A project that generates its tokens and commits them has put the one file we want inside the one place we skip.

The note it got was `no token source detected; pass tokenSource` — true, and useless: it never says a token pipeline was found, or where its output landed.

## The fix

`token_map`'s note is read by an **agent**, which can act on it by calling `token_map` again with `tokenSource`. So when the pool is empty and a build tool is in the dependencies, the note names the tool and the candidate files:

> Style Dictionary generates this project's design tokens, and its generated stylesheet is not scanned, because build/, dist/ and out/ are skipped as build artefacts. Re-run this tool with tokenSource set to the right one: `build/variables.css`

Verified live against a real Figma file:

```
1) agent 首次呼叫            tokens: 0   note: …tokenSource set to…: build/variables.css
2) agent 讀懂 note 再呼叫     tokens: 3 | high: 3
     Sky Blue/sky-blue-400  -> var(--color-sky-blue-400)
     Teal/teal-700          -> var(--color-teal-700)
     rounded/lg             -> var(--radius-lg)
```

## Decisions worth reviewing

- **Names rather than reads.** A `dist/` can hold a bundled vendor stylesheet that is not this project's tokens at all. Pointing at a file and letting the caller confirm keeps that judgement where it belongs, and keeps the pruning that makes every other walk fast.
- **Does not prejudge automatic support.** Reading it automatically needs a design decision this deliberately avoids: parse the tool's config for its `buildPath`, or defer to `.gitignore` over the baseline prune list. Both change materially more than a note, and neither should be picked without a real case.
- **Tool list chosen by weekly downloads**, not by impression: `style-dictionary` (1.7M), `@tokens-studio/sd-transforms` (214K — the Figma Tokens Studio → Style Dictionary bridge, squarely this server's audience), `@terrazzo/cli` (92K), `theo`, `@cobalt-ui/cli`.
- **Costs nothing when it does not apply.** The scan is bounded (400 files, 8 named) and runs only on an already-empty pool; a project with no build tool keeps its previous note byte for byte, which a test pins.

## Verification

- Three mutations — never detect a tool, never name a file, ignore the tool and keep the plain note — all caught.
- Live end-to-end through the built `dist` over real stdio against a connected Figma file.
- Full gate green: typecheck · lint · format:check · knip · build · test (1651).