### PR TITLE
test: close the two races behind the intermittent CI failure

### DIFF
--- a/packages/mcp/test/e2e/process-lifecycle.test.ts
+++ b/packages/mcp/test/e2e/process-lifecycle.test.ts
@@ -138,13 +138,21 @@ describe.skipIf(!existsSync(DIST_ENTRY))('process lifecycle (built dist)', () =>
           try {
             // Identified from the note it left when it bound, re-proved against the live process
             // table — the pid printed here is the one a user would kill.
-            await waitFor(
-              () => follower.stderr().includes(`port holder pid ${leader.child.pid} is suspended`),
-              'wedge diagnosed',
-              45_000,
-            );
-            expect(follower.stderr()).toContain('PORT CONFLICT');
-            expect(follower.stderr()).toContain(`kill ${leader.child.pid}`);
+            //
+            // Every line the diagnosis depends on is waited for *together*, rather than waiting on
+            // one and then asserting the rest. The follower writes the SIGCONT line before the
+            // PORT CONFLICT line, but its stderr reaches this process in chunks — waiting for the
+            // first and immediately asserting the second is a race, and it lost about once in
+            // thirty runs.
+            const diagnosed = (): boolean => {
+              const log = follower.stderr();
+              return (
+                log.includes(`port holder pid ${leader.child.pid} is suspended`) &&
+                log.includes('PORT CONFLICT') &&
+                log.includes(`kill ${leader.child.pid}`)
+              );
+            };
+            await waitFor(diagnosed, 'wedge diagnosed', 45_000);
 
             // And the SIGCONT it sent has to actually revive the leader, which is only observable
             // from the outside: the follower goes back to following it.

--- a/packages/mcp/test/election/leader-lock.test.ts
+++ b/packages/mcp/test/election/leader-lock.test.ts
@@ -17,9 +17,18 @@ import {
   writeLeaderLock,
 } from '../../src/election/leader-lock.js';
 
-// Ports here are only ever used as lock-file keys (nothing binds them), so a high random one keeps
-// parallel test files from sharing a file.
-let nextPort = 41_000 + Math.floor(Math.random() * 20_000);
+// Ports here are only ever used as lock-file keys — nothing binds them — but the key space is
+// shared with every other test file, and `election.test.ts` writes real notes keyed by the
+// *ephemeral* ports `freePort()` hands it, from a different worker process. A range that overlaps
+// the ephemeral one therefore collides for real: the earlier `41_000 + random * 20_000` crossed
+// 49152-61000 on macOS, and a hit made `readLeaderLock` return the other worker's note, failing
+// "is undefined when there is no lock for that port" — one test, at random, roughly once in a
+// hundred runs. Reproduced deliberately before this was changed.
+//
+// 20_000 is below every platform's ephemeral floor (Linux 32768, macOS/Windows 49152), so no port
+// any other file is handed can land here. The pid offset keeps two concurrent vitest runs on one
+// machine apart as well.
+let nextPort = 20_000 + (process.pid % 100) * 100;
 const testPort = (): number => (nextPort += 1);
 
 const written: number[] = [];
@@ -96,8 +105,19 @@ describe('leader lock: write / read', () => {
     expect(Math.abs((readLeaderLock(port)?.processStartedAt ?? 0) - selfStart)).toBeLessThan(2_000);
   });
 
+  it('keys its notes below every platform ephemeral range, so no other file can collide', () => {
+    // The invariant that closes the cross-worker race, pinned so an edit cannot quietly undo it:
+    // other files key their notes by ports `freePort()` hands them, which start at 32768 (Linux)
+    // and 49152 (macOS/Windows).
+    for (let i = 0; i < 50; i += 1) expect(testPort()).toBeLessThan(32_768);
+  });
+
   it('is undefined when there is no lock for that port', () => {
-    expect(readLeaderLock(testPort())).toBeUndefined();
+    // Asserting an absence means guaranteeing it: a crashed earlier run can leave a note at this
+    // key, and the assertion would then be reporting that leftover rather than the behaviour.
+    const port = testPort();
+    rmSync(leaderLockPath(port), { force: true });
+    expect(readLeaderLock(port)).toBeUndefined();
   });
 
   it.each([
@@ -171,6 +191,7 @@ describe('leader lock: identifying the holder', () => {
 
   it('is undefined when there is no lock at all', () => {
     const port = testPort();
+    rmSync(leaderLockPath(port), { force: true });
     const probe = fakeProbe(process.pid, { state: 'T', startedAt: Date.now() });
     expect(identifyPortHolder(port, probe)).toBeUndefined();
   });


### PR DESCRIPTION
## Description

Diagnoses and fixes the intermittent single-test failure that #159 shipped as a known-open item. There were **two distinct causes**, both found and both reproduced — neither was a load or timing sensitivity, which is where the search initially went wrong.

## Cause 1 — a shared key space between parallel test files

`leader-lock.test.ts` keyed its notes by `41_000 + random * 20_000`, which crosses the ephemeral range macOS hands out:

```
leader-lock.test.ts keys : 41000-61000
freePort() ephemeral     : 49152-65535
overlap                  : 49152-61000   (11,848 ports)
```

`election.test.ts`, `process-lifecycle.test.ts` and `mcp-wire.test.ts` all write **real** notes keyed by the ephemeral ports `freePort()` gives them, from other worker processes, concurrently — vitest parallelises by file. On a hit, `readLeaderLock` returned the other worker's note and `is undefined when there is no lock for that port` failed.

Reproduced by planting a foreign note at that key, which gave the exact observed signature:

```
Tests  1 failed | 39 passed (40)
AssertionError: expected { pid: 99999, port: 54325, …(3) } to be undefined
```

**Fixed in two layers**, both verified against that same planted collision (41/41 pass with foreign notes on the exact keys):

1. Keys move to `20_000` + a pid offset — below every platform's ephemeral floor (Linux 32768, macOS/Windows 49152) — with a new test pinning the invariant so it cannot be moved back silently.
2. The assertions that claim an *absence* now remove the file first, instead of assuming their key is untouched.

## Cause 2 — waiting for the first line of a multi-line diagnosis

Found by keeping the full output of 30 post-fix runs: one failed, and this time the log named the test.

```
FAIL  process lifecycle > a leader that holds the port but stops answering
AssertionError: expected '[node] became FOLLOWER…' to contain 'PORT CONFLICT'
```

`enterConflicted()` writes the SIGCONT line and *then* the PORT CONFLICT line, but the follower's stderr arrives in chunks. Waiting for the first and immediately asserting the second races the chunk boundary.

Measured rather than assumed: polling a real wedge as tightly as the event loop allows, the state "SIGCONT line present, PORT CONFLICT not yet" existed in **6 of 6 wedges**. The old assertion was betting on chunk timing every run and merely usually winning, since `waitFor` polls at 25ms and the window is normally shorter — consistent with a ~1-in-30 rate. All three lines are now waited for together.

## Why this took so long, and what was ruled out

Chasing *load* was the wrong instinct and cost the most time. Ruled out by measurement, not by argument:

- **Load** — 15 full-suite runs under six CPU burners: zero failures. Exactly what a key collision predicts; it does not care how busy the machine is.
- **A `freePort()` TOCTOU race** — the leading hypothesis, **disproved**: 4 concurrent workers, 3000 allocations, zero duplicate ports.
- **Timer races** — one real weakness was found and fixed in #159 (`dispatch`'s recovery-after-conflict test now runs on causal ordering), but it was not a cause here.

What actually worked was reasoning about *shared key spaces* — where two test files can name the same resource — and then keeping full logs rather than grep-filtered ones.

The timeline confirms both were real: the first failure of this kind predates the e2e test in Cause 2 existing at all.

## Class, not instance

Every other test that writes under `tmpdir()` uses `mkdtemp` (unique per call, race-free by construction), and the one fixed-path writer is env-guarded. `leader-lock.test.ts` was the only shared key space.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test` — 193 files / 1742 tests
- [x] Tests are added or updated for any behavior change
- [ ] Read-path / serializer changes verified live — n/a, test-only change
- [x] Documentation is updated if needed — n/a beyond the comments carrying the reasoning
