### PR TITLE
fix(tokens): report a token build tool's output even when other tokens were found

### DIFF
--- a/packages/mcp/src/tokens/load.ts
+++ b/packages/mcp/src/tokens/load.ts
@@ -205,8 +205,18 @@ const readOr = async (rootDir: string, rel: string): Promise<string | null> => {
  * Load the project's design tokens: the detected/overridden source when there is one, else the
  * repo-wide custom-property aggregation (whose pool the joins filter — incidental vars never
  * surface on their own). Notes mirror what token_map has always reported.
+ *
+ * Whatever that finds, the answer is then checked against the possibility that the project
+ * _generates_ its tokens somewhere no walk looks — see {@linkcode withGeneratedTokensNote}.
  */
 export const loadProjectTokens = async (
+  rootDir: string,
+  profile: ProjectProfile,
+  tokenSourceOverride: string | undefined,
+): Promise<LoadedProjectTokens> =>
+  withGeneratedTokensNote(rootDir, await readTokenSource(rootDir, profile, tokenSourceOverride));
+
+const readTokenSource = async (
   rootDir: string,
   profile: ProjectProfile,
   tokenSourceOverride: string | undefined,
@@ -305,36 +315,63 @@ export const loadProjectTokens = async (
       refusal,
     );
   }
-  // Nothing anywhere. Before giving up, say whether this project *generates* its tokens: a build
-  // tool writes readable CSS/SCSS into build/ or dist/, which every walk here prunes, so the pool
-  // is empty for a project that has tokens and has committed them. The generic "pass tokenSource"
-  // does not say that, and this note is read by an agent that can act on it — naming the tool and
-  // the candidate files turns a dead end into one more call.
-  const emptyNote = await emptyPoolNote(rootDir, note);
   return withPrefixedNote(
-    { tokens, source: null, ...(emptyNote === undefined ? {} : { note: emptyNote }), files },
+    { tokens, source: null, ...(note === undefined ? {} : { note }), files },
     refusal,
   );
 };
 
 /**
- * Why the pool came back empty, in the form most useful to the caller. Falls back to whatever
- * `resolveTokenSource` said when no token build tool is involved.
+ * Append what the project's token _build tool_ generated, when the result does not already account
+ * for it.
+ *
+ * A build tool writes readable CSS/SCSS into `build/` or `dist/`, which every walk here prunes as a
+ * build artefact — so the file a caller actually wants sits in the one place we skip. This note is
+ * read by an agent that can act on it by calling again with `tokenSource`, which is why it names
+ * the tool and the candidate paths rather than saying "pass tokenSource".
+ *
+ * Applied to _every_ result, not only an empty one. The first version fired only when the pool came
+ * back with nothing, which is the clean-room shape: a Style Dictionary project with one unrelated
+ * stylesheet anywhere returned that stylesheet's incidental `--header-height` and said nothing at
+ * all about the three design tokens in `build/`. Confidently incomplete is worse than empty, since
+ * it looks like an answer.
  */
