### PR TITLE
fix(plugin): load the node font before every set_text_properties write

### DIFF
--- a/packages/plugin/src/handlers/apply-style-to-node.ts
+++ b/packages/plugin/src/handlers/apply-style-to-node.ts
@@ -36,6 +36,11 @@ export const createApplyStyleToNodeHandler =
         `apply_style_to_node: node ${p.nodeId} cannot take a ${String(p.field)} style`,
       );
     }
+    // No font load, deliberately, even for `text`. The typings say `setTextStyleIdAsync` "requires
+    // the font to be loaded", which reads like the caller's job — every other text write here does
+    // load first. It is not: verified in a real file, applying a text style succeeds with neither
+    // the node's current face nor the style's own face loaded in the session. Being async is how
+    // the setter affords that. Adding a load would be a pointless round trip.
     await (fn as (id: string) => Promise<void>).call(node, p.styleId);
 
     const result: MutateResult = { ok: true, nodeId: node.id };

--- a/packages/plugin/src/handlers/set-text-properties.ts
+++ b/packages/plugin/src/handlers/set-text-properties.ts
@@ -3,12 +3,11 @@ import type { MutateResult } from '@figwright/shared';
 import type { SandboxToolHandler } from '../dispatcher.js';
 
 /**
- * Set a TEXT node's typography + layout/overflow props. Typography (fontName/fontSize/lineHeight/
- * letterSpacing/textCase/textDecoration/paragraphSpacing/paragraphIndent) mutates the node's runs,
- * so Figma requires every font on the node — plus the target fontName, if changing it — to be
- * loaded first. Layout/overflow props (textAutoResize/truncation/maxLines) are node-level and need
- * no font load. Applied in order autoResize → truncation → maxLines because maxLines only takes
- * effect once truncation is ENDING.
+ * Set a TEXT node's typography + layout/overflow props. Figma requires every font on the node —
+ * plus the target fontName, if changing it — to be loaded before _any_ of them is written: the
+ * layout/overflow three (textAutoResize/truncation/maxLines) are refused the same way typography
+ * is, despite reading as node-level settings. Applied in order autoResize → truncation → maxLines
+ * because maxLines only takes effect once truncation is ENDING.
  */
 export const createSetTextPropertiesHandler =
   (figmaCtx: typeof figma): SandboxToolHandler =>
@@ -61,9 +60,17 @@ export const createSetTextPropertiesHandler =
     }
     const text = node as TextNode;
 
-    // Typography mutations require fonts loaded. Load the node's current font(s) (so range mutations
-    // like fontSize/letterSpacing succeed) plus the new fontName, if one is being assigned.
-    const settingTypography =
+    // Every write below needs the node's font(s) loaded — the layout/overflow three included, which
+    // is not obvious and was got wrong here: Figma rejects `maxLines`, `textTruncation` and
+    // `textAutoResize` with `Cannot write to node with unloaded font` just as it rejects a
+    // typography write, so `{nodeId, maxLines: 3}` threw while `{nodeId, fontSize: 24, maxLines: 3}`
+    // succeeded. Nothing in the type checker or a mocked test can see that; the batch inverse that
+    // restores these same fields has always reloaded the captured fonts first.
+    //
+    // Load the node's current font(s) — every one of them when the node is mixed, so a range-wide
+    // mutation succeeds — plus the new fontName, if one is being assigned. Skipped only when there
+    // is nothing to write at all, which is the one case that touches no text.
+    const willWrite =
       p.fontName !== undefined ||
       p.fontSize !== undefined ||
       p.lineHeight !== undefined ||
@@ -72,27 +79,30 @@ export const createSetTextPropertiesHandler =
       p.textDecoration !== undefined ||
       p.paragraphSpacing !== undefined ||
       p.paragraphIndent !== undefined ||
