### PR TITLE
fix(plugin-ui): stop a tab switch from flashing a scrollbar

### DIFF
--- a/packages/plugin/ui/style.css
+++ b/packages/plugin/ui/style.css
@@ -107,7 +107,19 @@
 
 .tab-enter-from {
   opacity: 0;
-  transform: translateY(3px);
+  /*
+   * The panel enters from *above*, and the sign is load-bearing rather than a taste call. The
+   * entering panel is exactly as tall as the scroller it sits in (`min-h-full` plus the section's
+   * padding), so a downward offset puts its bottom edge 3px past the scrollable overflow area and
+   * switches the section's vertical scrollbar on for the length of the transition. Scrollable
+   * overflow only ever extends down and right, so an upward offset adds none — and none of the
+   * panel is clipped for it either, because those 3px are absorbed by the section's own `pt-2`.
+   *
+   * The bug this fixes is invisible on macOS, where scrollbars overlay the content and stay hidden
+   * until you scroll. On Windows they are classic scrollbars that take layout width, so the
+   * phantom one flashed into view — and shoved the panel 15px narrower — on every tab switch.
+   */
+  transform: translateY(-3px);
 }
 
 html,


### PR DESCRIPTION
## Description

Switching tabs flashed the panel's vertical scrollbar on and off again, on Windows only.

The entering panel is exactly as tall as the scroller it sits in (`min-h-full` plus the section's padding), so the `translateY(3px)` it faded in from put its bottom edge 3px past the scrollable overflow area — enough to switch `section`'s vertical scrollbar on for the length of the 150ms transition. Scrollable overflow only ever extends down and right, so entering from *above* adds none, and nothing is clipped for it either: those 3px are absorbed by the section's own `pt-2`. The motion reads the same, just settling down instead of rising.

The bug is invisible on macOS, where scrollbars overlay the content and stay hidden until you scroll. On Windows they are classic scrollbars that take layout width, so the phantom one both appeared at the section's right edge and shoved the panel 15px narrower on every switch.

Verified by driving the built panel over CDP and scanning every element for scrollable overflow, frame by frame, across three tab switches:

```
before:  11x  Y section.flex-1 overflow-x-hidden overflow-y-auto by 3
          6x  Y section.flex-1 overflow-x-hidden overflow-y-auto by 2
          6x  Y section.flex-1 overflow-x-hidden overflow-y-auto by 1
after:   NO SCROLLBAR OVERFLOW ANYWHERE
```

Then confirmed live in Figma on Windows, with the Activity tab filled past the point where it scrolls.

## Checklist

- [x] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm build` pass locally
- [ ] `pnpm test` — 33 pre-existing failures in the relay's timing-sensitive suites (`heartbeatIntervalMs: 30` and friends), unrelated to a CSS-only change; the plugin's own 98 component tests pass. `pnpm knip` was not run to completion.
- [ ] Tests are added or updated — none: this is a layout behavior with no coverage path in `happy-dom`, which has no layout engine. The CDP probe above is what verifies it.
- [x] Read-path / serializer changes verified against a real Figma file — n/a, no read-path change
- [x] Documentation updated if needed — n/a; the rationale lives in the comment next to the rule