-const emptyPoolNote = async (
+const withGeneratedTokensNote = async (
   rootDir: string,
-  detectionNote: string | undefined,
-): Promise<string | undefined> => {
+  loaded: LoadedProjectTokens,
+): Promise<LoadedProjectTokens> => {
   const tool = detectTokenBuildTool(await readProjectDeps(rootDir));
-  if (tool === null) return detectionNote;
+  if (tool === null) return loaded;
 
-  const candidates = await findGeneratedStylesheets(rootDir);
-  const where =
-    candidates.length === 0
-      ? 'its output directory (commonly build/ or dist/) holds no committed .css or .scss — run its build, or commit the generated stylesheet'
-      : `its generated stylesheet is not scanned, because build/, dist/ and out/ are skipped as build artefacts. Re-run this tool with tokenSource set to the right one: ${candidates.join(', ')}`;
-  return `${tool} generates this project's design tokens, and ${where}`;
+  // Nothing to say about files this result already read — including an explicit `tokenSource`
+  // pointed straight at the generated stylesheet, which is exactly what the note asks for.
+  const alreadyRead = new Set(loaded.files);
+  const candidates = (await findGeneratedStylesheets(rootDir)).filter(f => !alreadyRead.has(f));
+
+  const found = loaded.tokens.length > 0;
+  if (candidates.length === 0) {
+    // Output already read, or never built. Only the second is worth saying, and only when nothing
+    // else was found — otherwise the caller has an answer and this is noise.
+    if (found) return loaded;
+    return withNote(
+      loaded,
+      `${tool} generates this project's design tokens, and its output directory (commonly build/ or dist/) holds no committed .css or .scss — run its build, or commit the generated stylesheet`,
+    );
+  }
+
+  // "also" and "may be incomplete" only make sense alongside an answer; without one this *is* the
+  // answer, and it replaces the generic "no token source detected" rather than trailing it.
+  const addition = found
+    ? `${tool} also generates design tokens into a directory this does not scan (build/, dist/ and out/ are skipped as build artefacts), so the tokens above may be incomplete. Re-run with tokenSource set to the right one: ${candidates.join(', ')}`
+    : `${tool} generates this project's design tokens, and its generated stylesheet is not scanned, because build/, dist/ and out/ are skipped as build artefacts. Re-run this tool with tokenSource set to the right one: ${candidates.join(', ')}`;
+  return found ? withNote(loaded, addition) : { ...loaded, note: addition };
 };
+
+/** Append a clause to a result's note, or make it the note when there was none. */
+const withNote = (loaded: LoadedProjectTokens, addition: string): LoadedProjectTokens => ({
+  ...loaded,
+  note: loaded.note === undefined ? addition : `${loaded.note}; ${addition}`,
+});
 
 /**
  * A JS/TS framework config: its theme scales **plus** the repo's CSS custom properties.

--- a/packages/mcp/test/tokens/load.test.ts
+++ b/packages/mcp/test/tokens/load.test.ts
@@ -578,6 +578,77 @@ describe('resolveTokenSource', () => {
     }
   });
 
+  it('names the generated stylesheet even when other tokens were found', async () => {
+    // The first version fired only on a completely empty pool — the clean-room shape. A Style
+    // Dictionary project with one unrelated stylesheet anywhere returned that stylesheet's
+    // incidental `--header-height` and said nothing about the design tokens in build/. Confidently
+    // incomplete is worse than empty, because it looks like an answer.
+    const dir = await mkdtemp(join(tmpdir(), 'load-partial-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ devDependencies: { 'style-dictionary': '^5.5.1' } }),
+      );
+      await mkdir(join(dir, 'build'), { recursive: true });
+      await writeFile(join(dir, 'build', 'variables.css'), ':root { --color-primary: #6266F0; }');
+      await mkdir(join(dir, 'src'), { recursive: true });
+      await writeFile(join(dir, 'src', 'layout.css'), ':root { --header-height: 64px; }');
+
+      const loaded = await loadProjectTokens(dir, await analyzeProject(dir), undefined);
+      // The pool it did find is still returned, unchanged…
+      expect(loaded.tokens.map(t => t.name)).toEqual(['header-height']);
+      // …and the note now says what it missed, and that the answer may be partial.
+      expect(loaded.note).toContain('src/layout.css');
+      expect(loaded.note).toMatch(/Style Dictionary/);
+      expect(loaded.note).toMatch(/may be incomplete/);
+      expect(loaded.note).toContain('build/variables.css');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('says nothing when tokenSource already points at the generated stylesheet', async () => {
+    // Telling a caller to pass what they just passed is noise, and this note is read by an agent
+    // that may act on it.
+    const dir = await mkdtemp(join(tmpdir(), 'load-pointed-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ devDependencies: { 'style-dictionary': '^5.5.1' } }),
+      );
+      await mkdir(join(dir, 'build'), { recursive: true });
+      await writeFile(join(dir, 'build', 'variables.css'), ':root { --color-primary: #6266F0; }');
+
+      const loaded = await loadProjectTokens(dir, await analyzeProject(dir), 'build/variables.css');
+      expect(loaded.tokens.map(t => t.name)).toEqual(['color-primary']);
+      expect(loaded.note).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('says nothing when the tool emits no stylesheet and tokens were found anyway', async () => {
+    // A build tool configured for iOS/Android only has nothing this reader could use, so a project
+    // whose web tokens are already in place should read exactly as it did before.
+    const dir = await mkdtemp(join(tmpdir(), 'load-nonweb-'));
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ devDependencies: { 'style-dictionary': '^5.5.1' } }),
+      );
+      await mkdir(join(dir, 'build', 'ios'), { recursive: true });
+      await writeFile(join(dir, 'build', 'ios', 'Colors.swift'), '// generated');
+      await mkdir(join(dir, 'src'), { recursive: true });
+      await writeFile(join(dir, 'src', 'app.css'), ':root { --brand: #6266F0; }');
+
+      const loaded = await loadProjectTokens(dir, await analyzeProject(dir), undefined);
+      expect(loaded.tokens.map(t => t.name)).toEqual(['brand']);
+      expect(loaded.note).not.toMatch(/Style Dictionary/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('says the build has not run when the tool is there but the output is not', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'load-nobuild-'));
     try {


### PR DESCRIPTION
## The gap

#152 fired only when the token pool came back **completely empty** — the clean-room shape, which is the only one I tested. Measured on the realistic one:

```
only build/ output          tokens=0  hint shown
plus one src/layout.css     tokens=1  hint absent   ← the gap
```

A Style Dictionary project with a single unrelated stylesheet returns that stylesheet's incidental `--header-height` and says **nothing** about the three design tokens sitting in `build/`.

Confidently incomplete is worse than empty: the one token is real, so nothing about the result suggests the actual design tokens were never read.

## The fix

The check now applies to every result rather than only the empty one, as a **wrapper** around the loader rather than a branch inside it — one place it can be skipped instead of seven.

It stays silent wherever it would be noise:

- **files the result already read**, including an explicit `tokenSource` pointed straight at the generated stylesheet — telling a caller to pass what they just passed is worse than saying nothing, and an agent may act on it;
- a tool configured for **iOS/Android only**, emitting no stylesheet this reader could use;
- any project with **no such tool** in its dependencies.

Wording follows the situation: with an answer in hand it says the tool *also* generates tokens and the ones above may be incomplete; with none, it stays exactly the sentence #152 shipped and **replaces** the generic "no token source detected" rather than trailing it.

## Never worse — field by field against main, all five shapes

```
A empty pool                     tokens= 0  data same as main=true  note same=true
B partial pool — the fix         tokens= 1  data same as main=true  note same=false
C tokenSource already names it   tokens= 1  data same as main=true  note same=true
D tool present, no CSS output    tokens= 1  data same as main=true  note same=true
E no build tool                  tokens= 1  data same as main=true  note same=true
```

`tokens`, `source` and `files` are **identical in every case**. The note differs only in B — the case that was broken.

## Live, end to end

Through the built `dist` over real stdio against a connected Figma file, on the shape that was broken:

```
1) agent 首次呼叫     tokens: 1 | high: 0
   note: …aggregated 1 custom properties from src/layout.css; Style Dictionary also generates…
2) agent 照 note 再呼叫  tokens: 3 | high: 3
     Sky Blue/sky-blue-400  -> var(--color-sky-blue-400)
     Teal/teal-700          -> var(--color-teal-700)
     rounded/lg             -> var(--radius-lg)
```

## Verification

- Four mutations pinned: revert to empty-pool-only · hint about files already read · replace the note instead of appending · skip the wrapper entirely.
- Full gate green: typecheck · lint · format:check · knip · build · test (1663).

Found by testing the realistic shape rather than the fixture I had written for #152 — the gap was in my verification, not only in the code.