### PR TITLE
fix: load a text style's font before writing it, and let its typography bind to variables

### DIFF
--- a/packages/mcp/src/tools/binding-schema.ts
+++ b/packages/mcp/src/tools/binding-schema.ts
@@ -18,3 +18,18 @@ export const boundVariablesSchema = z
       'instead of the literal next to it. Omit to leave the value unbound: writing without it ' +
       'CLEARS any binding the object had.',
   );
+
+/**
+ * The same thing for a text style, whose typography values are scalars — there is no per-object
+ * level to hang them on, so the style itself carries them. This one accepts null because a text
+ * style write is a PATCH (omitted fields stay as they were), so unbinding has to be sayable;
+ * `set_text_range` takes the same shape for the same reason.
+ */
+export const textStyleBindingsSchema = z
+  .record(z.string(), z.union([z.string(), z.null()]))
+  .describe(
+    'Typography bindings as { field: variableId }: fontSize / lineHeight / letterSpacing / ' +
+      'paragraphSpacing / paragraphIndent take a FLOAT variable, fontFamily / fontStyle a STRING ' +
+      'one, fontWeight a FLOAT. Pass null for a field to unbind it; omit a field to leave it as it ' +
+      'is. A bound field wins over a literal passed for the same field in this call.',
+  );

--- a/packages/mcp/src/tools/create-text-style.ts
+++ b/packages/mcp/src/tools/create-text-style.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { textStyleBindingsSchema } from './binding-schema.js';
 import type { ToolSpec } from './spec.js';
 
 export const CREATE_TEXT_STYLE_TOOL_NAME = 'create_text_style';
@@ -26,6 +27,7 @@ export const createTextStyleTool: ToolSpec = {
       .describe(
         'Line-break balancing every node bound to this style inherits; maps 1:1 to CSS text-wrap',
       ),
+    boundVariables: textStyleBindingsSchema.optional(),
     description: z.string().optional(),
   }),
   kind: 'write',

--- a/packages/mcp/src/tools/update-text-style.ts
+++ b/packages/mcp/src/tools/update-text-style.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { textStyleBindingsSchema } from './binding-schema.js';
 import type { ToolSpec } from './spec.js';
 
 export const UPDATE_TEXT_STYLE_TOOL_NAME = 'update_text_style';
@@ -27,6 +28,7 @@ export const updateTextStyleTool: ToolSpec = {
       .describe(
         'Line-break balancing every node bound to this style inherits; maps 1:1 to CSS text-wrap',
       ),
+    boundVariables: textStyleBindingsSchema.optional(),
     description: z.string().optional(),
   }),
   kind: 'write',

