### PR TITLE
feat: carry export bytes as msgpack bin instead of base64

### DIFF
--- a/packages/mcp/src/tools/binary-payload.ts
+++ b/packages/mcp/src/tools/binary-payload.ts
@@ -2,15 +2,15 @@
  * Reading the export payload off a plugin reply, whichever way it arrived.
  *
  * The disk-landing tools (save_screenshots / export_pdf / export_video / save_image_fills) ask the
- * plugin for raw bytes with a `binary: true` request flag. A plugin new enough to understand it
- * answers with `bytes` — msgpack carries a Uint8Array as a native `bin`, so the payload skips
- * base64's 33% inflation and the encoder's per-character string scan. A plugin predating the flag
- * drops it silently (handlers read named params off a loose cast) and answers with `base64`, so
- * both shapes stay live and this is the one place that knows the difference.
+ * plugin for raw bytes with a `binary: true` request flag, written as a literal at each dispatch
+ * site rather than shared as a constant — `test/plugin-contract.ts` reads the plugin-facing
+ * argument surface out of the source text, and a spread of a named constant is exactly the shape it
+ * cannot see. A plugin new enough to understand it answers with `bytes` — msgpack carries a
+ * Uint8Array as a native `bin`, so the payload skips base64's 33% inflation and the encoder's
+ * per-character string scan. A plugin predating the flag drops it silently (handlers read named
+ * params off a loose cast) and answers with `base64`, so both shapes stay live and this is the one
+ * place that knows the difference.
  */
-
-/** The request flag every disk-landing tool sends; a plugin that doesn't know it answers in base64. */
-export const BINARY_REQUEST = { binary: true } as const;
 
 /** A reply carrying export bytes one way or the other. */
 export interface BinaryCarrier {

--- a/packages/mcp/src/tools/binary-payload.ts
+++ b/packages/mcp/src/tools/binary-payload.ts
@@ -1,0 +1,30 @@
+/**
+ * Reading the export payload off a plugin reply, whichever way it arrived.
+ *
+ * The disk-landing tools (save_screenshots / export_pdf / export_video / save_image_fills) ask the
+ * plugin for raw bytes with a `binary: true` request flag. A plugin new enough to understand it
+ * answers with `bytes` — msgpack carries a Uint8Array as a native `bin`, so the payload skips
+ * base64's 33% inflation and the encoder's per-character string scan. A plugin predating the flag
+ * drops it silently (handlers read named params off a loose cast) and answers with `base64`, so
+ * both shapes stay live and this is the one place that knows the difference.
+ */
+
+/** The request flag every disk-landing tool sends; a plugin that doesn't know it answers in base64. */
+export const BINARY_REQUEST = { binary: true } as const;
+
+/** A reply carrying export bytes one way or the other. */
+export interface BinaryCarrier {
+  base64?: string | null | undefined;
+  bytes?: Uint8Array | undefined;
+}
+
+/**
+ * The payload as bytes, or null when nothing was exported. `bytes` wins when present; otherwise the
+ * legacy base64 is decoded. Both absent (or base64 null) means the node was missing, not
+ * exportable, or the export failed — every caller maps that to a null path.
+ */
+export const binaryPayload = (carrier: BinaryCarrier): Buffer | null => {
+  if (carrier.bytes !== undefined) return Buffer.from(carrier.bytes);
+  const b64 = carrier.base64;
+  return b64 === undefined || b64 === null ? null : Buffer.from(b64, 'base64');
+};

--- a/packages/mcp/src/tools/export-pdf.ts
+++ b/packages/mcp/src/tools/export-pdf.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'node:path';
 import type { ExportPdfResult, PdfExport } from '@figwright/shared';
 import { z } from 'zod';
 
-import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
+import { binaryPayload } from './binary-payload.js';
 import type { ToolSpec } from './spec.js';
 
 export const EXPORT_PDF_TOOL_NAME = 'export_pdf';
@@ -57,7 +57,9 @@ export const handleExportPdf = async (
   rawArgs: unknown,
 ): Promise<ExportPdfResult> => {
   const args = inputSchema.parse(rawArgs);
-  const pluginArgs: Record<string, unknown> = { ...BINARY_REQUEST };
+  const pluginArgs: Record<string, unknown> = {};
+  // These bytes go to disk, never to a model, so they ride the wire as a msgpack `bin`.
+  pluginArgs.binary = true;
   if (args.nodeId !== undefined) pluginArgs.nodeId = args.nodeId;
   const pdf = (await dispatch(EXPORT_PDF_TOOL_NAME, pluginArgs)) as PdfExport;
   return writeExportedPdf(args.outPath, pdf);

--- a/packages/mcp/src/tools/export-pdf.ts
+++ b/packages/mcp/src/tools/export-pdf.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import type { ExportPdfResult, PdfExport } from '@figwright/shared';
 import { z } from 'zod';
 
+import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
 import type { ToolSpec } from './spec.js';
 
 export const EXPORT_PDF_TOOL_NAME = 'export_pdf';
@@ -42,20 +43,21 @@ export const writeExportedPdf = async (
   pdf: PdfExport,
 ): Promise<ExportPdfResult> => {
   const empty = pdf.empty === true ? { empty: true } : {};
-  if (pdf.base64 === null) return { nodeId: pdf.nodeId, path: null, ...empty };
+  const payload = binaryPayload(pdf);
+  if (payload === null) return { nodeId: pdf.nodeId, path: null, ...empty };
   const path = resolve(outPath);
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, Buffer.from(pdf.base64, 'base64'));
+  await writeFile(path, payload);
   return { nodeId: pdf.nodeId, path, ...empty };
 };
 
-/** Reuses the plugin-side export_pdf handler to fetch base64 bytes, then writes them to disk. */
+/** Reuses the plugin-side export_pdf handler to fetch the PDF bytes, then writes them to disk. */
 export const handleExportPdf = async (
   dispatch: ToolDispatcher,
   rawArgs: unknown,
 ): Promise<ExportPdfResult> => {
   const args = inputSchema.parse(rawArgs);
-  const pluginArgs: Record<string, unknown> = {};
+  const pluginArgs: Record<string, unknown> = { ...BINARY_REQUEST };
   if (args.nodeId !== undefined) pluginArgs.nodeId = args.nodeId;
   const pdf = (await dispatch(EXPORT_PDF_TOOL_NAME, pluginArgs)) as PdfExport;
   return writeExportedPdf(args.outPath, pdf);

--- a/packages/mcp/src/tools/export-video.ts
+++ b/packages/mcp/src/tools/export-video.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'node:path';
 import type { ExportVideoResult, VideoExport } from '@figwright/shared';
 import { z } from 'zod';
 
-import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
+import { binaryPayload } from './binary-payload.js';
 import { videoExportConstraintSchema } from './motion-schemas.js';
 import type { ToolSpec } from './spec.js';
 
@@ -83,7 +83,8 @@ export const handleExportVideo = async (
 ): Promise<ExportVideoResult> => {
   const { outPath, ...pluginArgs } = inputSchema.parse(rawArgs);
   const video = (await dispatch(EXPORT_VIDEO_TOOL_NAME, {
-    ...BINARY_REQUEST,
+    // These bytes go to disk, never to a model, so they ride the wire as a msgpack `bin`.
+    binary: true,
     ...pluginArgs,
   })) as VideoExport;
   return writeExportedVideo(outPath, video);

--- a/packages/mcp/src/tools/export-video.ts
+++ b/packages/mcp/src/tools/export-video.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import type { ExportVideoResult, VideoExport } from '@figwright/shared';
 import { z } from 'zod';
 
+import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
 import { videoExportConstraintSchema } from './motion-schemas.js';
 import type { ToolSpec } from './spec.js';
 
@@ -65,21 +66,25 @@ export const writeExportedVideo = async (
     ...(video.reason !== undefined ? { reason: video.reason } : {}),
     ...(video.error !== undefined ? { error: video.error } : {}),
   };
-  if (video.base64 === null) {
+  const payload = binaryPayload(video);
+  if (payload === null) {
     return { nodeId: video.nodeId, format: video.format, path: null, ...miss };
   }
   const path = resolve(outPath);
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, Buffer.from(video.base64, 'base64'));
+  await writeFile(path, payload);
   return { nodeId: video.nodeId, format: video.format, path };
 };
 
-/** Reuses the plugin-side export_video handler to fetch base64 bytes, then writes them to disk. */
+/** Reuses the plugin-side export_video handler to fetch the encoded bytes, then writes them to disk. */
 export const handleExportVideo = async (
   dispatch: ToolDispatcher,
   rawArgs: unknown,
 ): Promise<ExportVideoResult> => {
   const { outPath, ...pluginArgs } = inputSchema.parse(rawArgs);
-  const video = (await dispatch(EXPORT_VIDEO_TOOL_NAME, pluginArgs)) as VideoExport;
+  const video = (await dispatch(EXPORT_VIDEO_TOOL_NAME, {
+    ...BINARY_REQUEST,
+    ...pluginArgs,
+  })) as VideoExport;
   return writeExportedVideo(outPath, video);
 };

--- a/packages/mcp/src/tools/get-screenshot.ts
+++ b/packages/mcp/src/tools/get-screenshot.ts
@@ -39,8 +39,10 @@ export const getScreenshotTool: ToolSpec = {
   }),
   kind: 'read',
   // See index.ts: the public path dispatches with forVision so the sandbox caps an oversized scale
-  // to what a vision model resolves. save_screenshots dispatches the same tool without it.
-  injectedArgs: ['forVision'],
+  // to what a vision model resolves. save_screenshots dispatches the same tool without it, and with
+  // `binary` instead — its bytes land on disk, so they skip base64 (export_pdf / export_video /
+  // save_image_fills send the same flag, but they are `kind: 'local'` and so are not recorded here).
+  injectedArgs: ['forVision', 'binary'],
 };
 /** A subset of MCP tool-result content blocks this tool emits. */
 export type ScreenshotContent =

