### PR TITLE
docs: add an in-page nav row, drop the Glama badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@
 
 Where Playwright drives the browser, Figwright drives Figma.
 
+[Quick start](#quick-start) · [How it works](#how-it-works) · [Tools](#tools) · [Skills](#skills) · [FAQ](#faq) · [Contributing](#contributing)
+
 [![npm](https://img.shields.io/npm/v/@figwright/mcp?logo=npm&color=cb3837)](https://www.npmjs.com/package/@figwright/mcp)
 [![CI](https://github.com/awdr74100/figwright/actions/workflows/ci.yml/badge.svg)](https://github.com/awdr74100/figwright/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![Glama MCP server](https://glama.ai/mcp/servers/awdr74100/figwright/badges/score.svg)](https://glama.ai/mcp/servers/awdr74100/figwright)
 
 <a href="https://trendshift.io/repositories/68274?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-68274" target="_blank" rel="noopener noreferrer"><img alt="Figwright on Trendshift" src="https://trendshift.io/api/badge/trendshift/repositories/68274/daily?language=TypeScript" width="250" height="55"></a>
 

--- a/test/docs-sync.test.ts
+++ b/test/docs-sync.test.ts
@@ -26,3 +26,30 @@ describe('README tool counts', () => {
     expect(claims).toEqual(claims.map(() => ALL_TOOL_SPECS.length));
   });
 });
+
+// The front page opens with a nav row of in-page links, and the body links to its own sections too.
+// Renaming a heading silently breaks every one of them — GitHub renders a dead `#anchor` as an
+// ordinary link that scrolls nowhere, so nothing complains. Derive the anchors GitHub would mint
+// and check each link resolves.
+
+/** GitHub's heading slug: lowercase, drop punctuation, spaces to hyphens. */
+const slugify = (heading: string): string =>
+  heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/gu, '')
+    .replace(/\s+/gu, '-');
+
+describe('README in-page links', () => {
+  it.each(README_PATHS)('%s resolves every #anchor to a heading it contains', path => {
+    const body = readFileSync(join(import.meta.dirname, '..', path), 'utf8');
+    const anchors = new Set(
+      [...body.matchAll(/^#{1,6}\s+(.+)$/gmu)].map(m => slugify(m[1] as string)),
+    );
+    const dead = [...body.matchAll(/\]\((#[-\w]+)\)/gu)]
+      .map(m => m[1] as string)
+      .filter(link => !anchors.has(link.slice(1)));
+
+    expect(dead, `${path}: link(s) pointing at no heading`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two changes to the front page.

## An in-page nav row

Ghostty and drizzle-orm both open with a row of links directly under the
tagline — the first thing a reader meets is *where to go*, not what version
we're on. Ghostty's first link is an in-page anchor (`#about`), which is the
part that transfers: we have no separate site, but the sections are the
destinations.

```
[Quick start] · [How it works] · [Tools] · [Skills] · [FAQ] · [Contributing]
```

Placed above the badges — a link is an action, a badge is a status, so the
action comes first. Six entries, the same order of magnitude as Ghostty's
five and drizzle's four.

## The Glama badge is removed

It brings in very little traffic for a slot on the front page. `glama.json`
stays: that is the registry listing itself and is unaffected by the badge
going.

## A guard for the anchors

A renamed heading breaks every one of these links *silently* — GitHub
renders a dead `#anchor` as an ordinary link that just scrolls nowhere, so
nothing complains and no test noticed. The docs-sync suite now derives the
slugs GitHub would mint from each heading and fails on any in-page link
resolving to none of them. It covers the whole README, not only the nav row.

Verified by mutation: renaming `## Quick start` turns it red, while a
case-only edit (`FAQ` → `Faq`, same slug) correctly stays green — the guard
is not so eager that ordinary edits trip it.

---

Separately, I looked at 58 well-known repos to see what makes a badge row
read as "modern" — the finding was that `for-the-badge` is a minority style
(6/58) and 14/58 use no shields badges at all, while what actually reads as
modern is a **consistent `labelColor`** so the badges group visually.
Our four are currently red / green / blue / green against a black-and-white
logo. Not touching that here; it is a separate change and worth deciding on
its own.