-      p.textWrapStyle !== undefined;
-    if (settingTypography) {
+      p.textWrapStyle !== undefined ||
+      p.textAutoResize !== undefined ||
+      p.textTruncation !== undefined ||
+      p.maxLines !== undefined;
+    if (willWrite) {
       const fonts: FontName[] =
         text.fontName === figmaCtx.mixed && text.characters.length > 0
           ? text.getRangeAllFontNames(0, text.characters.length)
           : [text.fontName as FontName];
       if (p.fontName !== undefined) fonts.push(p.fontName);
       await Promise.all(fonts.map(font => figmaCtx.loadFontAsync(font)));
-
-      if (p.fontName !== undefined) text.fontName = p.fontName;
-      if (p.fontSize !== undefined) text.fontSize = p.fontSize as number;
-      if (p.lineHeight !== undefined) text.lineHeight = p.lineHeight as LineHeight;
-      if (p.letterSpacing !== undefined) text.letterSpacing = p.letterSpacing as LetterSpacing;
-      if (p.textCase !== undefined) text.textCase = p.textCase as TextNode['textCase'];
-      if (p.textDecoration !== undefined)
-        text.textDecoration = p.textDecoration as TextNode['textDecoration'];
-      if (p.paragraphSpacing !== undefined) text.paragraphSpacing = p.paragraphSpacing as number;
-      if (p.paragraphIndent !== undefined) text.paragraphIndent = p.paragraphIndent as number;
-      if (p.textWrapStyle !== undefined)
-        text.textWrapStyle = p.textWrapStyle as TextNode['textWrapStyle'];
     }
+
+    if (p.fontName !== undefined) text.fontName = p.fontName;
+    if (p.fontSize !== undefined) text.fontSize = p.fontSize as number;
+    if (p.lineHeight !== undefined) text.lineHeight = p.lineHeight as LineHeight;
+    if (p.letterSpacing !== undefined) text.letterSpacing = p.letterSpacing as LetterSpacing;
+    if (p.textCase !== undefined) text.textCase = p.textCase as TextNode['textCase'];
+    if (p.textDecoration !== undefined)
+      text.textDecoration = p.textDecoration as TextNode['textDecoration'];
+    if (p.paragraphSpacing !== undefined) text.paragraphSpacing = p.paragraphSpacing as number;
+    if (p.paragraphIndent !== undefined) text.paragraphIndent = p.paragraphIndent as number;
+    if (p.textWrapStyle !== undefined)
+      text.textWrapStyle = p.textWrapStyle as TextNode['textWrapStyle'];
 
     if (p.textAutoResize !== undefined)
       text.textAutoResize = p.textAutoResize as TextNode['textAutoResize'];

--- a/packages/plugin/src/handlers/set-text-range.ts
+++ b/packages/plugin/src/handlers/set-text-range.ts
@@ -121,6 +121,9 @@ export const createSetTextRangeHandler =
       }
       // Design-system bindings: shared styles (async setters), then variable bindings last so a bound
       // variable wins over a direct value set on the same field above.
+      // The face this style carries is not preloaded above, and does not need to be — the async
+      // style-id setters load what they need themselves (see apply-style-to-node.ts, where the same
+      // thing was checked against a real file with nothing loaded at all).
       if (r.textStyleId !== undefined)
         await text.setRangeTextStyleIdAsync(start, end, r.textStyleId);
       if (r.fillStyleId !== undefined)

--- a/packages/plugin/test/handlers/set-text-properties.test.ts
+++ b/packages/plugin/test/handlers/set-text-properties.test.ts
@@ -127,15 +127,58 @@ describe('set_text_properties handler', () => {
     expect(node.textWrapStyle).toBe('BALANCE');
   });
 
