### PR TITLE
ci: split the gate into a lint job and an OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  # Platform-independent gates. None of these need a build: typecheck, lint, format and
+  # knip all run against source, which is why they ran before `pnpm build` before too.
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -36,22 +39,23 @@ jobs:
       - run: pnpm lint
       - run: pnpm format:check
       - run: pnpm knip
-      - run: pnpm build
-      - run: pnpm test
 
-  # The one platform no contributor here can run, and the only one where a whole feature is guarded
-  # off rather than exercised: `election/leader-lock.ts` cannot read the process table (no `ps`) and
-  # cannot resume a suspended holder (no SIGSTOP to be suspended by), so it never names a pid and
-  # never signals — Windows gets the platform-independent half (the election's consecutive-silence
-  # count and dispatch's fail-fast) and the anonymous message. Those guards are asserted by forcing
-  # `process.platform`, which proves the branching but not that Node's fs and process APIs behave as
-  # assumed underneath it. This job is the part a stub cannot stand in for.
-  #
-  # Deliberately NOT the whole gate: typecheck / lint / format:check / knip are platform-independent
-  # and already ran above, and a Windows runner bills at 2×. What differs across platforms is the
-  # filesystem, process spawning and path handling — which is `build` and `test`.
-  windows:
-    runs-on: windows-latest
+  # What actually differs across platforms is the filesystem, process spawning and path
+  # handling — so this is the half that gets a matrix. Windows is the one platform no
+  # contributor here can run, and the only one where a whole feature is guarded off rather
+  # than exercised: `election/leader-lock.ts` cannot read the process table (no `ps`) and
+  # cannot resume a suspended holder (no SIGSTOP to be suspended by), so it never names a
+  # pid and never signals. Those guards are asserted by forcing `process.platform`, which
+  # proves the branching but not that Node's fs and process APIs behave as assumed
+  # underneath it. A real runner is the part a stub cannot stand in for.
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      # One platform failing must not cancel the other — which one broke is the finding.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -66,7 +70,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Build first: the dist-backed e2e tests skip themselves when `dist` is missing, so an
-      # unbuilt run here would pass while proving nothing — the same trap the Linux job avoids.
+      # Build first: the dist-backed e2e tests skip themselves when `dist` is missing, so
+      # an unbuilt run would pass while proving nothing.
       - run: pnpm build
       - run: pnpm test


### PR DESCRIPTION
## Description

The Windows job added in #159 was a hand-copied duplicate of `check`, named after its runner rather than its purpose, and the two jobs disagreed about what they were for: one ran the whole gate plus build and test, the other a silent subset guarded by a ten-line comment arguing why.

This splits CI **by purpose instead of by platform**:

| job | runs-on | runs |
| --- | --- | --- |
| `lint` | `ubuntu-latest` | `typecheck`, `lint`, `format:check`, `knip` |
| `test` | `${{ matrix.os }}` → `ubuntu-latest`, `windows-latest` | `build`, `test` |

Once the platform-independent gates live in their own job, "Windows deliberately runs less" stops being a special case that needs explaining — both matrix legs run exactly the same steps.

### Why this shape

I sampled the workflow files of 40 well-known Node/TS repositories (vite, vitest, rollup, rolldown, oxc, biome, prettier, eslint, pnpm, npm/cli, yarn, vue, svelte, kit, astro, nuxt, next, react-router, storybook, playwright, TypeScript, undici, nitro, changesets, turborepo, jest, webpack, zod, fastify, axios, execa, mcp typescript-sdk, gh cli, deno, nx, tailwindcss, ni, typescript-eslint, express, lodash):

- 31 test on Windows. **25 express it as a matrix over `os`** with Linux as the base; 8 keep a dedicated Windows job (vuejs/core, oxc, rolldown, deno, jest); 5 pass the OS into a reusable workflow.
- Job ids: **`test` appears in 20 repos, `lint` in 17** — the two most common by a wide margin. `lint` is the conventional umbrella name for the static gates even when the job also typechecks and formats (vite and vitest both do exactly that).
- Repeating the checkout/pnpm/setup-node preamble per job is the majority idiom — only 5 of 17 comparable repos factor it into a composite action — so it is left duplicated here rather than abstracted.

### Also fixed

- **Removed the claim that a Windows runner bills at 2x.** This repository is public, and [standard GitHub-hosted runners are free for public repositories](https://docs.github.com/en/billing/concepts/product-billing/github-actions); the 2x/10x multipliers only draw down private-repo minutes. The real cost of the Windows leg is wall clock: measured over the last 15 runs it takes ~102s (85-111s) against ~70s (56-89s) for Linux, so it sets the critical path.
- **Added `timeout-minutes`** (10 / 15). Neither job had one. This suite spawns processes and races for a port, so a hung run would have burned the 360-minute default.
- **`fail-fast: false`**, so one platform failing does not cancel the other — which of the two broke is the finding.

### Considered and rejected

- **`ubuntu-24.04-arm`** — technically viable (all 18 native binding packages in the lockfile ship `linux-arm64-gnu`) and free on public repos, but it saves nothing: total CI wall clock is bounded by the Windows leg, not the Linux one. It would also mean pinning a version manually, since there is no `ubuntu-latest-arm` alias.
- **`ubuntu-slim`** — 1 vCPU / 5 GB, container rather than VM, unprivileged, 15-minute job cap, and documented as "not suitable for typical heavyweight CI/CD builds". The repos that use it (vite, vitest, typescript-eslint, TypeScript) reserve it for changed-file gates, spell checks and status aggregation. The three small workflows here already finish in 4-15s, and `actionlint` could not move there anyway — it runs a `docker://` container action, which unprivileged containers do not support.
- **`macos-latest`** — the maintainer develops on macOS, so it is continuously exercised by hand; Windows is the platform no contributor here can run. Worth revisiting if a compiled binary release ever needs to be produced on macOS.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test`
- [x] Tests are added or updated for any behavior change — n/a, this changes only workflow configuration; `actionlint` passes on all five workflows
- [x] Read-path / serializer changes are verified with a live round-trip — n/a, no source changes
- [x] Documentation is updated if needed — n/a, no documented behavior changes