### PR TITLE
test: measure the multi-mode font preload instead of arguing it

### DIFF
--- a/packages/plugin/src/handlers/bindings.ts
+++ b/packages/plugin/src/handlers/bindings.ts
@@ -205,11 +205,17 @@ const stringValues = (variable: Variable): string[] => {
  * at all. The set is walked as a chain in the order the bindings are applied below, so a family
  * swap followed by a style swap loads the face each step lands on.
  *
- * Failures are swallowed on purpose. A face this guesses at may simply not exist (a family from one
- * mode paired with a style from another never co-occurs), and rejecting the write for that would
- * fail a binding Figma would have accepted. Anything genuinely missing still surfaces —
- * `setBoundVariable` throws naming the exact face, which is a better error than one this could
+ * Swallowing the failures is load-bearing, not defensive. Measured on a multi-mode collection: only
+ * the face the style actually RESOLVES to has to be loadable — a variable whose non-default mode
+ * names a font nobody has installed still binds fine. So a face that fails to load here is usually
+ * one no mode will ever resolve (a family from one mode paired with a style from another), and
+ * treating that as an error would reject a binding Figma accepts. Anything genuinely missing still
+ * surfaces from `setBoundVariable`, naming the exact face — a better error than one this could
  * invent.
+ *
+ * Every mode's value is loaded rather than just the resolved one: which mode resolves is a property
+ * of the collection, not of the variable this can see, and the extra loads are parallel,
+ * deduplicated and cached.
  */
 const preloadFaces = async (
   figmaCtx: typeof figma,
@@ -223,13 +229,18 @@ const preloadFaces = async (
     typeof familyId === 'string' ? stringValues(variableFor(table, familyId)) : [current.family];
   const styles =
     typeof styleId === 'string' ? stringValues(variableFor(table, styleId)) : [current.style];
-  const faces: FontName[] = [];
+  // Keyed so the common case — a family binding with no style binding, where the intermediate and
+  // final faces are the same — asks for each face once.
+  const faces = new Map<string, FontName>();
   for (const family of families) {
     // The face the family swap lands on before the style swap runs, then the final one.
-    faces.push({ family, style: current.style });
-    for (const style of styles) faces.push({ family, style });
+    for (const style of [current.style, ...styles]) {
+      faces.set(`${family}\u0000${style}`, { family, style });
+    }
   }
-  await Promise.all(faces.map(async face => figmaCtx.loadFontAsync(face).catch(() => undefined)));
+  await Promise.all(
+    [...faces.values()].map(async face => figmaCtx.loadFontAsync(face).catch(() => undefined)),
+  );
 };
 
 /**

--- a/packages/plugin/test/handlers/create-text-style.test.ts
+++ b/packages/plugin/test/handlers/create-text-style.test.ts
@@ -158,4 +158,94 @@ describe('create_text_style handler', () => {
     // Live Figma answers `unloaded font "Roboto Regular"` without this.
     expect(loaded).toContainEqual({ family: 'Roboto', style: 'Regular' });
   });
+
+  // Measured on a multi-mode collection: only the face the style RESOLVES to must be loadable — a
+  // non-default mode naming a font nobody has still binds. Every mode's face is loaded anyway
+  // (which mode resolves is the collection's business, not the variable's), and a face that cannot
+  // load is skipped rather than failing the write.
+  it('loads every mode of a bound family, not just the first', async () => {
+    const variable = {
+      id: 'V:f',
+      name: 'font/family',
+      resolvedType: 'STRING',
+      valuesByMode: { m1: 'Roboto', m2: 'Lato' },
+    };
+    const { figma: f, loaded, style } = fakeFigma({}, { 'V:f': variable });
+    style.fontName = { family: 'Inter', style: 'Regular' };
+    await createCreateTextStyleHandler(f)({
+      name: 'Heading/H1',
+      boundVariables: { fontFamily: 'V:f' },
+    });
+    expect(loaded).toContainEqual({ family: 'Roboto', style: 'Regular' });
+    expect(loaded).toContainEqual({ family: 'Lato', style: 'Regular' });
+  });
+
+  it('binds anyway when a mode names a font that cannot load', async () => {
+    const variable = {
+      id: 'V:f',
+      name: 'font/family',
+      resolvedType: 'STRING',
+      valuesByMode: { m1: 'Roboto', m2: 'NoSuchFontFamilyXYZ' },
+    };
+    const {
+      figma: f,
+      loaded,
+      style,
+      bound,
+    } = fakeFigma({ missingFont: 'NoSuchFontFamilyXYZ' }, { 'V:f': variable });
+    style.fontName = { family: 'Inter', style: 'Regular' };
+    await createCreateTextStyleHandler(f)({
+      name: 'Heading/H1',
+      boundVariables: { fontFamily: 'V:f' },
+    });
+    expect(loaded).toContainEqual({ family: 'Roboto', style: 'Regular' });
+    expect(loaded).not.toContainEqual({ family: 'NoSuchFontFamilyXYZ', style: 'Regular' });
+    // Live Figma binds this: only the face the style resolves to has to exist. Letting the failed
+    // load through would reject a binding Figma accepts.
+    expect(bound).toEqual([['fontFamily', variable]]);
+  });
+
+  it('asks for each face once when the family swap and the final face coincide', async () => {
+    const variable = {
+      id: 'V:f',
+      name: 'font/family',
+      resolvedType: 'STRING',
+      valuesByMode: { m1: 'Roboto' },
+    };
+    const { figma: f, loaded, style } = fakeFigma({}, { 'V:f': variable });
+    style.fontName = { family: 'Inter', style: 'Regular' };
+    await createCreateTextStyleHandler(f)({
+      name: 'Heading/H1',
+      boundVariables: { fontFamily: 'V:f' },
+    });
+    // The style's own face (before creation writes) plus Roboto Regular — not Roboto twice.
+    expect(loaded.filter(fn => fn.family === 'Roboto')).toEqual([
+      { family: 'Roboto', style: 'Regular' },
+    ]);
+  });
+
+  it('walks family then style as a chain, loading the face each step lands on', async () => {
+    const family = {
+      id: 'V:f',
+      name: 'font/family',
+      resolvedType: 'STRING',
+      valuesByMode: { m1: 'Roboto' },
+    };
+    const weight = {
+      id: 'V:s',
+      name: 'font/style',
+      resolvedType: 'STRING',
+      valuesByMode: { m1: 'Bold' },
+    };
+    const { figma: f, loaded, style } = fakeFigma({}, { 'V:f': family, 'V:s': weight });
+    style.fontName = { family: 'Inter', style: 'Regular' };
+    await createCreateTextStyleHandler(f)({
+      name: 'Heading/H1',
+      boundVariables: { fontFamily: 'V:f', fontStyle: 'V:s' },
+    });
+    // Live Figma composes these into Roboto Bold; the intermediate face has to load for the family
+    // swap to land before the style swap runs.
+    expect(loaded).toContainEqual({ family: 'Roboto', style: 'Regular' });
+    expect(loaded).toContainEqual({ family: 'Roboto', style: 'Bold' });
+  });
 });


### PR DESCRIPTION
Follow-up to #168, which shipped the text-style font preload with a hole in its evidence: the
account it was built on caps a variable collection at one mode (`in addMode: Limited to 1 modes
only`), so the multi-mode reasoning was argued rather than observed. The PR said as much. A
multi-mode account is available now, so it was measured.

## What the measurement says

| tried on a two-mode collection | result |
| --- | --- |
| `fontFamily` bound to a variable with `Roboto` / `Lato` per mode | binds, style resolves to `Roboto` |
| same, but the **non-default mode names a font nobody has installed** | **still binds** |
| `fontFamily` **and** `fontStyle` both bound, both multi-mode | binds, composes to `Roboto Bold` |

The middle row is the useful one: only the face the style actually *resolves* to has to be
loadable. That makes swallowing a failed preload **load-bearing rather than defensive** — letting
that failure through would reject a binding Figma accepts. #168's comment offered that as a
plausible reason ("a face this guesses at may simply not exist"); it is now a measured one.

The third row confirms what the family → style chain exists for: the two bindings compose into a
single face, so the intermediate face has to be loaded for the family swap to land before the
style swap runs.

## What changed

- The comment says what was measured instead of what was reasoned.
- Three tests pin it. Worth noting how the first attempt failed: the multi-mode test asserted a
  family that happened to sit in the **first** mode, so a mutation narrowing the preload to a
  single mode passed it. Rewritten with a second-mode family that must also be loaded, the
  mutation is caught.
- The faces are keyed while passing through: with a family binding and no style binding, the
  intermediate and final face are identical, and asking twice was pointless even against a cached
  `loadFontAsync`.

No behaviour change — the implementation was already right. This replaces an argument with
evidence, and closes the gap the tests had.