--- a/packages/mcp/test/plugin-contract.json
+++ b/packages/mcp/test/plugin-contract.json
@@ -273,6 +273,7 @@
       "requestId"
     ],
     "create_text_style": [
+      "boundVariables",
       "description",
       "fontName",
       "fontName.family",
@@ -346,6 +347,7 @@
       "styleId"
     ],
     "update_text_style": [
+      "boundVariables",
       "description",
       "fontName",
       "fontName.family",

--- a/packages/plugin/src/handlers/bindings.ts
+++ b/packages/plugin/src/handlers/bindings.ts
@@ -41,7 +41,7 @@ const idsIn = (sources: readonly unknown[]): string[] =>
  * this for us on the literal path: an unknown id is stored as-is and the value renders white, which
  * is exactly the silent breakage this turns into an error.
  */
-const resolveVariables = async (
+export const resolveVariables = async (
   figmaCtx: typeof figma,
   ids: readonly string[],
   where: string,
@@ -59,7 +59,7 @@ const resolveVariables = async (
   return table;
 };
 
-const variableFor = (table: ReadonlyMap<string, Variable>, id: string): Variable =>
+export const variableFor = (table: ReadonlyMap<string, Variable>, id: string): Variable =>
   table.get(id) as Variable;
 
 /**
@@ -160,4 +160,104 @@ export const toFigmaLayoutGridsBound = async (
     }
     return grid;
   });
+};
+
+/**
+ * A text style's bindings on the way IN. Unlike paints and effects — whole arrays that Figma
+ * replaces, so omitting a binding clears it — a text style write is a patch: fields left out stay
+ * as they were. Unbinding therefore needs to be sayable, and `null` says it, the same shape
+ * set_text_range already uses for a run's bindings.
+ */
+export type TextStyleBindings = Record<string, string | null>;
+
+/**
+ * Resolve a text style's bindings without touching a style. Split out so create_text_style can do
+ * it BEFORE `createTextStyle()` — an id that matches nothing then fails with no style to clean up.
+ */
+export const resolveTextStyleBindings = async (
+  figmaCtx: typeof figma,
+  bindings: TextStyleBindings,
+  where: string,
+): Promise<ReadonlyMap<string, Variable>> =>
+  resolveVariables(
+    figmaCtx,
+    Object.values(bindings).filter((id): id is string => typeof id === 'string'),
+    where,
+  );
+
+/** Fields whose binding changes which font face the style resolves to. */
+const FONT_FIELDS = new Set(['fontFamily', 'fontStyle', 'fontWeight']);
+
+/** Every string a variable can resolve to, across its modes — the font names a binding may need. */
+const stringValues = (variable: Variable): string[] => {
+  const out = new Set<string>();
+  for (const value of Object.values(variable.valuesByMode)) {
+    if (typeof value === 'string') out.add(value);
+  }
+  return [...out];
+};
+
+/**
+ * Load every face a set of bindings could resolve to, best effort.
+ *
+ * Binding `fontFamily` throws `unloaded font "<family> <style>"` unless that face is already loaded
+ * — measured; the numeric fields (fontSize / lineHeight / letterSpacing / paragraph*) need no load
+ * at all. The set is walked as a chain in the order the bindings are applied below, so a family
+ * swap followed by a style swap loads the face each step lands on.
+ *
+ * Failures are swallowed on purpose. A face this guesses at may simply not exist (a family from one
+ * mode paired with a style from another never co-occurs), and rejecting the write for that would
+ * fail a binding Figma would have accepted. Anything genuinely missing still surfaces —
+ * `setBoundVariable` throws naming the exact face, which is a better error than one this could
+ * invent.
+ */
+const preloadFaces = async (
+  figmaCtx: typeof figma,
+  current: FontName,
+  bindings: TextStyleBindings,
+  table: ReadonlyMap<string, Variable>,
+): Promise<void> => {
+  const familyId = bindings.fontFamily;
+  const styleId = bindings.fontStyle;
+  const families =
+    typeof familyId === 'string' ? stringValues(variableFor(table, familyId)) : [current.family];
+  const styles =
+    typeof styleId === 'string' ? stringValues(variableFor(table, styleId)) : [current.style];
+  const faces: FontName[] = [];
+  for (const family of families) {
+    // The face the family swap lands on before the style swap runs, then the final one.
+    faces.push({ family, style: current.style });
+    for (const style of styles) faces.push({ family, style });
+  }
+  await Promise.all(faces.map(async face => figmaCtx.loadFontAsync(face).catch(() => undefined)));
+};
+
+/**
+ * Apply a text style's variable bindings. Typography values are scalars, so unlike a paint or an
+ * effect there is no per-object level to hang these on — the style itself is where they live.
+ *
+ * Ordered family → style → weight → everything else so the font-affecting swaps happen against a
+ * face that was preloaded for exactly that step. The variable table is resolved separately (see
+ * {@link resolveTextStyleBindings}) so a caller can fail on an unknown id before it creates anything
+ * — the resolution needs no style, only the font preload does.
+ */
+export const applyTextStyleBindings = async (
+  figmaCtx: typeof figma,
+  style: TextStyle,
+  bindings: TextStyleBindings,
+  table: ReadonlyMap<string, Variable>,
+): Promise<void> => {
+  await preloadFaces(figmaCtx, style.fontName, bindings, table);
+
+  const ordered = Object.entries(bindings).toSorted(([a], [b]) => {
+    const rank = (field: string): number =>
+      field === 'fontFamily' ? 0 : field === 'fontStyle' ? 1 : FONT_FIELDS.has(field) ? 2 : 3;
+    return rank(a) - rank(b);
+  });
+  for (const [field, id] of ordered) {
+    style.setBoundVariable(
+      field as VariableBindableTextField,
+      id === null ? null : variableFor(table, id),
+    );
+  }
 };

--- a/packages/plugin/src/handlers/create-text-style.ts
+++ b/packages/plugin/src/handlers/create-text-style.ts
@@ -6,6 +6,11 @@ import type {
 } from '@figwright/shared';
 
 import type { SandboxToolHandler } from '../dispatcher.js';
+import {
+  applyTextStyleBindings,
+  resolveTextStyleBindings,
+  type TextStyleBindings,
+} from './bindings.js';
 import { toFigmaLineHeight } from './convert.js';
 
 export const createCreateTextStyleHandler =
@@ -18,15 +23,22 @@ export const createCreateTextStyleHandler =
       lineHeight?: unknown;
       letterSpacing?: unknown;
       textWrapStyle?: unknown;
+      boundVariables?: unknown;
       description?: unknown;
     };
     if (typeof p.name !== 'string') throw new TypeError('create_text_style: name must be a string');
 
-    // Load the requested font BEFORE creating anything. It is the only step here that can fail on
-    // caller input — a family/style the user does not have installed — and creating first would
-    // leave an orphan style behind in the document's style panel (and in whatever it publishes to)
-    // with no way to reach it from the failed call. Every sibling create_* handler validates before
-    // it mutates; this is the same rule, applied to the one check that happens to be async.
+    // Everything that can fail on caller input happens BEFORE anything is created. Creating first
+    // would leave an orphan style behind in the document's style panel (and in whatever it
+    // publishes to) with no way to reach it from the failed call. Every sibling create_* handler
+    // validates before it mutates; these are the same rule applied to the two checks that happen
+    // to be async — a variable id that matches nothing, and a font the user has not installed.
+    const bindings = p.boundVariables as TextStyleBindings | undefined;
+    const table =
+      bindings === undefined
+        ? undefined
+        : await resolveTextStyleBindings(figmaCtx, bindings, 'create_text_style');
+
     let fontName: FontName | undefined;
     if (p.fontName !== undefined) {
       const fn = p.fontName as SerializedFontName;
@@ -35,25 +47,35 @@ export const createCreateTextStyleHandler =
     }
 
     const style = figmaCtx.createTextStyle();
-    style.name = p.name;
-    if (fontName !== undefined) style.fontName = fontName;
-    // Every typography write below needs the style's own face loaded — Figma rejects them with
-    // `Cannot write to node with unloaded font` otherwise, and a style the plugin did not put a
-    // font on has none loaded. This load cannot fail on caller input: the face is either the one
-    // hoisted above or Figma's own default for a fresh style, so it stays out of the pre-creation
-    // validation above.
-    await figmaCtx.loadFontAsync(style.fontName);
-    if (typeof p.fontSize === 'number') style.fontSize = p.fontSize;
-    if (p.lineHeight !== undefined)
-      style.lineHeight = toFigmaLineHeight(p.lineHeight as SerializedLineHeight);
-    if (p.letterSpacing !== undefined) {
-      const ls = p.letterSpacing as SerializedLetterSpacing;
-      style.letterSpacing = { unit: ls.unit as 'PIXELS' | 'PERCENT', value: ls.value };
+    try {
+      style.name = p.name;
+      if (fontName !== undefined) style.fontName = fontName;
+      // Every typography write below needs the style's own face loaded — Figma rejects them with
+      // `Cannot write to node with unloaded font` otherwise, and a style the plugin did not put a
+      // font on has none loaded. This load cannot fail on caller input: the face is either the one
+      // hoisted above or Figma's own default for a fresh style.
+      await figmaCtx.loadFontAsync(style.fontName);
+      if (typeof p.fontSize === 'number') style.fontSize = p.fontSize;
+      if (p.lineHeight !== undefined)
+        style.lineHeight = toFigmaLineHeight(p.lineHeight as SerializedLineHeight);
+      if (p.letterSpacing !== undefined) {
+        const ls = p.letterSpacing as SerializedLetterSpacing;
+        style.letterSpacing = { unit: ls.unit as 'PIXELS' | 'PERCENT', value: ls.value };
+      }
+      if (typeof p.textWrapStyle === 'string') {
+        style.textWrapStyle = p.textWrapStyle as TextStyle['textWrapStyle'];
+      }
+      if (typeof p.description === 'string') style.description = p.description;
+      if (bindings !== undefined && table !== undefined) {
+        await applyTextStyleBindings(figmaCtx, style, bindings, table);
+      }
+    } catch (error) {
+      // What is left after both hoists: a binding's target FACE is only computable once the
+      // style's base face is known, and that is only after creation when fontName was omitted. So
+      // that one orphan is undone instead of prevented — the same outcome, by the only route left.
+      style.remove();
+      throw error;
     }
-    if (typeof p.textWrapStyle === 'string') {
-      style.textWrapStyle = p.textWrapStyle as TextStyle['textWrapStyle'];
-    }
-    if (typeof p.description === 'string') style.description = p.description;
 
     const result: StyleResult = { ok: true, styleId: style.id, name: style.name };
     return result;

--- a/packages/plugin/src/handlers/create-text-style.ts
+++ b/packages/plugin/src/handlers/create-text-style.ts
@@ -37,6 +37,12 @@ export const createCreateTextStyleHandler =
     const style = figmaCtx.createTextStyle();
     style.name = p.name;
     if (fontName !== undefined) style.fontName = fontName;
+    // Every typography write below needs the style's own face loaded — Figma rejects them with
+    // `Cannot write to node with unloaded font` otherwise, and a style the plugin did not put a
+    // font on has none loaded. This load cannot fail on caller input: the face is either the one
+    // hoisted above or Figma's own default for a fresh style, so it stays out of the pre-creation
+    // validation above.
+    await figmaCtx.loadFontAsync(style.fontName);
     if (typeof p.fontSize === 'number') style.fontSize = p.fontSize;
     if (p.lineHeight !== undefined)
       style.lineHeight = toFigmaLineHeight(p.lineHeight as SerializedLineHeight);
@@ -44,13 +50,7 @@ export const createCreateTextStyleHandler =
       const ls = p.letterSpacing as SerializedLetterSpacing;
       style.letterSpacing = { unit: ls.unit as 'PIXELS' | 'PERCENT', value: ls.value };
     }
-    // Needs the font loaded (it writes through to the style's text runs), unlike the numeric fields
-    // above. This one has to run after creation: with fontName omitted the face is whatever default
-    // Figma put on the fresh style, which is not knowable beforehand. Acceptable where the hoisted
-    // load is not — that default is Figma's own bundled face, not caller input, so it does not fail
-    // on a bad argument.
     if (typeof p.textWrapStyle === 'string') {
-      await figmaCtx.loadFontAsync(style.fontName);
       style.textWrapStyle = p.textWrapStyle as TextStyle['textWrapStyle'];
     }
     if (typeof p.description === 'string') style.description = p.description;

--- a/packages/plugin/src/handlers/update-text-style.ts
+++ b/packages/plugin/src/handlers/update-text-style.ts
@@ -6,6 +6,11 @@ import type {
 } from '@figwright/shared';
 
 import type { SandboxToolHandler } from '../dispatcher.js';
+import {
+  applyTextStyleBindings,
+  resolveTextStyleBindings,
+  type TextStyleBindings,
+} from './bindings.js';
 import { toFigmaLineHeight } from './convert.js';
 
 export const createUpdateTextStyleHandler =
@@ -19,6 +24,7 @@ export const createUpdateTextStyleHandler =
       lineHeight?: unknown;
       letterSpacing?: unknown;
       textWrapStyle?: unknown;
+      boundVariables?: unknown;
       description?: unknown;
     };
     if (typeof p.styleId !== 'string') {
@@ -55,6 +61,12 @@ export const createUpdateTextStyleHandler =
       ts.textWrapStyle = p.textWrapStyle as TextStyle['textWrapStyle'];
     }
     if (typeof p.description === 'string') ts.description = p.description;
+    // Last, so a bound field wins over a literal set for the same field above.
+    if (p.boundVariables !== undefined) {
+      const bindings = p.boundVariables as TextStyleBindings;
+      const table = await resolveTextStyleBindings(figmaCtx, bindings, 'update_text_style');
+      await applyTextStyleBindings(figmaCtx, ts, bindings, table);
+    }
 
     const result: StyleResult = { ok: true, styleId: ts.id, name: ts.name };
     return result;

--- a/packages/plugin/src/handlers/update-text-style.ts
+++ b/packages/plugin/src/handlers/update-text-style.ts
@@ -31,13 +31,19 @@ export const createUpdateTextStyleHandler =
     }
     const ts = style as TextStyle;
     if (typeof p.name === 'string') ts.name = p.name;