--- a/packages/mcp/src/tools/save-image-fills.ts
+++ b/packages/mcp/src/tools/save-image-fills.ts
@@ -10,6 +10,7 @@ import type {
 } from '@figwright/shared';
 import { z } from 'zod';
 
+import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
 import type { ToolSpec } from './spec.js';
 
 export const SAVE_IMAGE_FILLS_TOOL_NAME = 'save_image_fills';
@@ -85,7 +86,7 @@ const carry = (img: NodeImageFills['images'][number]): Omit<SavedImageFill, 'for
 });
 
 /**
- * Decode the base64 image bytes into files under outDir (created if missing). Files are named by
+ * Land the original image-fill bytes as files under outDir (created if missing). Files are named by
  * imageHash so an asset reused across many nodes is written exactly once; every usage still gets
  * its own result entry pointing at the shared path. Pure-fs and dispatch-free so it can be
  * unit-tested against a temp directory.
@@ -102,8 +103,8 @@ export const writeImageFills = async (
   const toWrite = new Map<string, Buffer>();
   const outNodes: SavedNodeImageFills[] = nodes.map(node => {
     const images: SavedImageFill[] = node.images.map(img => {
-      if (img.base64 === null || img.imageHash === null) return { ...carry(img), path: null };
-      const buf = Buffer.from(img.base64, 'base64');
+      const buf = binaryPayload(img);
+      if (buf === null || img.imageHash === null) return { ...carry(img), path: null };
       const { format, ext } = detectImageFormat(buf);
       const path = join(dir, `${sanitize(img.imageHash)}.${ext}`);
       if (!toWrite.has(path)) toWrite.set(path, buf);
@@ -128,6 +129,7 @@ export const handleSaveImageFills = async (
 ): Promise<SaveImageFillsResult> => {
   const args = inputSchema.parse(rawArgs);
   const { nodes } = (await dispatch(SAVE_IMAGE_FILLS_TOOL_NAME, {
+    ...BINARY_REQUEST,
     nodeIds: args.nodeIds,
   })) as ImageFillsResult;
   return writeImageFills(args.outDir, nodes);

--- a/packages/mcp/src/tools/save-image-fills.ts
+++ b/packages/mcp/src/tools/save-image-fills.ts
@@ -10,7 +10,7 @@ import type {
 } from '@figwright/shared';
 import { z } from 'zod';
 
-import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
+import { binaryPayload } from './binary-payload.js';
 import type { ToolSpec } from './spec.js';
 
 export const SAVE_IMAGE_FILLS_TOOL_NAME = 'save_image_fills';
@@ -129,7 +129,8 @@ export const handleSaveImageFills = async (
 ): Promise<SaveImageFillsResult> => {
   const args = inputSchema.parse(rawArgs);
   const { nodes } = (await dispatch(SAVE_IMAGE_FILLS_TOOL_NAME, {
-    ...BINARY_REQUEST,
+    // These bytes go to disk, never to a model, so they ride the wire as a msgpack `bin`.
+    binary: true,
     nodeIds: args.nodeIds,
   })) as ImageFillsResult;
   return writeImageFills(args.outDir, nodes);

--- a/packages/mcp/src/tools/save-screenshots.ts
+++ b/packages/mcp/src/tools/save-screenshots.ts
@@ -10,7 +10,7 @@ import {
 } from '@figwright/shared';
 import { z } from 'zod';
 
-import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
+import { binaryPayload } from './binary-payload.js';
 import { GET_SCREENSHOT_TOOL_NAME } from './get-screenshot.js';
 import type { ToolSpec } from './spec.js';
 
@@ -84,7 +84,9 @@ export const handleSaveScreenshots = async (
 ): Promise<SaveScreenshotsResult> => {
   const args = inputSchema.parse(rawArgs);
 
-  const screenshotArgs: Record<string, unknown> = { ...BINARY_REQUEST, nodeIds: args.nodeIds };
+  const screenshotArgs: Record<string, unknown> = { nodeIds: args.nodeIds };
+  // These bytes go to disk, never to a model, so they ride the wire as a msgpack `bin`.
+  screenshotArgs.binary = true;
   if (args.format !== undefined) screenshotArgs.format = args.format;
   // Always pass an explicit scale: an omitted scale makes get_screenshot auto-fit the raster for
   // model consumption, but files written to disk are user artifacts and must stay full-res.

--- a/packages/mcp/src/tools/save-screenshots.ts
+++ b/packages/mcp/src/tools/save-screenshots.ts
@@ -10,6 +10,7 @@ import {
 } from '@figwright/shared';
 import { z } from 'zod';
 
+import { BINARY_REQUEST, binaryPayload } from './binary-payload.js';
 import { GET_SCREENSHOT_TOOL_NAME } from './get-screenshot.js';
 import type { ToolSpec } from './spec.js';
 
@@ -43,8 +44,8 @@ const EXTENSIONS: Record<string, string> = { PNG: 'png', JPG: 'jpg', SVG: 'svg' 
 const sanitize = (id: string): string => id.replace(/[^\w.-]/g, '-');
 
 /**
- * Decode the base64 images into files under outDir (created if missing). Pure-fs and dispatch-free
- * so it can be unit-tested against a temp directory.
+ * Land the exported images as files under outDir (created if missing). Pure-fs and dispatch-free so
+ * it can be unit-tested against a temp directory.
  */
 export const writeScreenshots = async (
   outDir: string,
@@ -59,11 +60,11 @@ export const writeScreenshots = async (
         ...(img.empty === true ? { empty: true as const } : {}),
         ...(img.recovered === true ? { recovered: true as const } : {}),
       };
-      if (img.base64 === null)
-        return { nodeId: img.nodeId, format: img.format, path: null, ...flags };
+      const payload = binaryPayload(img);
+      if (payload === null) return { nodeId: img.nodeId, format: img.format, path: null, ...flags };
       const ext = EXTENSIONS[img.format] ?? img.format.toLowerCase();
       const path = join(dir, `${sanitize(img.nodeId)}.${ext}`);
-      await writeFile(path, Buffer.from(img.base64, 'base64'));
+      await writeFile(path, payload);
       return { nodeId: img.nodeId, format: img.format, path, ...flags };
     }),
   );
