### PR TITLE
docs: add the Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Where Playwright drives the browser, Figwright drives Figma.
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![Glama MCP server](https://glama.ai/mcp/servers/awdr74100/figwright/badges/score.svg)](https://glama.ai/mcp/servers/awdr74100/figwright)
 
+<a href="https://trendshift.io/repositories/68274?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-68274" target="_blank" rel="noopener noreferrer"><img alt="Figwright on Trendshift" src="https://trendshift.io/api/badge/trendshift/repositories/68274/daily?language=TypeScript" width="250" height="55"></a>
+
 </div>
 
 ## What is Figwright?


### PR DESCRIPTION
We're on Trendshift — adding the badge.

Placed below the shields row rather than inside it. At 250×55 it does not
line up with the 20px-tall badges, and putting it between the tagline and
the badges would split that block; below, it is still centred and above the
fold.

Kept the official snippet as-is apart from the alt text, which becomes
"Figwright on Trendshift" rather than the URL-encoded
`awdr74100%2Ffigwright | Trendshift` a screen reader would otherwise read
out.

Only the root README — `packages/mcp/README.md` (the npm page) opens with
prose and carries no badges at all. `Trendshift` is not added to
`.cspell.json`, matching `Glama`, which is not in there either.

Badge image and link both verified reachable (HTTP 200).