-    // A new fontName must be loaded before assignment (Figma throws otherwise). Numeric fields
-    // (fontSize / lineHeight / letterSpacing) don't need a load — they don't touch the glyph set.
+    // A new fontName must be loaded before assignment (Figma throws otherwise).
     if (p.fontName !== undefined) {
       const fn = p.fontName as SerializedFontName;
       await figmaCtx.loadFontAsync({ family: fn.family, style: fn.style });
       ts.fontName = { family: fn.family, style: fn.style };
     }
+    // So must the style's CURRENT face, before any typography write — fontSize / lineHeight /
+    // letterSpacing / textWrapStyle all write through to the style's text runs, and Figma rejects
+    // each with `Cannot write to node with unloaded font` against a face this session never
+    // loaded. That is most styles: nothing loads a font just by reading it, so before this an
+    // update that touched only fontSize failed on any style the caller had not also re-fonted.
+    // loadFontAsync is cached, so repeating it after the assignment above is free.
+    await figmaCtx.loadFontAsync(ts.fontName);
     if (typeof p.fontSize === 'number') ts.fontSize = p.fontSize;
     if (p.lineHeight !== undefined)
       ts.lineHeight = toFigmaLineHeight(p.lineHeight as SerializedLineHeight);
@@ -45,12 +51,7 @@ export const createUpdateTextStyleHandler =
       const ls = p.letterSpacing as SerializedLetterSpacing;
       ts.letterSpacing = { unit: ls.unit as 'PIXELS' | 'PERCENT', value: ls.value };
     }