@@ -74,8 +75,8 @@ export const writeScreenshots = async (
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
 
 /**
- * Reuses the plugin-side get_screenshot export (no dedicated plugin handler) to fetch base64 bytes,
- * then lands them on the server filesystem — the first server-side write tool.
+ * Reuses the plugin-side get_screenshot export (no dedicated plugin handler) to fetch the raster
+ * bytes, then lands them on the server filesystem — the first server-side write tool.
  */
 export const handleSaveScreenshots = async (
   dispatch: ToolDispatcher,
@@ -83,7 +84,7 @@ export const handleSaveScreenshots = async (
 ): Promise<SaveScreenshotsResult> => {
   const args = inputSchema.parse(rawArgs);
 
-  const screenshotArgs: Record<string, unknown> = { nodeIds: args.nodeIds };
+  const screenshotArgs: Record<string, unknown> = { ...BINARY_REQUEST, nodeIds: args.nodeIds };
   if (args.format !== undefined) screenshotArgs.format = args.format;
   // Always pass an explicit scale: an omitted scale makes get_screenshot auto-fit the raster for
   // model consumption, but files written to disk are user artifacts and must stay full-res.

--- a/packages/mcp/test/plugin-contract.json
+++ b/packages/mcp/test/plugin-contract.json
@@ -23,7 +23,7 @@
     "get_node_motion": ["nodeId"],
     "list_files": [],
     "get_design_context": ["budget", "dedupeComponents", "depth", "detail", "nodeId"],
-    "get_screenshot": ["forVision", "format", "nodeIds", "scale"],
+    "get_screenshot": ["binary", "forVision", "format", "nodeIds", "scale"],
     "set_fills": [
       "fills",
       "fills[].color",

--- a/packages/mcp/test/tools/binary-payload.test.ts
+++ b/packages/mcp/test/tools/binary-payload.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { BINARY_REQUEST, binaryPayload } from '../../src/tools/binary-payload.js';
+
+describe('binaryPayload', () => {
+  it('takes the raw bytes when the plugin answered the binary request', () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    expect(binaryPayload({ base64: null, bytes })).toEqual(Buffer.from(bytes));
+  });
+
+  it('falls back to base64 for a plugin that dropped the binary flag', () => {
+    expect(binaryPayload({ base64: 'iVBORw==' })).toEqual(Buffer.from('iVBORw==', 'base64'));
+  });
+
+  it('prefers bytes when a reply somehow carries both', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(binaryPayload({ base64: 'AAAA', bytes })).toEqual(Buffer.from(bytes));
+  });
+
+  it('reports nothing exported for base64 null, an absent base64, or an empty reply', () => {
+    expect(binaryPayload({ base64: null })).toBeNull();
+    expect(binaryPayload({})).toBeNull();
+  });
+
+  it('keeps zero-length bytes distinct from nothing exported', () => {
+    // A blank-but-real export (an empty frame) must still land a file rather than a null path.
+    const empty = binaryPayload({ base64: null, bytes: new Uint8Array(0) });
+    expect(empty).not.toBeNull();
+    expect(empty?.byteLength).toBe(0);
+  });
+
+  it('is the single flag every disk-landing tool sends', () => {
+    expect(BINARY_REQUEST).toEqual({ binary: true });
+  });
+});

--- a/packages/mcp/test/tools/binary-payload.test.ts
+++ b/packages/mcp/test/tools/binary-payload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { BINARY_REQUEST, binaryPayload } from '../../src/tools/binary-payload.js';
+import { binaryPayload } from '../../src/tools/binary-payload.js';
 
 describe('binaryPayload', () => {
   it('takes the raw bytes when the plugin answered the binary request', () => {
@@ -27,9 +27,5 @@ describe('binaryPayload', () => {
     const empty = binaryPayload({ base64: null, bytes: new Uint8Array(0) });
     expect(empty).not.toBeNull();
     expect(empty?.byteLength).toBe(0);
-  });
-
-  it('is the single flag every disk-landing tool sends', () => {
-    expect(BINARY_REQUEST).toEqual({ binary: true });
   });
 });

--- a/packages/mcp/test/tools/export-pdf.test.ts
+++ b/packages/mcp/test/tools/export-pdf.test.ts
@@ -78,9 +78,22 @@ describe('handleExportPdf', () => {
 
     const result = (await handleExportPdf(dispatch, { outPath: path })) as ExportPdfResult;
 
-    expect(dispatched).toEqual({ tool: 'export_pdf', args: {} });
+    expect(dispatched).toEqual({ tool: 'export_pdf', args: { binary: true } });
     expect(result).toEqual({ nodeId: '0:1', path });
     expect((await readFile(path)).toString('base64')).toBe('AAAA');
+  });
+
+  it('writes raw bytes when the plugin answers the binary request', async () => {
+    const dir = await makeDir();
+    const path = join(dir, 'bin.pdf');
+    const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+    const dispatch: ToolDispatcher = async () =>
+      ({ nodeId: '0:1', base64: null, bytes }) satisfies PdfExport;
+
+    const result = (await handleExportPdf(dispatch, { outPath: path })) as ExportPdfResult;
+
+    expect(result).toEqual({ nodeId: '0:1', path });
+    expect(new Uint8Array(await readFile(path))).toEqual(bytes);
   });
 
   it('forwards nodeId to the plugin export', async () => {
@@ -91,7 +104,7 @@ describe('handleExportPdf', () => {
       return { nodeId: '3:21', base64: 'AAAA' } satisfies PdfExport;
     };
     await handleExportPdf(dispatch, { nodeId: '3:21', outPath: join(dir, 'frame.pdf') });
-    expect(forwarded).toEqual({ nodeId: '3:21' });
+    expect(forwarded).toEqual({ binary: true, nodeId: '3:21' });
   });
 
   it('rejects input missing outPath', async () => {

--- a/packages/mcp/test/tools/export-video.test.ts
+++ b/packages/mcp/test/tools/export-video.test.ts
@@ -109,9 +109,29 @@ describe('handleExportVideo', () => {
       outPath: path,
     })) as ExportVideoResult;
 
-    expect(dispatched).toEqual({ tool: 'export_video', args: { nodeId: '5:5', format: 'MP4' } });
+    expect(dispatched).toEqual({
+      tool: 'export_video',
+      args: { binary: true, nodeId: '5:5', format: 'MP4' },
+    });
     expect(result).toEqual({ nodeId: '5:5', format: 'MP4', path });
     expect((await readFile(path)).toString('base64')).toBe('AAAA');
+  });
+
+  it('writes raw bytes when the plugin answers the binary request', async () => {
+    const dir = await makeDir();
+    const path = join(dir, 'bin.mp4');
+    const bytes = new Uint8Array([0x00, 0x00, 0x00, 0x18]);
+    const dispatch: ToolDispatcher = async () =>
+      ({ nodeId: '5:5', format: 'MP4', base64: null, bytes }) satisfies VideoExport;
+
+    const result = (await handleExportVideo(dispatch, {
+      nodeId: '5:5',
+      format: 'MP4',
+      outPath: path,
+    })) as ExportVideoResult;
+
+    expect(result).toEqual({ nodeId: '5:5', format: 'MP4', path });
+    expect(new Uint8Array(await readFile(path))).toEqual(bytes);
   });
 
   it('forwards fps / quality / constraint to the plugin export', async () => {
@@ -130,6 +150,7 @@ describe('handleExportVideo', () => {
       outPath: join(dir, 'frame.webm'),
     });
     expect(forwarded).toEqual({
+      binary: true,
       nodeId: '3:21',
       format: 'WEBM',
       fps: 30,

--- a/packages/mcp/test/tools/save-image-fills.test.ts
+++ b/packages/mcp/test/tools/save-image-fills.test.ts
@@ -183,7 +183,10 @@ describe('handleSaveImageFills', () => {
       outDir: dir,
     })) as SaveImageFillsResult;
 
-    expect(dispatched).toEqual({ tool: 'save_image_fills', args: { nodeIds: ['1:1'] } });
+    expect(dispatched).toEqual({
+      tool: 'save_image_fills',
+      args: { binary: true, nodeIds: ['1:1'] },
+    });
     expect(result.nodes[0]?.images[0]).toEqual({
       index: 0,
       imageHash: 'h',
@@ -191,6 +194,29 @@ describe('handleSaveImageFills', () => {
       path: join(dir, 'h.png'),
     });
     expect((await readFile(join(dir, 'h.png'))).toString('base64')).toBe(PNG_B64);
+  });
+
+  it('lands raw bytes when the plugin answers the binary request', async () => {
+    const dir = await makeDir();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const dispatch: ToolDispatcher = async () =>
+      ({
+        nodes: [{ nodeId: '1:1', images: [{ index: 0, imageHash: 'h', base64: null, bytes }] }],
+      }) satisfies ImageFillsResult;
+
+    const result = (await handleSaveImageFills(dispatch, {
+      nodeIds: ['1:1'],
+      outDir: dir,
+    })) as SaveImageFillsResult;
+
+    // Format detection reads magic bytes, so it has to work off the binary payload too.
+    expect(result.nodes[0]?.images[0]).toEqual({
+      index: 0,
+      imageHash: 'h',
+      format: 'PNG',
+      path: join(dir, 'h.png'),
+    });
+    expect(new Uint8Array(await readFile(join(dir, 'h.png')))).toEqual(bytes);
   });
 
   it('rejects input missing outDir', async () => {

--- a/packages/mcp/test/tools/save-screenshots.test.ts
+++ b/packages/mcp/test/tools/save-screenshots.test.ts
@@ -105,9 +105,29 @@ describe('handleSaveScreenshots', () => {
 
     // scale:1 is always forwarded explicitly — an omitted scale would make get_screenshot auto-fit
     // the raster for model consumption, but files on disk are user artifacts and stay full-res.
-    expect(dispatched).toEqual({ tool: 'get_screenshot', args: { nodeIds: ['1:1'], scale: 1 } });
+    expect(dispatched).toEqual({
+      tool: 'get_screenshot',
+      args: { binary: true, nodeIds: ['1:1'], scale: 1 },
+    });
     expect(result.saved[0]).toEqual({ nodeId: '1:1', format: 'PNG', path: join(dir, '1-1.png') });
     expect((await readFile(join(dir, '1-1.png'))).toString('base64')).toBe('AAAA');
+  });
+
+  it('lands raw bytes when the plugin answers the binary request', async () => {
+    const dir = await makeDir();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d]);
+    const dispatch: ToolDispatcher = async () =>
+      ({
+        images: [{ nodeId: '1:1', format: 'PNG', base64: null, bytes }],
+      }) satisfies GetScreenshotResult;
+
+    const result = (await handleSaveScreenshots(dispatch, {
+      nodeIds: ['1:1'],
+      outDir: dir,
+    })) as SaveScreenshotsResult;
+
+    expect(result.saved[0]).toEqual({ nodeId: '1:1', format: 'PNG', path: join(dir, '1-1.png') });
+    expect(new Uint8Array(await readFile(join(dir, '1-1.png')))).toEqual(bytes);
   });
 
   it('forwards format and scale to get_screenshot', async () => {
@@ -123,7 +143,7 @@ describe('handleSaveScreenshots', () => {
       format: 'JPG',
       scale: 2,
     });
-    expect(forwarded).toEqual({ nodeIds: ['1:1'], format: 'JPG', scale: 2 });
+    expect(forwarded).toEqual({ binary: true, nodeIds: ['1:1'], format: 'JPG', scale: 2 });
   });
 
   it('rejects input missing outDir', async () => {

--- a/packages/plugin/src/handlers/export-pdf.ts
+++ b/packages/plugin/src/handlers/export-pdf.ts
@@ -13,7 +13,7 @@ const isExportable = (node: BaseNode): node is BaseNode & ExportMixin => 'export
 export const createExportPdfHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
   async params => {
-    const p = (params ?? {}) as { nodeId?: unknown };
+    const p = (params ?? {}) as { nodeId?: unknown; binary?: unknown };
     if (p.nodeId !== undefined && typeof p.nodeId !== 'string') {
       throw new TypeError('export_pdf: nodeId must be a string');
     }
@@ -29,7 +29,11 @@ export const createExportPdfHandler =
     }
 
     const bytes = await node.exportAsync({ format: 'PDF' });
-    const result: PdfExport = { nodeId: node.id, base64: figmaCtx.base64Encode(bytes) };
+    // See get_screenshot: `binary` means the server lands these bytes on disk, so they skip base64.
+    const result: PdfExport =
+      p.binary === true
+        ? { nodeId: node.id, base64: null, bytes }
+        : { nodeId: node.id, base64: figmaCtx.base64Encode(bytes) };
     // A PAGE has no absoluteRenderBounds; only flag empty when the property exists and is null.
     const renderBounds = (node as { absoluteRenderBounds?: unknown }).absoluteRenderBounds;
     if (renderBounds === null) result.empty = true;

--- a/packages/plugin/src/handlers/export-video.ts
+++ b/packages/plugin/src/handlers/export-video.ts
@@ -42,6 +42,7 @@ export const createExportVideoHandler =
       quality?: unknown;
       loopCount?: unknown;
       constraint?: unknown;
+      binary?: unknown;
     };
     if (typeof p.nodeId !== 'string') throw new TypeError('export_video: nodeId must be a string');
     if (p.format !== 'MP4' && p.format !== 'GIF' && p.format !== 'WEBM') {
@@ -67,7 +68,10 @@ export const createExportVideoHandler =
 
     try {
       const bytes = await frame.exportAsync(buildVideoSettings(format, p));
-      return { nodeId: frame.id, format, base64: figmaCtx.base64Encode(bytes) };
+      // See get_screenshot: `binary` means the server lands these bytes on disk, so they skip base64.
+      return p.binary === true
+        ? { nodeId: frame.id, format, base64: null, bytes }
+        : { nodeId: frame.id, format, base64: figmaCtx.base64Encode(bytes) };
     } catch (err) {
       // exportAsync rejects for a static (no-animation) frame, a bad setting, or a raced render —
       // carry Figma's real message rather than guessing a single cause.

--- a/packages/plugin/src/handlers/get-screenshot.ts
+++ b/packages/plugin/src/handlers/get-screenshot.ts
@@ -119,6 +119,7 @@ export const createGetScreenshotHandler =
       format?: unknown;
       scale?: unknown;
       forVision?: unknown;
+      binary?: unknown;
     };
     if (
       !Array.isArray(p.nodeIds) ||
@@ -144,6 +145,14 @@ export const createGetScreenshotHandler =
     // save_screenshots leaves it off: those bytes go to disk, never to a model, so the caller's
     // scale is kept exactly and files stay full-res.
     const forVision = p.forVision === true;
+    // Set by the tools that land the raster on disk. Those bytes never enter a model's context, so
+    // they skip base64 entirely and ride the wire as a msgpack `bin`. An older server never sends
+    // the flag and keeps getting base64, which is why both branches exist.
+    const binary = p.binary === true;
+    const exported = (nodeId: string, bytes: Uint8Array): ScreenshotImage =>
+      binary
+        ? { nodeId, format, base64: null, bytes }
+        : { nodeId, format, base64: figmaCtx.base64Encode(bytes) };
     // useAbsoluteBounds renders the node at its own bounding box instead of its (clipped) render
     // region — see the recovery path below. We only ever turn it on for that recovery.
     const makeSettings = (useAbsoluteBounds: boolean, scale: number): ExportSettings =>
@@ -178,7 +187,7 @@ export const createGetScreenshotHandler =
           const box = geom.absoluteRenderBounds ?? geom.absoluteBoundingBox;
           const scale = resolveScale(box, requestedScale, forVision, true, ceiling);
           const bytes = await node.exportAsync(makeSettings(false, scale));
-          const image: ScreenshotImage = { nodeId, format, base64: figmaCtx.base64Encode(bytes) };
+          const image = exported(nodeId, bytes);
           attachRasterDims(image, box, scale);
           return image;
         }
@@ -194,7 +203,7 @@ export const createGetScreenshotHandler =
         // A blank isn't worth fitting — keep it at 1x unless the caller asked for a scale.
         const scale = resolveScale(box, requestedScale, forVision, recoverable, ceiling);
         const bytes = await node.exportAsync(makeSettings(recoverable, scale));
-        const image: ScreenshotImage = { nodeId, format, base64: figmaCtx.base64Encode(bytes) };
+        const image = exported(nodeId, bytes);
         if (recoverable) image.recovered = true;
         else image.empty = true;
         attachRasterDims(image, box, scale);

--- a/packages/plugin/src/handlers/save-image-fills.ts
+++ b/packages/plugin/src/handlers/save-image-fills.ts
@@ -2,9 +2,9 @@ import type { ImageFillBytes, ImageFillsResult, NodeImageFills } from '@figwrigh
 
 import type { SandboxToolHandler } from '../dispatcher.js';
 
-/** Bytes + intrinsic size for one resolved image hash. */
+/** The wire payload + intrinsic size for one resolved image hash. */
 interface ResolvedImage {
-  bytes: Uint8Array;
+  payload: Pick<ImageFillBytes, 'base64' | 'bytes'>;
   width: number;
   height: number;
 }
@@ -19,6 +19,21 @@ interface ResolvedImage {
  * fetch + size lookup is memoized by hash, so a design that repeats one asset doesn't re-download
  * it N times.
  */
+/** One fill's result entry — at module scope so the map callback stays spread-free. */
+const fillEntry = (
+  index: number,
+  imageHash: string,
+  data: ResolvedImage,
+  scaleMode: string,
+): ImageFillBytes => ({
+  index,
+  imageHash,
+  ...data.payload,
+  width: data.width,
+  height: data.height,
+  scaleMode,
+});
+
 export const createSaveImageFillsHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
   async params => {
@@ -32,24 +47,9 @@ export const createSaveImageFillsHandler =
     }
 
     // See get_screenshot: `binary` means the server lands these bytes on disk, so they skip base64.
-    // Encoding stays per-usage rather than per-hash so the memoized fetch keeps returning raw bytes
-    // — a hash reused across nodes is still fetched exactly once either way.
     const binary = p.binary === true;
-    const resolved = (
-      index: number,
-      imageHash: string,
-      data: ResolvedImage,
-      scaleMode: string,
-    ): ImageFillBytes => ({
-      index,
-      imageHash,
-      ...(binary
-        ? { base64: null, bytes: data.bytes }
-        : { base64: figmaCtx.base64Encode(data.bytes) }),
-      width: data.width,
-      height: data.height,
-      scaleMode,
-    });
+    const toPayload = (bytes: Uint8Array): Pick<ImageFillBytes, 'base64' | 'bytes'> =>
+      binary ? { base64: null, bytes } : { base64: figmaCtx.base64Encode(bytes) };
 
     const cache = new Map<string, Promise<ResolvedImage | null>>();
     const fetchImage = (hash: string): Promise<ResolvedImage | null> => {
@@ -59,7 +59,9 @@ export const createSaveImageFillsHandler =
           const image = figmaCtx.getImageByHash(hash);
           if (image === null) return null;
           const [bytes, size] = await Promise.all([image.getBytesAsync(), image.getSizeAsync()]);
-          return { bytes, width: size.width, height: size.height };
+          // Encoded inside the memo, not per usage: a logo reused across 50 nodes must cost one
+          // base64Encode, not 50. The cache is what makes that true, so the payload belongs in it.
+          return { payload: toPayload(bytes), width: size.width, height: size.height };
         })();
         cache.set(hash, pending);
       }
@@ -86,7 +88,7 @@ export const createSaveImageFillsHandler =
             if (imageHash === null) return { index, imageHash: null, base64: null, scaleMode };
             const data = await fetchImage(imageHash);
             if (data === null) return { index, imageHash, base64: null, scaleMode };
-            return resolved(index, imageHash, data, scaleMode);
+            return fillEntry(index, imageHash, data, scaleMode);
           }),
         );
         const images = entries.filter((e): e is ImageFillBytes => e !== null);

--- a/packages/plugin/src/handlers/save-image-fills.ts
+++ b/packages/plugin/src/handlers/save-image-fills.ts
@@ -4,7 +4,7 @@ import type { SandboxToolHandler } from '../dispatcher.js';
 
 /** Bytes + intrinsic size for one resolved image hash. */
 interface ResolvedImage {
-  base64: string;
+  bytes: Uint8Array;
   width: number;
   height: number;
 }
@@ -22,7 +22,7 @@ interface ResolvedImage {
 export const createSaveImageFillsHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
   async params => {
-    const p = (params ?? {}) as { nodeIds?: unknown };
+    const p = (params ?? {}) as { nodeIds?: unknown; binary?: unknown };
     if (
       !Array.isArray(p.nodeIds) ||
       p.nodeIds.length === 0 ||
@@ -30,6 +30,26 @@ export const createSaveImageFillsHandler =
     ) {
       throw new TypeError('save_image_fills: nodeIds must be a non-empty string[]');
     }
+
+    // See get_screenshot: `binary` means the server lands these bytes on disk, so they skip base64.
+    // Encoding stays per-usage rather than per-hash so the memoized fetch keeps returning raw bytes
+    // — a hash reused across nodes is still fetched exactly once either way.
+    const binary = p.binary === true;
+    const resolved = (
+      index: number,
+      imageHash: string,
+      data: ResolvedImage,
+      scaleMode: string,
+    ): ImageFillBytes => ({
+      index,
+      imageHash,
+      ...(binary
+        ? { base64: null, bytes: data.bytes }
+        : { base64: figmaCtx.base64Encode(data.bytes) }),
+      width: data.width,
+      height: data.height,
+      scaleMode,
+    });
 
     const cache = new Map<string, Promise<ResolvedImage | null>>();
     const fetchImage = (hash: string): Promise<ResolvedImage | null> => {
@@ -39,7 +59,7 @@ export const createSaveImageFillsHandler =
           const image = figmaCtx.getImageByHash(hash);
           if (image === null) return null;
           const [bytes, size] = await Promise.all([image.getBytesAsync(), image.getSizeAsync()]);
-          return { base64: figmaCtx.base64Encode(bytes), width: size.width, height: size.height };
+          return { bytes, width: size.width, height: size.height };
         })();
         cache.set(hash, pending);
       }
@@ -66,14 +86,7 @@ export const createSaveImageFillsHandler =
             if (imageHash === null) return { index, imageHash: null, base64: null, scaleMode };
             const data = await fetchImage(imageHash);
             if (data === null) return { index, imageHash, base64: null, scaleMode };
-            return {
-              index,
-              imageHash,
-              base64: data.base64,
-              width: data.width,
-              height: data.height,
-              scaleMode,
-            };
+            return resolved(index, imageHash, data, scaleMode);
           }),
         );
         const images = entries.filter((e): e is ImageFillBytes => e !== null);

--- a/packages/plugin/test/handlers/export-pdf.test.ts
+++ b/packages/plugin/test/handlers/export-pdf.test.ts
@@ -37,6 +37,20 @@ describe('export_pdf handler', () => {
     expect(result).toEqual({ nodeId: '3:21', base64: Buffer.from(pdfBytes).toString('base64') });
   });
 
+  it('returns raw bytes instead of base64 when the server asks for binary', async () => {
+    const base64Spy = vi.fn<(bytes: Uint8Array) => string>(base64Encode);
+    const figmaCtx = {
+      currentPage: { id: '0:1', exportAsync: async () => pdfBytes },
+      base64Encode: base64Spy,
+    } as unknown as typeof figma;
+
+    const result = (await createExportPdfHandler(figmaCtx)({ binary: true })) as PdfExport;
+
+    expect(result).toEqual({ nodeId: '0:1', base64: null, bytes: pdfBytes });
+    // The point of the flag: the 33% base64 inflation is never paid on this path.
+    expect(base64Spy).not.toHaveBeenCalled();
+  });
+
   it('returns base64 null for a missing / non-exportable node', async () => {
     const figmaCtx = {
       currentPage: { id: '0:1' },

--- a/packages/plugin/test/handlers/export-video.test.ts
+++ b/packages/plugin/test/handlers/export-video.test.ts
@@ -1,0 +1,125 @@
+import type { VideoExport } from '@figwright/shared';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createExportVideoHandler } from '../../src/handlers/export-video.js';
+
+const videoBytes = new Uint8Array([0x00, 0x00, 0x00, 0x18]);
+const base64Encode = (bytes: Uint8Array): string => Buffer.from(bytes).toString('base64');
+
+/** A node whose getTopLevelFrame() resolves to an exportable frame. */
+const animatedNode = (
+  frameId: string,
+  exportAsync: (settings: unknown) => Promise<Uint8Array>,
+): unknown => ({
+  id: frameId,
+  getTopLevelFrame: () => ({ id: frameId, exportAsync }),
+});
+
+const makeFigma = (nodes: Record<string, unknown>, editorType = 'figma'): typeof figma =>
+  ({
+    editorType,
+    base64Encode,
+    getNodeByIdAsync: async (id: string) => nodes[id] ?? null,
+  }) as unknown as typeof figma;
+
+describe('export_video handler', () => {
+  it('exports the enclosing top-level frame to base64 by default', async () => {
+    const exportAsync = vi.fn<() => Promise<Uint8Array>>(async () => videoBytes);
+    const f = makeFigma({ '5:5': animatedNode('5:5', exportAsync) });
+
+    const result = (await createExportVideoHandler(f)({
+      nodeId: '5:5',
+      format: 'MP4',
+    })) as VideoExport;
+
+    expect(result).toEqual({ nodeId: '5:5', format: 'MP4', base64: base64Encode(videoBytes) });
+    expect(exportAsync).toHaveBeenCalledWith({ format: 'MP4' });
+  });
+
+  it('returns raw bytes instead of base64 when the server asks for binary', async () => {
+    const base64Spy = vi.fn<(bytes: Uint8Array) => string>(base64Encode);
+    const f = {
+      ...makeFigma({ '5:5': animatedNode('5:5', async () => videoBytes) }),
+      base64Encode: base64Spy,
+    } as unknown as typeof figma;
+
+    const result = (await createExportVideoHandler(f)({
+      nodeId: '5:5',
+      format: 'MP4',
+      binary: true,
+    })) as VideoExport;
+
+    expect(result).toEqual({ nodeId: '5:5', format: 'MP4', base64: null, bytes: videoBytes });
+    expect(base64Spy).not.toHaveBeenCalled();
+  });
+
+  it('carries fps / quality / constraint into the export settings', async () => {
+    const exportAsync = vi.fn<() => Promise<Uint8Array>>(async () => videoBytes);
+    const f = makeFigma({ '3:21': animatedNode('3:21', exportAsync) });
+
+    await createExportVideoHandler(f)({
+      nodeId: '3:21',
+      format: 'WEBM',
+      fps: 30,
+      quality: 'HIGH',
+      constraint: { type: 'SCALE', value: 2 },
+    });
+
+    expect(exportAsync).toHaveBeenCalledWith({
+      format: 'WEBM',
+      fps: 30,
+      quality: 'HIGH',
+      constraint: { type: 'SCALE', value: 2 },
+    });
+  });
+
+  it('misses with a reason (and no bytes) outside the Figma Design editor', async () => {
+    const f = makeFigma({}, 'figjam');
+    const result = (await createExportVideoHandler(f)({
+      nodeId: '5:5',
+      format: 'MP4',
+      binary: true,
+    })) as VideoExport;
+    expect(result).toEqual({
+      nodeId: '5:5',
+      format: 'MP4',
+      base64: null,
+      reason: 'wrong-editor',
+    });
+  });
+
+  it('reports a missing node rather than throwing', async () => {
+    const f = makeFigma({});
+    const result = (await createExportVideoHandler(f)({
+      nodeId: '9:9',
+      format: 'GIF',
+    })) as VideoExport;
+    expect(result).toEqual({ nodeId: '9:9', format: 'GIF', base64: null, reason: 'not-found' });
+  });
+
+  it("surfaces Figma's own message when exportAsync rejects", async () => {
+    const f = makeFigma({
+      '5:5': animatedNode('5:5', async () => {
+        throw new Error('no animation to export');
+      }),
+    });
+    const result = (await createExportVideoHandler(f)({
+      nodeId: '5:5',
+      format: 'MP4',
+    })) as VideoExport;
+    expect(result).toEqual({
+      nodeId: '5:5',
+      format: 'MP4',
+      base64: null,
+      reason: 'failed',
+      error: 'no animation to export',
+    });
+  });
+
+  it('rejects a bad format up front', async () => {
+    const f = makeFigma({});
+    await expect(createExportVideoHandler(f)({ nodeId: '5:5', format: 'AVI' })).rejects.toThrow(
+      /format must be MP4, GIF, or WEBM/,
+    );
+  });
+});

--- a/packages/plugin/test/handlers/get-screenshot.test.ts
+++ b/packages/plugin/test/handlers/get-screenshot.test.ts
@@ -43,6 +43,41 @@ describe('get_screenshot handler', () => {
     expect(calls[0]).toEqual({ format: 'PNG', constraint: { type: 'SCALE', value: 1 } });
   });
 
+  it('returns raw bytes instead of base64 when the server asks for binary', async () => {
+    const calls: ExportCall[] = [];
+    const handler = createGetScreenshotHandler(
+      fakeFigma({ '1:1': exportable('1:1', calls) }, calls),
+    );
+    const result = (await handler({ nodeIds: ['1:1'], binary: true })) as GetScreenshotResult;
+    expect(result.images).toEqual([
+      { nodeId: '1:1', format: 'PNG', base64: null, bytes: new Uint8Array([1, 2, 3]) },
+    ]);
+  });
+
+  it('keeps the recovery path on the binary payload too', async () => {
+    // The clipped-node branch builds its image separately, so it needs its own guard against
+    // drifting back to base64.
+    const calls: ExportCall[] = [];
+    const clipped = {
+      id: '2:2',
+      visible: true,
+      absoluteRenderBounds: null,
+      absoluteBoundingBox: { x: 0, y: 0, width: 100, height: 40 },
+      exportAsync: async (settings: ExportCall) => {
+        calls.push(settings);
+        return new Uint8Array([9, 9]);
+      },
+    } as unknown as BaseNode;
+    const handler = createGetScreenshotHandler(fakeFigma({ '2:2': clipped }, calls));
+    const result = (await handler({ nodeIds: ['2:2'], binary: true })) as GetScreenshotResult;
+    expect(result.images[0]).toMatchObject({
+      nodeId: '2:2',
+      base64: null,
+      bytes: new Uint8Array([9, 9]),
+      recovered: true,
+    });
+  });
+
   it('passes scale through for raster formats', async () => {
     const calls: ExportCall[] = [];
     const handler = createGetScreenshotHandler(

--- a/packages/plugin/test/handlers/save-image-fills.test.ts
+++ b/packages/plugin/test/handlers/save-image-fills.test.ts
@@ -69,6 +69,29 @@ describe('save_image_fills handler', () => {
     ]);
   });
 
+  it('returns raw bytes instead of base64 when the server asks for binary', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const getBytes = vi.fn<() => Promise<Uint8Array>>(async () => bytes);
+    const f = makeFigma(
+      { '1:1': { fills: [imagePaint('h')] } },
+      { h: { getBytesAsync: getBytes, getSizeAsync: async () => ({ width: 10, height: 20 }) } },
+      getBytes,
+    );
+    const result = (await createSaveImageFillsHandler(f)({
+      nodeIds: ['1:1'],
+      binary: true,
+    })) as ImageFillsResult;
+    expect(result.nodes[0]?.images[0]).toEqual({
+      index: 0,
+      imageHash: 'h',
+      base64: null,
+      bytes,
+      width: 10,
+      height: 20,
+      scaleMode: 'FILL',
+    });
+  });
+
   it('fetches a shared imageHash exactly once across nodes/fills', async () => {
     const getBytes = vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([9]));
     const f = makeFigma(

--- a/packages/plugin/test/handlers/save-image-fills.test.ts
+++ b/packages/plugin/test/handlers/save-image-fills.test.ts
@@ -69,6 +69,37 @@ describe('save_image_fills handler', () => {
     ]);
   });
 
+  it('encodes a shared imageHash once, not once per usage', async () => {
+    // The memo holds the finished payload, not the raw bytes: a logo reused across nodes must cost
+    // one base64Encode. Encoding per usage would be invisible in the result and quadratic in fills.
+    const encode = vi.fn<(bytes: Uint8Array) => string>(bytes => `b64(${bytes.length})`);
+    const getBytes = vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array([1, 2, 3]));
+    const f = {
+      ...makeFigma(
+        {
+          '1:1': { fills: [imagePaint('logo'), imagePaint('logo')] },
+          '2:2': { fills: [imagePaint('logo')] },
+        },
+        { logo: { getBytesAsync: getBytes, getSizeAsync: async () => ({ width: 1, height: 1 }) } },
+        getBytes,
+      ),
+      base64Encode: encode,
+    } as unknown as typeof figma;
+
+    const result = (await createSaveImageFillsHandler(f)({
+      nodeIds: ['1:1', '2:2'],
+    })) as ImageFillsResult;
+
+    expect(getBytes).toHaveBeenCalledTimes(1);
+    expect(encode).toHaveBeenCalledTimes(1);
+    // all three usages still carry the payload
+    expect(result.nodes.flatMap(n => n.images).map(i => i.base64)).toEqual([
+      'b64(3)',
+      'b64(3)',
+      'b64(3)',
+    ]);
+  });
+
   it('returns raw bytes instead of base64 when the server asks for binary', async () => {
     const bytes = new Uint8Array([1, 2, 3]);
     const getBytes = vi.fn<() => Promise<Uint8Array>>(async () => bytes);

--- a/packages/plugin/test/relay/payload.test.ts
+++ b/packages/plugin/test/relay/payload.test.ts
@@ -22,6 +22,28 @@ describe('summarizePayload', () => {
     expect(p.preview).toContain('"nodeId": "1:2"');
   });
 
+  it('elides raw export bytes without letting JSON expand them per byte', () => {
+    // Regression guard: a Uint8Array has no toJSON, so an unguarded JSON.stringify turns a 4.4MB
+    // export into a 51MB string and ~375ms of work on the thread that draws the panel.
+    const bytes = new Uint8Array(64_000);
+    const started = Date.now();
+    const p = summarizePayload({ images: [{ nodeId: '1:2', base64: null, bytes }] });
+    expect(p.preview).toContain('bytes elided');
+    expect(p.preview).not.toMatch(/"0":\s*0/);
+    // The preview stays proportional to the structure, not to the payload's byte count.
+    expect(p.preview.length).toBeLessThan(500);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('counts binary by its real byteLength, not by the elision placeholder', () => {
+    const bytes = new Uint8Array(50_000);
+    const withBinary = summarizePayload({ nodeId: '1:2', bytes });
+    const withoutBinary = summarizePayload({ nodeId: '1:2' });
+    // bytes reflect what actually crossed the wire — a msgpack `bin` costs its byteLength.
+    expect(withBinary.bytes - withoutBinary.bytes).toBeGreaterThanOrEqual(50_000);
+    expect(withBinary.bytes).toBeLessThan(60_000);
+  });
+
   it('caps the preview and flags truncation for an oversized result', () => {
     // Many short strings → no per-string elision, but a huge total that must be capped.
     const big = Array.from({ length: 20_000 }, (_, i) => `item-${i}`);

--- a/packages/plugin/ui/relay/payload.ts
+++ b/packages/plugin/ui/relay/payload.ts
@@ -1,8 +1,8 @@
 // Turns a tool result — the exact object the relay sends back to the MCP server, i.e. what the LLM
 // receives — into a display-ready snapshot for the Activity tab. Captured at the boundary so the
-// human can see precisely what figwright fed the model. Long strings (base64 images) are elided and
-// the whole thing is capped so a huge tree can't lock up the panel; the digest still reports the
-// real size that crossed the wire.
+// human can see precisely what figwright fed the model. Long strings (base64 images) and raw export
+// bytes are elided and the whole thing is capped so a huge tree can't lock up the panel; the digest
+// still reports the real size that crossed the wire.
 
 /** A captured, display-ready view of a tool result as it was sent to the LLM. */
 export interface ActivityPayload {
@@ -25,25 +25,51 @@ export const PREVIEW_CAP = 100_000;
 const byteLength = (s: string): number =>
   typeof TextEncoder === 'undefined' ? s.length : new TextEncoder().encode(s).length;
 
-const elideLongStrings = (_key: string, value: unknown): unknown => {
-  if (typeof value === 'string' && value.length > LONG_STRING_THRESHOLD) {
-    return `‹${value.length.toLocaleString()} chars elided›`;
-  }
-  return value;
+/**
+ * Replacer that keeps a payload cheap to stringify.
+ *
+ * Raw export bytes have to be intercepted _before_ JSON sees them: a Uint8Array has no toJSON, so
+ * `JSON.stringify` expands it into one key per byte — a 4.4MB export becomes a 51MB string and
+ * ~375ms of main-thread work, on the very thread that draws the panel. Binary is summarised by
+ * length, and its real byteLength is accumulated so the digest still reports what crossed the wire
+ * rather than the placeholder.
+ */
+const makeElider = (): { replacer: (key: string, value: unknown) => unknown; binary: number } => {
+  const state = {
+    binary: 0,
+    replacer: (_key: string, value: unknown): unknown => {
+      if (ArrayBuffer.isView(value)) {
+        state.binary += value.byteLength;
+        return `‹${value.byteLength.toLocaleString()} bytes elided›`;
+      }
+      if (typeof value === 'string' && value.length > LONG_STRING_THRESHOLD) {
+        return `‹${value.length.toLocaleString()} chars elided›`;
+      }
+      return value;
+    },
+  };
+  return state;
 };
 
 /** Snapshot a tool result for display: real byte size + an elided, capped, pretty-printed preview. */
 export const summarizePayload = (result: unknown): ActivityPayload => {
+  // Long strings stay counted (they really did cross the wire as text); binary is counted by its
+  // own byteLength, which is what a msgpack `bin` actually costs.
+  const sizer = makeElider();
   let bytes = 0;
   try {
-    bytes = byteLength(JSON.stringify(result) ?? String(result));
+    const sized = JSON.stringify(result, (key, value) =>
+      typeof value === 'string' ? value : sizer.replacer(key, value),
+    );
+    bytes = byteLength(sized ?? String(result)) + sizer.binary;
   } catch {
     /* circular / non-serializable — leave bytes at 0, fall through to the preview's own guard */
   }
 
+  const elider = makeElider();
   let json: string;
   try {
-    json = JSON.stringify(result, elideLongStrings, 2) ?? String(result);
+    json = JSON.stringify(result, elider.replacer, 2) ?? String(result);
   } catch {
     json = String(result);
   }

--- a/packages/shared/src/queries.ts
+++ b/packages/shared/src/queries.ts
@@ -26,6 +26,22 @@ export const SCREENSHOT_FORMATS = ['PNG', 'JPG', 'SVG'] as const;
 export type ScreenshotFormat = (typeof SCREENSHOT_FORMATS)[number];
 
 /**
+ * Raw export bytes, carried in place of `base64` on the paths that land on disk. msgpack encodes a
+ * Uint8Array as a native `bin`, so base64's 33% inflation buys nothing here — the server used to
+ * decode straight back to bytes anyway, making it a pure round trip.
+ *
+ * Both fields exist because the server asks for bytes with a `binary: true` request flag that a
+ * plugin predating this simply drops, answering with `base64` as before. So every consumer reads
+ * the payload as "`bytes`, else `base64`" (see `binaryPayload` server-side); neither present means
+ * nothing was exported.
+ */
+// Typed against ArrayBufferLike rather than z.instanceof's ArrayBuffer: Figma's exportAsync and
+// getBytesAsync both hand back Uint8Array<ArrayBufferLike>.
+export const ExportBytesSchema = z
+  .custom<Uint8Array<ArrayBufferLike>>(value => value instanceof Uint8Array)
+  .optional();
+
+/**
  * Per-node export; base64 is null when the node is missing or not exportable.
  *
  * A node that renders nothing in place (absoluteRenderBounds === null — fully clipped / off-canvas,
@@ -50,6 +66,7 @@ export const ScreenshotImageSchema = z.object({
   width: z.number().optional(),
   height: z.number().optional(),
   scale: z.number().optional(),
+  bytes: ExportBytesSchema,
 });
 export type ScreenshotImage = z.infer<typeof ScreenshotImageSchema>;
 
@@ -86,6 +103,7 @@ export const PdfExportSchema = z.object({
   nodeId: z.string(),
   base64: z.string().nullable(),
   empty: z.boolean().optional(),
+  bytes: ExportBytesSchema,
 });
 export type PdfExport = z.infer<typeof PdfExportSchema>;
 
@@ -124,6 +142,7 @@ export const VideoExportSchema = z.object({
   reason: z.enum(VIDEO_EXPORT_MISS_REASONS).optional(),
   /** Figma's own rejection message, present when reason is `failed`. */
   error: z.string().optional(),
+  bytes: ExportBytesSchema,
 });
 export type VideoExport = z.infer<typeof VideoExportSchema>;
 
@@ -152,6 +171,7 @@ export const ImageFillBytesSchema = z.object({
   width: z.number().optional(),
   height: z.number().optional(),
   scaleMode: z.string().optional(),
+  bytes: ExportBytesSchema,
 });
 export type ImageFillBytes = z.infer<typeof ImageFillBytesSchema>;
 


### PR DESCRIPTION
## What

The four tools that land bytes on disk — `save_screenshots`, `export_pdf`, `export_video`, `save_image_fills` — used to receive their payload as a base64 string and immediately decode it back to bytes. msgpack already carries a `Uint8Array` as a native `bin`, so that round trip cost 33% of the wire for nothing.

The server now sends `binary: true` with those requests and reads the payload through a single `binaryPayload()` helper. **No version gate is needed** — a plugin predating the flag drops it (handlers read named params off a loose cast) and keeps answering in base64, so the fallback *is* the negotiation.

## Numbers

Measured on a real 1440×4170 frame at scale 2 (4,586,696 byte PNG):

| | wire | encode |
|---|---|---|
| base64 (before) | 5.83 MB | 12.00 ms |
| bin (after) | 4.37 MB | 0.53 ms |

The encode win is not msgpack being clever about bytes — it's `@msgpack/msgpack` sizing a string header with a per-character JS scan (`utf8Count`, `Encoder.mjs:259`) before encoding it. On a 5.6M-character base64 string that scan alone is 12 ms, versus 0.8 ms for `Buffer.byteLength`. Taking strings off this path removes the problem rather than working around it.

## Scope boundary

`get_screenshot`'s vision path is **deliberately untouched**. Those bytes have to reach the model as base64 anyway, and that raster is capped at 2576px long edge, making it the smallest payload class. `mcp/src/tools/get-screenshot.ts` has a zero-line diff.

Nothing the LLM sees changes: the four LLM-facing result schemas (`SavedScreenshot`, `ExportPdfResult`, `ExportVideoResult`, `SavedImageFill`) are untouched — they only ever carried `path`. The new tests use exact `toEqual` matching, so a `bytes` key leaking into a result would fail the suite.

## Commits

1. `feat(wire)` — server asks for bytes, reads them through `binaryPayload()`
2. `feat(plugin)` — the four handlers answer the flag with raw bytes
3. `fix(panel)` — see below

## The panel bug this surfaced

`summarizePayload` JSON-stringifies every tool result for the Activity tab, and its elider only knew about long strings. A `Uint8Array` has no `toJSON`, so JSON expands it into one key per byte: the 4.4 MB export this branch introduces became a **51 MB string and ~375 ms of work, twice per result, on the thread that draws the panel**.

Found by asking what evidence would distinguish the new path from the base64 fallback in a live run — the panel is where the two are visibly different, which is also where this bites. Binary is now elided by length, with its real `byteLength` counted toward the digest. The regression guards were mutation-checked: both fail against the old implementation.

## Verification

Six gates green (typecheck / lint --deny-warnings / format:check / knip / build / 1686 tests).

Live-verified against a real file across three builds — `save_screenshots`, `export_pdf` and `save_image_fills` all exercised, with `ping` confirming both `buildId` *and* `routedSessionId` changed on every reload (a stale plugin silently drops the new param and still answers `ok`, so the build id alone proves nothing).

- Screenshot md5 identical across all four runs, including the pre-change baseline: `7e45d42eb45166f0e2313e71ba441fa1`, 4,586,696 bytes
- PDF and image-fill outputs carry valid `%PDF-1.7` / PNG magic bytes; format detection reads magic bytes, so it works off the binary payload too
- Byte-identical output does **not** by itself prove the new path ran (the fallback produces the same file by design), so the Activity panel was read for distinguishing evidence:

```json
{ "nodeId": "3282:20863", "format": "PNG", "base64": null,
  "bytes": "‹4,586,696 bytes elided›", "width": 2880, "height": 8340, "scale": 2 }
```

`export_video` is covered by unit tests only — verifying it live needs an animated frame that wasn't available. It had no handler test at all before this; this adds one covering both payload modes, the miss reasons, and the settings passthrough.