### PR TITLE
test(contract): close the local-tool hole in the plugin argument gate

### DIFF
--- a/packages/mcp/src/tools/analyze-project.ts
+++ b/packages/mcp/src/tools/analyze-project.ts
@@ -22,6 +22,8 @@ export const analyzeProjectTool: ToolSpec = {
     'vite-svg-loader / …) → svg.mode component vs url + an import hint.',
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 export const handleAnalyzeProject = async (rawArgs: unknown): Promise<ProjectProfile> => {
   const args = inputSchema.parse(rawArgs);

--- a/packages/mcp/src/tools/component-map.ts
+++ b/packages/mcp/src/tools/component-map.ts
@@ -61,6 +61,8 @@ export const componentMapTool: ToolSpec = {
     'staleOverrides, profile }.',
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
 

--- a/packages/mcp/src/tools/design-diff.ts
+++ b/packages/mcp/src/tools/design-diff.ts
@@ -52,6 +52,8 @@ export const designDiffTool: ToolSpec = {
     'never mutates Figma. Scope by a component / section nodeId, the same unit codegen works on.',
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;

--- a/packages/mcp/src/tools/export-pdf.ts
+++ b/packages/mcp/src/tools/export-pdf.ts
@@ -30,6 +30,9 @@ export const exportPdfTool: ToolSpec = {
     'target is missing or not exportable, and empty:true means it rendered a blank PDF.',
   inputSchema,
   kind: 'local',
+  // Dispatches to a same-named sandbox handler; outPath stays on the server.
+  serverOnlyArgs: ['outPath'],
+  injectedArgs: ['binary'],
 };
 
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;

--- a/packages/mcp/src/tools/export-video.ts
+++ b/packages/mcp/src/tools/export-video.ts
@@ -49,6 +49,9 @@ export const exportVideoTool: ToolSpec = {
     'calls, or the render can fail. Returns { nodeId, format, path, reason?, error? }.',
   inputSchema,
   kind: 'local',
+  // Dispatches to a same-named sandbox handler; outPath stays on the server.
+  serverOnlyArgs: ['outPath'],
+  injectedArgs: ['binary'],
 };
 
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;

--- a/packages/mcp/src/tools/icon-map.ts
+++ b/packages/mcp/src/tools/icon-map.ts
@@ -61,6 +61,8 @@ export const iconMapTool: ToolSpec = {
     'server cwd. Returns { mappings, unmapped, iconLibraries, profile }.',
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
 

--- a/packages/mcp/src/tools/save-image-fills.ts
+++ b/packages/mcp/src/tools/save-image-fills.ts
@@ -38,6 +38,9 @@ export const saveImageFillsTool: ToolSpec = {
     'for a vector node use export_pdf.',
   inputSchema,
   kind: 'local',
+  // Dispatches to a same-named sandbox handler; outDir stays on the server.
+  serverOnlyArgs: ['outDir'],
+  injectedArgs: ['binary'],
 };
 
 /**

--- a/packages/mcp/src/tools/save-screenshots.ts
+++ b/packages/mcp/src/tools/save-screenshots.ts
@@ -37,6 +37,8 @@ export const saveScreenshotsTool: ToolSpec = {
     'Files are named after a sanitized node id.',
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 const EXTENSIONS: Record<string, string> = { PNG: 'png', JPG: 'jpg', SVG: 'svg' };
 

--- a/packages/mcp/src/tools/scan-components.ts
+++ b/packages/mcp/src/tools/scan-components.ts
@@ -25,6 +25,8 @@ export const scanComponentsTool: ToolSpec = {
     "detected profile's; rootDir defaults to the server cwd. Returns { components, profile }.",
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 export interface ScanComponentsResult {
   components: ScannedComponent[];

--- a/packages/mcp/src/tools/spec.ts
+++ b/packages/mcp/src/tools/spec.ts
@@ -39,4 +39,22 @@ export interface ToolSpec {
    * `requestId` is not listed: it is derived from `kind === 'write'` at the dispatch site.
    */
   injectedArgs?: readonly string[];
+  /**
+   * Required on every `kind: 'local'` spec — the plugin-facing half of a tool whose `inputSchema`
+   * is not it. A read/write tool dispatches its own schema verbatim, so the schema _is_ the
+   * contract; a local tool's handler builds the plugin payload by hand, and the schema also carries
+   * server-only fields (`outPath`, `outDir`) that must never be recorded as plugin arguments.
+   *
+   * An array names those server-only fields and opts the tool into the recorded contract: its
+   * plugin-facing surface is `inputSchema − serverOnlyArgs + injectedArgs`. `null` says the tool
+   * has no plugin handler of its own and borrows another tool's (save_screenshots → get_screenshot,
+   * component_map → get_design_context), so its arguments are recorded under the tool it borrows.
+   *
+   * Declared as the _exclusions_ rather than the plugin argument list on purpose. The list would be
+   * a hand-kept mirror of the schema that goes stale silently — the failure this repo keeps
+   * relearning. The exclusions are few and change far less often, and forgetting one fails loud: an
+   * unlisted server-only field shows up as a new plugin argument in the contract diff, which is
+   * noisy and wrong rather than quiet and wrong.
+   */
+  serverOnlyArgs?: readonly string[] | null;
 }

--- a/packages/mcp/src/tools/token-map.ts
+++ b/packages/mcp/src/tools/token-map.ts
@@ -117,6 +117,8 @@ export const tokenMapTool: ToolSpec = {
     'profile }.',
   inputSchema,
   kind: 'local',
+  // No sandbox handler of its own; its plugin arguments are recorded under the tool it reuses.
+  serverOnlyArgs: null,
 };
 export type ToolDispatcher = (toolName: string, args: unknown) => Promise<unknown>;
 

--- a/packages/mcp/test/plugin-contract.json
+++ b/packages/mcp/test/plugin-contract.json
@@ -24,6 +24,19 @@
     "list_files": [],
     "get_design_context": ["budget", "dedupeComponents", "depth", "detail", "nodeId"],
     "get_screenshot": ["binary", "forVision", "format", "nodeIds", "scale"],
+    "save_image_fills": ["binary", "nodeIds"],
+    "export_pdf": ["binary", "nodeId"],
+    "export_video": [
+      "binary",
+      "constraint",
+      "constraint.type",
+      "constraint.value",
+      "format",
+      "fps",
+      "loopCount",
+      "nodeId",
+      "quality"
+    ],
     "set_fills": [
       "fills",
       "fills[].color",

--- a/packages/mcp/test/plugin-contract.test.ts
+++ b/packages/mcp/test/plugin-contract.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ALL_TOOL_SPECS } from '../src/tools/registry.js';
 import {
+  collect,
   derivePluginContract,
   diffContracts,
   type PluginToolContract,
@@ -123,6 +124,72 @@ describe('plugin argument contract', () => {
     expect(derived).not.toHaveProperty('analyze_project');
     expect(derived.set_layout_props).toContain('layoutSizingHorizontal');
     expect(derived.get_screenshot).toContain('forVision');
+  });
+
+  it('makes every local tool state whether it has a sandbox handler of its own', () => {
+    // The hole this closes: `kind === 'local'` used to mean "skip", so export_pdf / export_video /
+    // save_image_fills sent arguments to their own sandbox handlers that nothing here recorded. A
+    // new local tool must not be able to opt out of that by saying nothing, so an absent
+    // declaration is a failure — `null` is how a tool says it reuses another tool's handler.
+    const undeclared = ALL_TOOL_SPECS.filter(
+      spec => spec.kind === 'local' && spec.serverOnlyArgs === undefined,
+    ).map(spec => spec.name);
+    expect(undeclared).toEqual([]);
+
+    // Pins both halves of the split so neither side can quietly empty out.
+    const owns = ALL_TOOL_SPECS.filter(
+      spec =>
+        spec.kind === 'local' && spec.serverOnlyArgs !== undefined && spec.serverOnlyArgs !== null,
+    ).map(spec => spec.name);
+    expect(owns.toSorted()).toEqual(['export_pdf', 'export_video', 'save_image_fills']);
+    for (const name of owns) expect(derived).toHaveProperty(name);
+    // save_screenshots dispatches get_screenshot, so its arguments live under that entry, not here.
+    expect(derived).not.toHaveProperty('save_screenshots');
+  });
+
+  it('only excludes arguments the tool actually has', () => {
+    // A stale or misspelled exclusion silently widens the hole it was meant to describe: the field
+    // it names is gone or never existed, and the real server-only field flows into the contract
+    // unnoticed. Checked against the schema rather than trusted.
+    for (const spec of ALL_TOOL_SPECS) {
+      const serverOnly = spec.serverOnlyArgs;
+      if (serverOnly === undefined || serverOnly === null) continue;
+      const own = new Set<string>();
+      collect(spec.inputSchema, '', own);
+      for (const arg of serverOnly) {
+        expect({ tool: spec.name, arg, inSchema: own.has(arg) }).toEqual({
+          tool: spec.name,
+          arg,
+          inSchema: true,
+        });
+      }
+    }
+  });
+
+  it('records every argument a handler-owning local tool is seen to dispatch', () => {
+    // The recorded entry is derived from the schema, which is one step removed from what the
+    // handler actually sends. This reads the send site back: every argument the scan finds in the
+    // tool's own file has to appear in that tool's entry, so a renamed or hand-added field cannot
+    // sit in the code while the contract describes something else. A lower bound by nature — the
+    // scan cannot see through a spread of a variable — but it is read from the real call site.
+    const toolsRoot = join(dirname(fileURLToPath(import.meta.url)), '../src/tools');
+    for (const spec of ALL_TOOL_SPECS) {
+      if (
+        spec.kind !== 'local' ||
+        spec.serverOnlyArgs === undefined ||
+        spec.serverOnlyArgs === null
+      )
+        continue;
+      const file = join(toolsRoot, `${spec.name.replaceAll('_', '-')}.ts`);
+      const seen = [...scanInjectedArgs(readFileSync(file, 'utf8'))].toSorted();
+      const recordedArgs = new Set(derived[spec.name] ?? []);
+      expect({ tool: spec.name, missing: seen.filter(arg => !recordedArgs.has(arg)) }).toEqual({
+        tool: spec.name,
+        missing: [],
+      });
+      // Vacuous if the scan found nothing — every one of these hand-builds a payload.
+      expect(seen.length).toBeGreaterThan(0);
+    }
   });
 
   it('descends into nested and array arguments', () => {

--- a/packages/mcp/test/plugin-contract.ts
+++ b/packages/mcp/test/plugin-contract.ts
@@ -12,14 +12,18 @@ import { ALL_TOOL_SPECS } from '../src/tools/registry.js';
  * added a field" from an invisible event into a diff.
  *
  * Paths are dotted and descend through arrays and unions (`track.keyframes[].easing.type`), because
- * a nested addition drops just as silently as a top-level one. `local` tools are excluded: they
- * never reach the plugin.
+ * a nested addition drops just as silently as a top-level one.
+ *
+ * A read/write tool dispatches its own schema verbatim, so the schema is the contract. A `local`
+ * tool's handler builds the plugin payload by hand, so its schema is not: `serverOnlyArgs` names
+ * the fields that stay on the server (an output path), and `null` there means the tool has no
+ * sandbox handler of its own — its arguments belong to the tool it reuses, which records them.
  *
  * `batch.ops[].params` stops at `unknown` on purpose — it is the union of every other tool's
  * arguments, and each of those tools records its own entry here, so the arguments a batched op
  * carries are covered under the tool it batches rather than duplicated under `batch`.
  */
-const collect = (schema: z.ZodType, prefix: string, out: Set<string>): void => {
+export const collect = (schema: z.ZodType, prefix: string, out: Set<string>): void => {
   const def = schema.def as { type: string; [key: string]: unknown };
 
   switch (def.type) {
@@ -70,12 +74,22 @@ const collect = (schema: z.ZodType, prefix: string, out: Set<string>): void => {
 
 export type PluginToolContract = Record<string, readonly string[]>;
 
+/** True when `path` is `arg` itself or something nested under it (`outPath`, `outPath.dir`). */
+const isUnder = (path: string, arg: string): boolean =>
+  path === arg || path.startsWith(`${arg}.`) || path.startsWith(`${arg}[`);
+
 export const derivePluginContract = (): PluginToolContract => {
   const contract: Record<string, readonly string[]> = {};
   for (const spec of ALL_TOOL_SPECS) {
-    if (spec.kind === 'local') continue;
-    const paths = new Set<string>();
-    collect(spec.inputSchema, '', paths);
+    // A local tool with no sandbox handler of its own contributes nothing here; one that has a
+    // handler contributes its schema minus the fields that never leave the server.
+    const serverOnly = spec.kind === 'local' ? spec.serverOnlyArgs : undefined;
+    if (spec.kind === 'local' && (serverOnly === null || serverOnly === undefined)) continue;
+    const schemaPaths = new Set<string>();
+    collect(spec.inputSchema, '', schemaPaths);
+    const paths = new Set(
+      [...schemaPaths].filter(path => !(serverOnly ?? []).some(arg => isUnder(path, arg))),
+    );
     // Server-added arguments reach the same handlers and drop just as silently, but appear in no
     // schema — `forVision` was the worst measured case and would have been invisible here.
     for (const arg of spec.injectedArgs ?? []) paths.add(arg);


### PR DESCRIPTION
Follow-up to #156, which surfaced this: `test/plugin-contract.ts` skipped every `kind: 'local'` tool, so three of them — `export_pdf`, `export_video`, `save_image_fills` — dispatched arguments to their own sandbox handlers that nothing recorded.

## Why the skip existed, and why it wasn't just an oversight

A read/write tool dispatches its own `inputSchema` verbatim, so the schema *is* the plugin contract. A local tool's handler builds the payload by hand, and its schema also carries server-only fields — `export_video` literally destructures `const { outPath, ...pluginArgs } = inputSchema.parse(rawArgs)`. Deriving from the schema would have recorded `outPath` as a plugin argument, which is wrong. Skipping avoided recording the wrong thing at the cost of recording nothing.

## What was actually exposed

Verified against the gate as it stood, by mutating `export_pdf`:

| | |
|---|---|
| Send an invented argument (`totallyNewArg`) | caught — the scan covers all of `src/` |
| Declare it to satisfy that check | passes, and **the recorded contract is not touched** |
| Send a name another tool already has (`depth`) | silent — a documented global limit of the scan |

So the residual hole was the middle row: a new argument on a local tool got flagged once, then disappeared into a declaration. The two things the recorded entry does — say *which* tool gained the argument, and put the change next to `MIN_PLUGIN_VERSION` so the floor decision lands in the diff — never happened.

## The fix

`serverOnlyArgs` on `ToolSpec`, required on every local spec:

- an array names the fields that stay on the server, and opts the tool in — surface is `inputSchema − serverOnlyArgs + injectedArgs`
- `null` says the tool has no sandbox handler of its own and borrows another's (`save_screenshots` → `get_screenshot`; `component_map` / `design_diff` / `icon_map` / `token_map` / `analyze_project` / `scan_components` → `get_design_context`), so its arguments are recorded under the tool it borrows

Declared as the *exclusions* rather than as the plugin argument list on purpose. A list would be a hand-kept mirror of the schema that goes stale silently — the failure mode this repo keeps relearning. The exclusions are few and stable, and forgetting one fails loud: an unlisted server-only field turns up as a new plugin argument in the contract diff, which is noisy and wrong rather than quiet and wrong.

## Recorded

```diff
+"save_image_fills": ["binary", "nodeIds"],
+"export_pdf": ["binary", "nodeId"],
+"export_video": ["binary", "constraint", "constraint.type", "constraint.value",
+                 "format", "fps", "loopCount", "nodeId", "quality"],
```

`outPath` / `outDir` correctly absent. The gate classifies these LOUD — an older plugin answers `METHOD_NOT_FOUND`, which is visible rather than silent — so `MIN_PLUGIN_VERSION` stays at 0.5.0.

## Guards, each mutation-checked

1. Every local spec must declare `serverOnlyArgs` — absent is a failure, so a new local tool cannot opt out of the gate by saying nothing. Both halves of the owns/borrows split are pinned so neither can quietly empty out.
2. Every exclusion must name a field the schema actually has — a stale or misspelled one widens the hole it was meant to describe.
3. Every argument the scan finds in a handler-owning tool's own source file must appear in that tool's entry. The recorded entry comes from the schema, one step removed from what the handler sends; this reads the send site back. A lower bound (the scan cannot see through a spread of a variable), but read from the real call site.

Mutations verified to fail: removing a declaration, misspelling an exclusion, dispatching an argument the schema lacks, and mislabelling either direction of the split. Baseline is clean before and after each.

## Scope

`serverOnlyArgs` and `injectedArgs` are declaration-only — read by the contract derivation in `test/` and by nothing at runtime — so there is no behaviour change to verify against a live plugin.

Not addressed: the scan's known blind spot for a name another tool already uses (row three above). That predates this and is called out in the existing test comment as a deliberate limit.