-    // Unlike fontSize / lineHeight / letterSpacing, this one *does* need the font loaded — it
-    // writes through to the style's text runs, so Figma rejects it against an unloaded font even
-    // when the font itself is not changing. Load the style's current font (already the new one if
-    // fontName was assigned above; loadFontAsync is cached, so the repeat is free).
     if (typeof p.textWrapStyle === 'string') {
-      await figmaCtx.loadFontAsync(ts.fontName);
       ts.textWrapStyle = p.textWrapStyle as TextStyle['textWrapStyle'];
     }
     if (typeof p.description === 'string') ts.description = p.description;

--- a/packages/plugin/test/handlers/create-text-style.test.ts
+++ b/packages/plugin/test/handlers/create-text-style.test.ts
@@ -38,7 +38,13 @@ describe('create_text_style handler', () => {
       letterSpacing: { unit: 'PIXELS', value: 0 },
     })) as StyleResult;
 
-    expect(loaded).toEqual([{ family: 'Inter', style: 'Bold' }]);
+    // Twice: hoisted before creation (a font the user may not have is the one caller-input
+    // failure here), then again as the style's own face, which every typography write below needs
+    // loaded. loadFontAsync is cached, so the repeat costs nothing.
+    expect(loaded).toEqual([
+      { family: 'Inter', style: 'Bold' },
+      { family: 'Inter', style: 'Bold' },
+    ]);
     expect(style.fontName).toEqual({ family: 'Inter', style: 'Bold' });
     expect(style.fontSize).toBe(32);
     expect(style.lineHeight).toEqual({ unit: 'PERCENT', value: 120 });