-  it('does not load fonts when only layout/overflow props change', async () => {
+  // Figma refuses these three against an unloaded font exactly as it refuses a typography write,
+  // so each is checked on its own: `{nodeId, maxLines: 3}` threw `Cannot write to node with
+  // unloaded font` in a real file while `{nodeId, fontSize: 24, maxLines: 3}` went through, which
+  // is why the miss survived — any call that also touched typography loaded the font on the way
+  // past. A mock cannot reproduce the refusal, so what is pinned here is that the load happens.
+  it.each(['textAutoResize', 'textTruncation', 'maxLines'])(
+    'loads the node font before writing %s on its own',
+    async field => {
+      const loadFontAsync = vi.fn<() => Promise<void>>(async () => {});
+      const node = {
+        id: '1:1',
+        type: 'TEXT',
+        fontName: { family: 'Inter', style: 'Regular' },
+        characters: 'hi',
+        textAutoResize: 'NONE',
+        textTruncation: 'DISABLED',
+        maxLines: null,
+      };
+      const value = { textAutoResize: 'HEIGHT', textTruncation: 'ENDING', maxLines: 3 }[field];
+
+      await createSetTextPropertiesHandler(fakeFigma(node, loadFontAsync))({
+        nodeId: '1:1',
+        [field]: value,
+      });
+
+      expect(loadFontAsync).toHaveBeenCalledWith({ family: 'Inter', style: 'Regular' });
+      expect(node[field as keyof typeof node]).toBe(value);
+    },
+  );
+
+  it('clears maxLines with an explicit null, still loading the font first', async () => {
     const loadFontAsync = vi.fn<() => Promise<void>>(async () => {});
-    const node = { id: '1:1', type: 'TEXT', textAutoResize: 'NONE' };
+    const node = {
+      id: '1:1',
+      type: 'TEXT',
+      fontName: { family: 'Inter', style: 'Regular' },
+      characters: 'hi',
+      maxLines: 3,
+    };
     await createSetTextPropertiesHandler(fakeFigma(node, loadFontAsync))({
       nodeId: '1:1',
-      textAutoResize: 'HEIGHT',
+      maxLines: null,
     });
+    expect(loadFontAsync).toHaveBeenCalledWith({ family: 'Inter', style: 'Regular' });
+    expect(node.maxLines).toBeNull();
+  });
+
+  it('loads nothing when there is nothing to write', async () => {
+    const loadFontAsync = vi.fn<() => Promise<void>>(async () => {});
+    const node = { id: '1:1', type: 'TEXT', fontName: { family: 'Inter', style: 'Regular' } };
+    await createSetTextPropertiesHandler(fakeFigma(node, loadFontAsync))({ nodeId: '1:1' });
     expect(loadFontAsync).not.toHaveBeenCalled();
-    expect(node.textAutoResize).toBe('HEIGHT');
   });
 
   it('throws on non-TEXT node, missing node, or bad input', async () => {


### PR DESCRIPTION
Found while verifying #179 against a real Figma file.

## The bug

`set_text_properties` threw on its own layout/overflow half:

```
set_text_properties({nodeId, maxLines: 3})
→ Cannot write to node with unloaded font "Inter Regular"
```

Figma refuses `maxLines`, `textTruncation` and `textAutoResize` against an
unloaded font exactly as it refuses a typography write, despite all three
reading as node-level settings — the handler's own comment claimed they
"need no font load". It loaded fonts only when a typography field was
present, so `{nodeId, fontSize: 24, maxLines: 3}` succeeded while
`{nodeId, maxLines: 3}` did not. Any call that also touched typography
loaded the font on its way past, which is why this survived.

## Why no gate caught it

The type checker has no opinion, and the handler's mocked `loadFontAsync`
never enforces the precondition — so a test could assert the *absence* of
the load and pass. One did:

```
it('does not load fonts when only layout/overflow props change')
  expect(loadFontAsync).not.toHaveBeenCalled();
```

It reads as an optimisation and is actually the bug written down as the
spec. Replaced with one case per field, plus the explicit-`null` path and
the genuine no-op (nothing to write → nothing loaded).

The repo already knew better in one place: the batch inverse restoring
these same three fields reloads the captured fonts first, and says in a
comment that Figma requires it. The undo path was right about Figma while
the forward path was not.

## The sweep

Every write to a TEXT node or TextStyle, and whether it loads first:

| | |
|---|---|
| `create_text`, `set_text`, `set_text_range`, `find_replace_text`, `create_text_style`, `update_text_style`, batch inverses | load unconditionally — correct |
| `set_text_properties` | loaded **conditionally** — the bug, fixed here |
| `apply_style_to_node`, `set_text_range`'s `textStyleId` | load nothing for the style — **checked, correct as-is** |

That last row was the interesting one. Both call an async style-id setter
the typings describe as requiring "the font to be loaded", and
`apply_style_to_node` loads nothing whatsoever — it looked like the same
bug twice more. It is not: in a cold session, applying a text style
succeeds with neither the node's current face nor the style's own face
loaded. Being async is how those setters afford that; the typings are
describing the state reached, not a precondition on the caller. Both got a
comment rather than a change, because the surrounding handlers all load
fonts and the next reader will infer what I did.

## Verified live

Plugin reloaded between builds (a session id that does not move means the
plugin never reloaded), and every check run on a **cold font cache** —
`loadFontAsync` caches per session, so a warm one makes all of these pass
regardless of the fix.

*Before and after, same call, same node, both cold:*

- unfixed build: `{nodeId, maxLines: 3}` →
  `Cannot write to node with unloaded font "Inter Regular"`
- this build: same call → `{ok: true}`, and
  `{textTruncation: "ENDING", maxLines: 3}` reads back as set

*All three fields, each sent alone with no typography field, each against a
node whose face was never loaded in the session.* Three different faces, so
loading one does not warm the next:

| node face | sent alone | result |
|---|---|---|
| Inter Regular | `textAutoResize: "HEIGHT"` | applied, was `WIDTH_AND_HEIGHT` |
| Inter Bold | `textTruncation: "ENDING"` | applied, was `DISABLED` |
| Inter Medium | `maxLines: 2` | applied, was `1` |

(`maxLines` sent alone against `textTruncation: "DISABLED"` reads back
`null` — Figma only honours it once truncation is `ENDING`, which the tool
description already states. Not a write that failed.)

*The sweep's negative result, also live:* `apply_style_to_node` with a text
style whose face was never loaded, onto a node whose face was never loaded →
applied, `styleIds.text` bound and the node's `fontName`/`fontSize` updated
to the style's.

## Related

Third instance of this class: `update_text_style` failing when only
`fontSize` changed, and `create_text_style` needing the face loaded before
writing `textWrapStyle`. Whether a given write needs a loaded font is a
Figma runtime precondition that no mock reproduces — each of the three was
found by running against a real file, never by a test.
