### PR TITLE
chore(deps): update @figma/plugin-typings to ^1.135.0

### DIFF
--- a/.claude/skills/figma-typings-audit/SKILL.md
+++ b/.claude/skills/figma-typings-audit/SKILL.md
@@ -40,15 +40,47 @@ npm pack @figma/plugin-typings@<installed> @figma/plugin-typings@<target> --pack
 for v in <installed> <target>; do
   mkdir -p "$v" && tar -xzf "figma-plugin-typings-$v.tgz" -C "$v" --strip-components=1
 done
-diff -u <installed>/plugin-api.d.ts <target>/plugin-api.d.ts > api.diff
-wc -l api.diff
+diff -rq <installed> <target>            # which files differ at all — start here
+diff -u <installed>/package.json <target>/package.json
+diff -u <installed>/index.d.ts <target>/index.d.ts
 ```
 
-Diff **`plugin-api.d.ts`**, not `plugin-api-standalone.d.ts` — `packages/plugin/tsconfig.json` sets
-`types: ["@figma/plugin-typings"]`, whose `index.d.ts` references the former.
+`diff -rq` first, so the set of changed files is observed rather than assumed. Every file it names
+has to be accounted for — including `plugin-api-standalone.d.ts`, whose trailing `export { ... }` is
+one enormous single line where a removed symbol is easy to miss.
 
-Also diff `index.d.ts` (it declares the `figma` global, `fetch`, timers) — small, but high blast
-radius.
+`index.d.ts` declares the `figma` global, `fetch` and timers — small, but high blast radius.
+`package.json` looks irrelevant and isn't: **its `devDependencies.prettier` explains formatting
+noise.** When that version moves, the `.d.ts` diff fills with reflowed unions and `extends` clauses
+that mean nothing. Check it before reading a single hunk.
+
+### Normalize before diffing the `.d.ts`
+
+Never classify hunks straight out of `diff -u`. Reformat **both** versions with the target's own
+formatter first, so what survives is guaranteed to be semantic:
+
+```bash
+mkdir -p norm
+for v in <installed> <target>; do
+  for f in plugin-api.d.ts plugin-api-standalone.d.ts; do cp "$v/$f" "norm/$v.$f"; done
+done
+cp <target>/.prettierrc norm/.prettierrc          # the package ships its own config
+npx --yes prettier@<version from target package.json devDeps> --write "norm/*.d.ts"
+diff -u norm/<installed>.plugin-api.d.ts norm/<target>.plugin-api.d.ts
+diff -u norm/<installed>.plugin-api-standalone.d.ts norm/<target>.plugin-api-standalone.d.ts
+```
+
+Watch prettier's own per-file output: the **target** files should report `unchanged`. That confirms
+you picked the right formatter version, and turns "the noise is upstream reformatting" from a guess
+into an observation.
+
+Classify from these normalized diffs. `plugin-api.d.ts` is the one that matters —
+`packages/plugin/tsconfig.json` sets `types: ["@figma/plugin-typings"]`, whose `index.d.ts`
+references it — and standalone serves as a cross-check that nothing was missed.
+
+Measured on 1.134.0 → 1.135.0: 328 raw lines collapsed to 32, all of them one change.
+**Never estimate the size of a release from raw diff line count** — 1.134.0 was smaller (228 lines)
+and carried three real buckets.
 
 When the jump spans several releases, diff the two endpoints; the cumulative effect is what matters.
 Go release-by-release only to attribute a specific change to a version.

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -19,7 +19,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "^1.134.0",
+    "@figma/plugin-typings": "^1.135.0",
     "@figwright/shared": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@figma/plugin-typings':
-        specifier: ^1.134.0
-        version: 1.134.0
+        specifier: ^1.135.0
+        version: 1.135.0
       '@figwright/shared':
         specifier: workspace:*
         version: link:../shared
@@ -157,8 +157,8 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@figma/plugin-typings@1.134.0':
-    resolution: {integrity: sha512-e0JSSt7lczdi748/NLVEb7rhf/PG1IZyzieMiQ1AsaPN+A+sqvyYlIfxjzodPKrcdc9Pw9ZVjcHsT36oU744IA==}
+  '@figma/plugin-typings@1.135.0':
+    resolution: {integrity: sha512-vP9ftEPH2uKaDAiFr8e6ZHYe2yaK+sYuZgVS8okOT51cdQjg/LK7w7rLPSge0vN/zcKsQX6kel4LQi1z14nM0A==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2304,7 +2304,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@figma/plugin-typings@1.134.0': {}
+  '@figma/plugin-typings@1.135.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
## What moved

The only semantic change in 1.134.0 → 1.135.0 is the removal of the empty `SublayerDimensionsMixin` interface, plus the four places that referenced it:

- the declaration itself (`interface SublayerDimensionsMixin {}`)
- `LabelSublayerNode extends SublayerDimensionsMixin` → `LabelSublayerNode`
- `ConnectorNode.text: TextSublayerNode & SublayerDimensionsMixin` → `TextSublayerNode`
- the `export { ... }` list at the end of `plugin-api-standalone.d.ts`

It had no members, so intersecting with it was a no-op, and nothing under `packages/plugin/src/` referenced any of those symbols. No new API, and no new fields on existing types — so the hand-written Zod mirrors in `shared` need no follow-up.

## Why the diff is 328 lines and says nothing

The package bumped its own `devDependencies.prettier` from `^2.6.1` to `3.9.3`. Prettier 3 reflows unions and `extends` clauses, which churned dozens of interfaces. Reformatting both versions with prettier 3.9.3 collapses the diff to **32 lines / 3 hunks** (38 / 4 for the standalone bundle) — all of them the one change above.

## Verification

- Sandbox probe: type-checked `packages/plugin/src` + `protocol` against **both** 1.134.0 and 1.135.0 typings out-of-tree — clean on both, so the baseline makes the result meaningful.
- All six gates green: typecheck, lint, format:check, knip, build, test (1815 tests).
- No live verification, because there are no code changes to verify.

## Second commit

Stage 1 of the `figma-typings-audit` skill picked up what this audit exposed: start from `diff -rq` over the whole tarball rather than assuming which files matter (that assumption is why the standalone `export { ... }` reference was missed on the first pass), read `package.json` for the formatter version, and normalize both versions with the target's own prettier before classifying any hunk.

https://claude.ai/code/session_01BTqd8nddxELMevKhXTqj2n