### PR TITLE
chore(deps): update zod to ^4.5.4

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,7 @@
     "ignore": "^7.0.6",
     "oxc-parser": "^0.147.0",
     "ws": "^8.21.3",
-    "zod": "^4.5.2"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@figwright/shared": "workspace:*",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -16,7 +16,7 @@
     "@lucide/vue": "^1.35.0",
     "@vueuse/core": "^14.4.0",
     "vue": "^3.5.42",
-    "zod": "^4.5.2"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@figma/plugin-typings": "^1.136.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.3",
-    "zod": "^4.5.2"
+    "zod": "^4.5.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3
       zod:
-        specifier: ^4.5.2
-        version: 4.5.2
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@figwright/shared':
         specifier: workspace:*
@@ -82,8 +82,8 @@ importers:
         specifier: ^3.5.42
         version: 3.5.42(typescript@6.0.3)
       zod:
-        specifier: ^4.5.2
-        version: 4.5.2
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@figma/plugin-typings':
         specifier: ^1.136.0
@@ -122,8 +122,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       zod:
-        specifier: ^4.5.2
-        version: 4.5.2
+        specifier: ^4.5.4
+        version: 4.5.4
 
 packages:
 
@@ -2041,6 +2041,9 @@ packages:
   zod@4.5.2:
     resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
 snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
@@ -2101,12 +2104,12 @@ snapshots:
 
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
-      zod: 4.5.2
+      zod: 4.5.4
 
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
-      zod: 4.5.2
+      zod: 4.5.4
 
   '@msgpack/msgpack@3.1.3': {}
 
@@ -3553,3 +3556,5 @@ snapshots:
       '@yuku-parser/binding-win32-x64': 0.8.7
 
   zod@4.5.2: {}
+
+  zod@4.5.4: {}


### PR DESCRIPTION
Two patch releases. Neither one's trigger exists in this repo.

## What changed upstream

| | fix | reachable here |
|---|---|---|
| 4.5.3 | `emit record numeric keys as strings in toJSONSchema` (#6497) | no |
| 4.5.4 | `stop the cycle walk from firing a default factory` (#6500) | no |

**#6497 touches `json-schema-processors.ts`**, which is where every
advertised tool schema comes from, so it got read rather than assumed. The
new `stringifyKeyNames` only fires when a record's key schema is *numeric*;
the remainder of that diff renames a local `regexes` binding out of the way
of a newly added import. All 23 records here key on a bare `z.string()` —
the one grep hit that isn't is a comment describing a competitor's shape.

**#6500 needs a `.default()`** anywhere in a schema to trigger. There are
none. It edits `memoizer.ts`, which is load-bearing for 4.5's method
memoization, but nothing here configures a memoizer directly.

## Verified, not reasoned

| check | result |
|---|---|
| six gates | green, 1,897 tests |
| JSON Schema canaries | green — Zod's rendering is unchanged |
| wire probe, all 112 tools | **`no wire-observable change`** |
| runtime parsing, 1,538-case corpus | **0 differences** |

The corpus is the same fixed one built for the 4.5 upgrade, replayed
against both versions: accept/reject verdict, every issue's `code` and
`path`, and the parsed data all match. The wire probe is the one worth
noting — on 4.4.3 → 4.5.2 it reported ten tools whose schemas had
reshaped; here it is clean.

This is the first upgrade where the canary test added in #184 did its job:
a green run *is* the evidence that Zod's schema output did not move, which
before that test existed could only be established by diffing snapshots by
hand.

## Cost

Plugin bundle grows **2,180 bytes** (221,031 → 223,211) for code on paths
we never take. The server bundle is byte-identical; zod is external to it.

## Also tracked

Of the three Zod PRs being watched since the 4.5 audit, one landed:

- `#6491` publish Zod Mini as `@zod/mini` — **merged**, but no file touches
  `v4/classic` or `v4/core`, so no effect here
- `#6492` install methods as own properties under a test runner — still
  open. Worth continuing to watch: it keys off `NODE_ENV=test`, which
  vitest sets, so it would make this repo's test environment use a
  different object layout than production
- `#6493` `z.minProperties()` / `z.maxProperties()` — still open, additive
