### PR TITLE
fix(walk): return repo files in a deterministic order

### DIFF
--- a/packages/mcp/src/repo-walk.ts
+++ b/packages/mcp/src/repo-walk.ts
@@ -87,5 +87,39 @@ export async function* walkRepoFiles(
     .crawl(rootDir)
     .withPromise();
 
-  yield* files;
+  yield* files.toSorted(byDepthThenPath);
 }
+
+/**
+ * Canonical order for a repo listing: shallowest path first, then by code unit.
+ *
+ * Deterministic is the point, and the disorder was measured rather than assumed: fdir crawls
+ * directories concurrently, so two runs over the same unchanged repo return the same _set_ of files
+ * in a different order. On Bulma the first three differed between consecutive runs. That reached
+ * the output — `token_map`'s note listed a different sample of files each time, and on a repo where
+ * several files declare one token name the `from` handed back changed run to run. Same input,
+ * different answer.
+ *
+ * Depth leads rather than plain a-z as a tie-break _preference_, not as a fix for a proven bug: one
+ * caller takes the first match rather than aggregating (`findTailwindCssEntry`), and a Tailwind v4
+ * entry is conventionally shallow (`src/index.css`), so ranking `src/index.css` above
+ * `src/a/b/c.css` is the better guess where plain a-z would invert them. Note the limits — this
+ * does not disambiguate two candidates at the _same_ depth, and no fixture made that caller vary
+ * between runs in the first place, so its stability is a by-product here, not a repair.
+ *
+ * Compared with `<` rather than localeCompare on purpose — locale-aware collation varies by
+ * environment, which is the property this function exists to remove.
+ */
+const byDepthThenPath = (a: string, b: string): number => {
+  const byDepth = pathDepth(a) - pathDepth(b);
+  if (byDepth !== 0) return byDepth;
+  if (a < b) return -1;
+  return a > b ? 1 : 0;
+};
+
+/** How many directories deep a repo-relative posix path sits. */
+const pathDepth = (path: string): number => {
+  let n = 0;
+  for (const ch of path) if (ch === '/') n += 1;
+  return n;
+};

--- a/packages/mcp/test/repo-walk.test.ts
+++ b/packages/mcp/test/repo-walk.test.ts
@@ -89,3 +89,68 @@ describe('walkRepoFiles', () => {
     expect((await collect(root)).length).toBe(3);
   });
 });
+
+// The existing helper above sorts, which is why none of those tests could see the order the walk
+// actually produced. These use the raw sequence.
+const rawCollect = async (
+  root: string,
+  opts?: Parameters<typeof walkRepoFiles>[1],
+): Promise<string[]> => {
+  const out: string[] = [];
+  for await (const rel of walkRepoFiles(root, opts)) out.push(rel);
+  return out;
+};
+
+describe('walkRepoFiles ordering', () => {
+  it('returns the same sequence on every run over an unchanged repo', async () => {
+    // fdir crawls concurrently, so without an explicit order the same repo yields the same *set* in
+    // a different sequence each time — measured on Bulma, where consecutive runs disagreed on the
+    // first three files. It reached the output: token_map's note sampled different files each call,
+    // and where several files declare one token name the `from` handed back changed run to run.
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 60; i += 1) {
+      files[`pkg${i}/a.css`] = 'x';
+      files[`pkg${i}/nested/b.css`] = 'x';
+    }
+    const root = await make(files);
+    const runs: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop -- separate crawls on purpose
+      runs.push((await rawCollect(root, { extensions: ['.css'] })).join('\n'));
+    }
+    expect(new Set(runs).size).toBe(1);
+  });
+
+  it('orders shallowest first, then by code unit', async () => {
+    // Depth leads as a tie-break preference for the one caller that takes the *first* match rather
+    // than aggregating (findTailwindCssEntry): a Tailwind v4 entry is conventionally shallow, and
+    // plain a-z would rank `src/a/b/deep.css` above `src/index.css`.
+    const root = await make({
+      'src/a/b/deep.css': 'x',
+      'src/index.css': 'x',
+      'zz/later.css': 'x',
+      'root.css': 'x',
+    });
+    expect(await rawCollect(root, { extensions: ['.css'] })).toEqual([
+      'root.css',
+      'src/index.css',
+      'zz/later.css',
+      'src/a/b/deep.css',
+    ]);
+  });
+
+  it('orders by code unit rather than locale collation', async () => {
+    // localeCompare is environment-dependent, which is the property this ordering exists to remove.
+    // These are names an ICU collation orders differently from their code units: it folds case
+    // (`a` before `B`) and treats `ä` as a variant of `a` (before `z`), while the code units run
+    // B (0x42) < a (0x61) < z (0x7A) < ä (0xE4). Deliberately no case-only pair — a
+    // case-insensitive filesystem would collapse the two into one file.
+    const root = await make({ 'a.css': 'x', 'B.css': 'x', 'z.css': 'x', 'ä.css': 'x' });
+    expect(await rawCollect(root, { extensions: ['.css'] })).toEqual([
+      'B.css',
+      'a.css',
+      'z.css',
+      'ä.css',
+    ]);
+  });
+});