--- a/packages/plugin/test/handlers/create-text-style.test.ts
+++ b/packages/plugin/test/handlers/create-text-style.test.ts
@@ -7,23 +7,38 @@ import { createCreateTextStyleHandler } from '../../src/handlers/create-text-sty
  * `missingFont` makes loadFontAsync reject for that family, the way Figma does for a font the user
  * has not installed — the one failure in this handler that caller input can cause.
  */
-const fakeFigma = ({ missingFont }: { missingFont?: string } = {}): {
+const fakeFigma = (
+  { missingFont }: { missingFont?: string } = {},
+  variables: Record<string, unknown> = {},
+): {
   figma: typeof figma;
   loaded: FontName[];
   style: Record<string, unknown>;
   createTextStyle: ReturnType<typeof vi.fn<() => Record<string, unknown>>>;
+  bound: [string, unknown][];
+  removed: () => number;
 } => {
   const loaded: FontName[] = [];
-  const style: Record<string, unknown> = { id: 'S:0', name: '' };
+  const bound: [string, unknown][] = [];
+  let removed = 0;
+  const style: Record<string, unknown> = {
+    id: 'S:0',
+    name: '',
+    setBoundVariable: (field: string, variable: unknown) => bound.push([field, variable]),
+    remove: () => {
+      removed += 1;
+    },
+  };
   const createTextStyle = vi.fn<() => Record<string, unknown>>(() => style);
   const figmaCtx = {
     createTextStyle,
+    variables: { getVariableByIdAsync: async (id: string) => variables[id] ?? null },
     loadFontAsync: vi.fn<(fn: FontName) => Promise<void>>(async (fn: FontName) => {
       if (fn.family === missingFont) throw new Error(`Cannot find font ${fn.family}`);
       loaded.push(fn);
     }),
   } as unknown as typeof figma;
-  return { figma: figmaCtx, loaded, style, createTextStyle };
+  return { figma: figmaCtx, loaded, style, createTextStyle, bound, removed: () => removed };
 };
 
 describe('create_text_style handler', () => {
@@ -81,5 +96,66 @@ describe('create_text_style handler', () => {
     const { figma: f } = fakeFigma();
     const handler = createCreateTextStyleHandler(f);
     await expect(handler({ fontSize: 12 })).rejects.toThrow(/name/);
+  });
+
+  // Typography values are scalars, so a text style is the only place its bindings can live — there
+  // is no per-paint level like a fill has (issue #164).
+  it('binds typography fields on the created style', async () => {
+    const variable = { id: 'V:1', name: 'size/lg', resolvedType: 'FLOAT', valuesByMode: {} };
+    const { figma: f, bound } = fakeFigma({}, { 'V:1': variable });
+    await createCreateTextStyleHandler(f)({
+      name: 'Heading/H1',
+      fontName: { family: 'Inter', style: 'Bold' },
+      boundVariables: { fontSize: 'V:1' },
+    });
+    expect(bound).toEqual([['fontSize', variable]]);
+  });
+
+  // The one failure that cannot be hoisted ahead of creation: a binding's target face is only
+  // computable once the style's base face is, which is after creation when fontName is omitted.
+  // So the orphan gets undone rather than prevented — a style left in the panel would still be
+  // published to the library from there.
+  it('creates nothing when a binding cannot be resolved', async () => {
+    const { figma: f, createTextStyle } = fakeFigma();
+    await expect(
+      createCreateTextStyleHandler(f)({
+        name: 'Heading/H1',
+        boundVariables: { fontSize: 'V:gone' },
+      }),
+    ).rejects.toThrow('create_text_style: variable V:gone not found');
+    expect(createTextStyle).not.toHaveBeenCalled();
+  });
+
+  // What the resolution hoist above cannot cover: the face a binding lands on is only computable
+  // once the style's base face is, i.e. after creation when fontName was omitted. A style left in
+  // the panel would still be published to the library from there, so it gets undone.
+  it('removes the style it created when the binding itself fails', async () => {
+    const variable = { id: 'V:1', name: 'size/lg', resolvedType: 'FLOAT', valuesByMode: {} };
+    const { figma: f, style, removed } = fakeFigma({}, { 'V:1': variable });
+    style.fontName = { family: 'Inter', style: 'Regular' };
+    style.setBoundVariable = () => {
+      throw new Error('in setBoundVariable: unloaded font "Roboto Bold"');
+    };
+    await expect(
+      createCreateTextStyleHandler(f)({ name: 'Heading/H1', boundVariables: { fontSize: 'V:1' } }),
+    ).rejects.toThrow('unloaded font');
+    expect(removed()).toBe(1);
+  });
+
+  it('loads the face a fontFamily binding will resolve to before binding it', async () => {
+    const variable = {
+      id: 'V:f',
+      name: 'font/family',
+      resolvedType: 'STRING',
+      valuesByMode: { m1: 'Roboto' },
+    };
+    const { figma: f, loaded, style } = fakeFigma({}, { 'V:f': variable });
+    style.fontName = { family: 'Inter', style: 'Regular' };
+    await createCreateTextStyleHandler(f)({
+      name: 'Heading/H1',
+      boundVariables: { fontFamily: 'V:f' },
+    });
+    // Live Figma answers `unloaded font "Roboto Regular"` without this.
+    expect(loaded).toContainEqual({ family: 'Roboto', style: 'Regular' });
   });
 });

--- a/packages/plugin/test/handlers/update-text-style.test.ts
+++ b/packages/plugin/test/handlers/update-text-style.test.ts
@@ -5,15 +5,21 @@ import { createUpdateTextStyleHandler } from '../../src/handlers/update-text-sty
 
 const fakeFigma = (
   style: Record<string, unknown> | null,
-): { figma: typeof figma; loaded: FontName[] } => {
+  variables: Record<string, unknown> = {},
+): { figma: typeof figma; loaded: FontName[]; bound: [string, unknown][] } => {
   const loaded: FontName[] = [];
+  const bound: [string, unknown][] = [];
+  if (style !== null) {
+    style.setBoundVariable = (field: string, variable: unknown) => bound.push([field, variable]);
+  }
   const figmaCtx = {
     getStyleByIdAsync: async () => style,
+    variables: { getVariableByIdAsync: async (id: string) => variables[id] ?? null },
     loadFontAsync: vi.fn<(fn: FontName) => Promise<void>>(async (fn: FontName) => {
       loaded.push(fn);
     }),
   } as unknown as typeof figma;
-  return { figma: figmaCtx, loaded };
+  return { figma: figmaCtx, loaded, bound };
 };
 
 describe('update_text_style handler', () => {
@@ -102,5 +108,59 @@ describe('update_text_style handler', () => {
     await expect(createUpdateTextStyleHandler(fakeFigma(null).figma)({})).rejects.toThrow(
       /styleId/,
     );
+  });
+
+  it('binds typography fields, and unbinds one passed as null', async () => {
+    const variable = { id: 'V:1', name: 'size/lg', resolvedType: 'FLOAT', valuesByMode: {} };
+    const style: Record<string, unknown> = {
+      id: 'S:0',
+      type: 'TEXT',
+      name: 'Body',
+      fontName: { family: 'Inter', style: 'Regular' },
+    };
+    const { figma: f, bound } = fakeFigma(style, { 'V:1': variable });
+    await createUpdateTextStyleHandler(f)({
+      styleId: 'S:0',
+      boundVariables: { fontSize: 'V:1', lineHeight: null },
+    });
+    // A text style write is a patch, so omission cannot mean "unbind" the way it does for the
+    // whole-array paints and effects — null is how a caller says it.
+    expect(bound).toEqual([
+      ['fontSize', variable],
+      ['lineHeight', null],
+    ]);
+  });
+
+  it('applies bindings after literals, so a bound field wins over one set in the same call', async () => {
+    const variable = { id: 'V:1', name: 'size/lg', resolvedType: 'FLOAT', valuesByMode: {} };
+    const style: Record<string, unknown> = {
+      id: 'S:0',
+      type: 'TEXT',
+      name: 'Body',
+      fontName: { family: 'Inter', style: 'Regular' },
+      fontSize: 12,
+    };
+    const { figma: f, bound } = fakeFigma(style, { 'V:1': variable });
+    await createUpdateTextStyleHandler(f)({
+      styleId: 'S:0',
+      fontSize: 99,
+      boundVariables: { fontSize: 'V:1' },
+    });
+    expect(style.fontSize).toBe(99); // the literal landed first…
+    expect(bound).toEqual([['fontSize', variable]]); // …and the binding then took over the field
+  });
+
+  it('leaves the style untouched when a binding cannot be resolved', async () => {
+    const style: Record<string, unknown> = {
+      id: 'S:0',
+      type: 'TEXT',
+      name: 'Body',
+      fontName: { family: 'Inter', style: 'Regular' },
+    };
+    const { figma: f, bound } = fakeFigma(style);
+    await expect(
+      createUpdateTextStyleHandler(f)({ styleId: 'S:0', boundVariables: { fontSize: 'V:gone' } }),
+    ).rejects.toThrow('update_text_style: variable V:gone not found');
+    expect(bound).toEqual([]);
   });
 });

--- a/packages/plugin/test/handlers/update-text-style.test.ts
+++ b/packages/plugin/test/handlers/update-text-style.test.ts
@@ -37,7 +37,12 @@ describe('update_text_style handler', () => {
       lineHeight: { unit: 'PERCENT', value: 120 },
     })) as StyleResult;
 
-    expect(loaded).toEqual([{ family: 'Inter', style: 'Bold' }]); // new font loaded before assign
+    // The new font before assigning it, then the style's now-current face before the typography
+    // writes. loadFontAsync is cached, so the repeat is free.
+    expect(loaded).toEqual([
+      { family: 'Inter', style: 'Bold' },
+      { family: 'Inter', style: 'Bold' },
+    ]);
     expect(style.name).toBe('Heading/H1');
     expect(style.fontName).toEqual({ family: 'Inter', style: 'Bold' });
     expect(style.fontSize).toBe(32);
@@ -66,11 +71,22 @@ describe('update_text_style handler', () => {
     expect(style.textWrapStyle).toBe('PRETTY'); // omitted → unchanged
   });
 
-  it('does not load a font for a numeric-only update (fontName omitted)', async () => {
-    const style: Record<string, unknown> = { id: 'S:0', type: 'TEXT', name: 'x', fontSize: 12 };
+  // This test used to assert the opposite — that a size-only update loads nothing, on the
+  // reasoning that changing a number "touches no glyphs". Live Figma disagrees: it answers
+  // `in set_fontSize: Cannot write to node with unloaded font "Inter Regular"`. Since nothing
+  // loads a font just by reading a style, that made update_text_style fail on any style the caller
+  // had not also re-fonted in the same session — which is most of them.
+  it("loads the style's own font even for a numeric-only update (fontName omitted)", async () => {
+    const style: Record<string, unknown> = {
+      id: 'S:0',
+      type: 'TEXT',
+      name: 'x',
+      fontName: { family: 'Inter', style: 'Regular' },
+      fontSize: 12,
+    };
     const { figma: f, loaded } = fakeFigma(style);
     await createUpdateTextStyleHandler(f)({ styleId: 'S:0', fontSize: 16 });
-    expect(loaded).toEqual([]); // a size-only change touches no glyphs → no font work
+    expect(loaded).toEqual([{ family: 'Inter', style: 'Regular' }]);
     expect(style.fontSize).toBe(16);
   });
 

--- a/skills/figma-build/references/author-design-system.md
+++ b/skills/figma-build/references/author-design-system.md
@@ -76,6 +76,14 @@ on a shadow, `sectionSize` / `count` / `offset` / `gutterSize` on a grid. A bind
 id does not resolve is an error, not a silent miss, so a stale id fails loudly instead of painting
 the value white.
 
+A **text style** binds the same way, on `create_text_style` / `update_text_style` — `fontSize`,
+`lineHeight`, `letterSpacing`, `paragraphSpacing` and `paragraphIndent` to a FLOAT variable,
+`fontFamily` / `fontStyle` to a STRING one — which is how a type ramp step tracks the size and
+weight tokens instead of restating them. Two differences from the paints and effects above, both
+because a text style write is a **patch** rather than a whole-array replacement: omitting a field
+leaves it as it was (it does not unbind), so pass `null` to unbind one; and a bound field wins over
+a literal passed for that same field in the same call, so send one or the other, not both.
+
 ## Components & variant sets
 
 1. **`create_component`** — a reusable main component (size/name/position). Build its internals like


### PR DESCRIPTION
The last shape #164 exposed on read but could not write back — and, found while measuring it, a
bug that had nothing to do with bindings.

## The bug found on the way

`update_text_style` with nothing but a `fontSize` fails:

```
in set_fontSize: Cannot write to node with unloaded font "Inter Regular".
```

So does `lineHeight`, and so does `letterSpacing`. Reading a style does not load its font, and
these handlers only loaded one when the call also passed `fontName` — so updating a size on any
style the caller had not also re-fonted in the same session simply failed. That is most styles.

`create_text_style` had the same hole with a worse ending: it wrote *after* creating, so the throw
left an orphan style behind in the design-system panel — reproduced live, style intact in the file
with the default `fontSize: 12` it never got past.

Both fixed by loading the style's own face before any typography write. That load is hoisted to
just after creation, the earliest possible when `fontName` is omitted (the face is then whatever
default Figma put on the fresh style). Safe where the caller-input load is not: a default face
cannot fail on a bad argument.

The test that asserted the opposite went with it — it read *"a size-only change touches no glyphs
→ no font work"*, which is a plausible thing to believe and not what Figma does.

## Text-style bindings

`create_text_style` / `update_text_style` now take the same `boundVariables` `get_styles` reports.
A text style's values are scalars, so unlike a paint or an effect there is no per-object level to
hang them on — the style itself carries them.

Two differences from the paints and effects in #167, both because a text style write is a **patch**
rather than a whole-array replacement:

- **Omitting a field leaves it alone**; `null` is how a caller unbinds — the shape `set_text_range`
  already uses for a run's bindings.
- **Bindings apply after literals**, so a bound field wins over a literal passed for the same field
  in one call.

Binding a font field has a prerequisite the numeric ones do not — measured:

| bound field | needs a font loaded first? |
| --- | --- |
| `fontSize`, `lineHeight`, `letterSpacing`, `paragraphSpacing`, `paragraphIndent` | no |
| `fontFamily` | **yes** — `unloaded font "<family> <style>"` otherwise |
| `fontStyle`, `fontWeight` | not observed to, but same treatment |

So the faces are walked as a chain in the order the bindings apply — family swap, then style swap —
and preloaded best effort. Failures there are swallowed deliberately: a guessed face may not exist
(a family from one mode paired with a style from another never co-occurs), and rejecting the write
for that would fail a binding Figma would have taken. Anything genuinely missing still surfaces,
from Figma, naming the exact face.

Ids resolve **before** `createTextStyle()`, so an id matching no variable creates nothing at all.
What that cannot cover — the target face is only computable once the style's base face is, i.e.
after creation when `fontName` was omitted — is undone with a `remove()` instead.

## Measured limits

A multi-mode variable could not be tested: this account's plan caps a collection at one mode
(`in addMode: Limited to 1 modes only`). The preload takes every mode's value into account, so the
single-mode case is exact and the multi-mode one is covered by the best-effort pass rather than by
evidence.

## Verification

- **10 mutations** of the new logic, each confirmed to fail at least one test.
- **Live, end to end**: the `fontSize` + `lineHeight` + `letterSpacing` update that threw an hour
  earlier now succeeds; a `fontFamily` binding resolves the style's face to `Roboto Regular` with
  no `unloaded font`; a bound `fontSize` reads back as the variable's `42`; `null` removes one
  binding and leaves its sibling; and an unresolvable id fails with
  `create_text_style: variable VariableID:9999:9999 not found`, creating **nothing**.
- Every commit builds and passes the full suite on its own.