### PR DESCRIPTION
## The defect, measured

`walkRepoFiles` is shared by five callers — the component scan, the icon scan, the profile's CSS probe, and both token pools. fdir crawls directories concurrently, so the same unchanged repo returns the same **set** of files in a different sequence on every run. Two consecutive runs over Bulma:

```
run A 前三個: docs/website.scss, sass/components/breadcrumb.scss, sass/components/card.scss
run B 前三個: docs/website.scss, sass/base/generic.scss,          sass/base/skeleton.scss
檔案集合相同: true
```

It reached the output:

- `token_map`'s note sampled a different six files each call.
- On a repo where several files declare one token name, the `from` handed back changed run to run — `pkg0/_v.scss` on one call, `pkg1/_v.scss` on the next, **same input, different answer**.

That matters more since #151, because `from` is the file a caller must `@use` — and because any future run-against-run comparison would see phantom changes.

## The fix

The walk already buffers the entire crawl before yielding, so ordering it costs one sort and changes nothing about memory or streaming.

**Shallowest-first, then by code unit.**

- Depth leads as a tie-break **preference**, not a repair: `findTailwindCssEntry` takes the *first* match rather than aggregating, and a v4 entry is conventionally shallow — so ranking `src/index.css` above `src/a/b/deep.css` is the better guess where plain a-z would invert them. Stated as a preference on purpose: **no fixture made that caller vary between runs** (three tries, up to 300 packages of decoys), so its stability here is a by-product, not evidence of a bug fixed. An earlier draft of the code comment overclaimed this; it now says only what was measured.
- Code units rather than `localeCompare`, since locale-aware collation is environment-dependent — the exact property this change removes.

## Never worse — checked where a caller consumes it

Compared against `main` over Bootstrap, Bulma and vue/core at the **joined mapping** level, not the level that changed:

```
bootstrap: pool 1192 → 1192   8/8 mappings identical
bulma:     pool 7712 → 7712   8/8 mappings identical
core:      pool    2 → 2      8/8 mappings identical

NO REGRESSION vs main
```

Plus, per consumer: byte-stable across three runs, and set-identical to main's content.

## Verification

- Four mutations pinned: no sort · plain a-z · locale collation · (a deepest-first variant had no distinct target).
- **The existing suite's blind spot**: its `collect` helper called `.toSorted()`, which is why none of its seven tests could ever see the order the walk produced. The new tests use the raw sequence.
- Full gate green: typecheck · lint · format:check · knip · build · test (1660).

## Note on process

While writing the tests I overwrote the existing `repo-walk.test.ts` instead of appending to it. Caught by `git status` showing `M` rather than `??`, restored from HEAD, and the seven original tests are intact and passing — but worth stating plainly rather than leaving in the diff.