### PR TITLE
fix(plugin): stop a resize drag from depending on pointer capture holding

### DIFF
--- a/packages/plugin/test/composables/use-panel-window.test.ts
+++ b/packages/plugin/test/composables/use-panel-window.test.ts
@@ -1,39 +1,92 @@
+// @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createPanelHide,
   createPanelResize,
   PANEL_MIN_SIZE,
+  type PanelSize,
 } from '../../protocol/panel-control.js';
 import { usePanelWindow } from '../../ui/composables/usePanelWindow.js';
 import { GRIP_OFFSET } from '../../ui/sandbox/commands.js';
 
 const postMessage = vi.fn<(message: unknown, targetOrigin: string) => void>();
 
-/** A pointer event carries only what the resize handlers actually read. */
-const pointerAt = (clientX: number, clientY: number): PointerEvent =>
-  ({
-    clientX,
-    clientY,
-    pointerId: 1,
-    target: { setPointerCapture: vi.fn<(id: number) => void>() },
-  }) as unknown as PointerEvent;
+/**
+ * A real element with a real drag on it.
+ *
+ * The previous version of this file passed a bare `{ setPointerCapture }` object as the event
+ * target, which meant nothing here ever exercised the thing the drag actually depends on: whether
+ * events keep arriving once the pointer has left the 16px grip. A real DOM makes that observable,
+ * and it is the whole subject of this file.
+ */
+let grip: HTMLElement;
+/**
+ * The element the pointer actually lands on. The grip draws an svg, so a press hits a `<path>` or
+ * the `<svg>` — never the div the handler sits on. Pressing the child is what makes `target` and
+ * `currentTarget` different elements, and therefore what makes capturing on the wrong one visible.
+ */
+let mark: SVGElement;
+
+const press = (clientX: number, clientY: number): void => {
+  mark.dispatchEvent(
+    new PointerEvent('pointerdown', { clientX, clientY, pointerId: 1, buttons: 1, bubbles: true }),
+  );
+};
+
+/** Moves and releases go to `window`, which is where a drag that has left the grip lands. */
+const move = (clientX: number, clientY: number, buttons = 1): void => {
+  window.dispatchEvent(
+    new PointerEvent('pointermove', { clientX, clientY, pointerId: 1, buttons }),
+  );
+};
+
+const release = (clientX: number, clientY: number, type = 'pointerup'): void => {
+  window.dispatchEvent(new PointerEvent(type, { clientX, clientY, pointerId: 1, buttons: 0 }));
+};
 
 const sentMessages = (): unknown[] =>
   postMessage.mock.calls.map(
     ([envelope]) => (envelope as { pluginMessage: unknown }).pluginMessage,
   );
 
+const persisted = (): unknown[] =>
+  sentMessages().filter(m => (m as { persist?: boolean }).persist === true);
+
+const size = (clientX: number, clientY: number): PanelSize => ({
+  width: clientX + GRIP_OFFSET,
+  height: clientY + GRIP_OFFSET,
+});
+
+/** Start a drag on the grip, wired the way the component wires it. */
+const startDrag = (clientX = 500, clientY = 600): void => {
+  const { onResizeStart } = usePanelWindow();
+  grip.addEventListener('pointerdown', e => onResizeStart(e as PointerEvent));
+  press(clientX, clientY);
+};
+
+beforeEach(() => {
+  postMessage.mockClear();
+  vi.stubGlobal('parent', { postMessage });
+  grip = document.createElement('div');
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  mark = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  svg.append(mark);
+  grip.append(svg);
+  document.body.append(grip);
+});
+
+afterEach(() => {
+  // End any drag a test left running. A live drag holds listeners on `window`, and `window` is the
+  // one object these tests share — without this, a test that never releases makes the *next* one
+  // see its moves too. (Dispatching one release ends every live drag at once, which is itself the
+  // behaviour: the listeners are per-drag and each removes its own.)
+  window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, buttons: 0 }));
+  grip.remove();
+  vi.unstubAllGlobals();
+});
+
 describe('usePanelWindow', () => {
-  beforeEach(() => {
-    postMessage.mockClear();
-    vi.stubGlobal('parent', { postMessage });
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it('asks the sandbox to hide the panel rather than close the plugin', () => {
     usePanelWindow().runInBackground();
 
@@ -43,78 +96,173 @@ describe('usePanelWindow', () => {
 
   describe('drag-to-resize', () => {
     it('ignores pointer movement that is not part of a drag', () => {
-      const { onResizeMove } = usePanelWindow();
+      usePanelWindow();
 
-      onResizeMove(pointerAt(500, 600));
+      move(500, 600);
 
       expect(postMessage).not.toHaveBeenCalled();
     });
 
-    it('captures the pointer on drag start so the drag survives leaving the grip', () => {
-      const { onResizeStart } = usePanelWindow();
-      const event = pointerAt(500, 600);
+    it('captures the pointer on the element that owns the handler, not the one under it', () => {
+      // The press lands on the `<path>` the grip draws. Capturing there ties the drag to an element
+      // the listeners do not belong to and that the component is free to re-render away; the div
+      // they sit on is the one guaranteed to outlive the drag.
+      const onGrip = vi.spyOn(grip, 'setPointerCapture').mockImplementation(() => {});
+      const onMark = vi.spyOn(mark, 'setPointerCapture').mockImplementation(() => {});
+      startDrag();
 
-      onResizeStart(event);
-
-      expect(
-        (event.target as unknown as { setPointerCapture: ReturnType<typeof vi.fn> })
-          .setPointerCapture,
-      ).toHaveBeenCalledWith(1);
+      expect(onGrip).toHaveBeenCalledWith(1);
+      expect(onMark).not.toHaveBeenCalled();
     });
 
     it('streams sizes without persisting while dragging', () => {
-      const { onResizeStart, onResizeMove } = usePanelWindow();
+      startDrag(500, 600);
+      move(520, 620);
 
-      onResizeStart(pointerAt(500, 600));
-      onResizeMove(pointerAt(520, 620));
-
-      expect(sentMessages()).toEqual([
-        createPanelResize({ width: 520 + GRIP_OFFSET, height: 620 + GRIP_OFFSET }, false),
-      ]);
+      expect(sentMessages()).toEqual([createPanelResize(size(520, 620), false)]);
     });
 
     it('persists exactly once, on release', () => {
-      const { onResizeStart, onResizeMove, onResizeEnd } = usePanelWindow();
+      startDrag(500, 600);
+      move(510, 610);
+      move(520, 620);
+      release(530, 630);
 
-      onResizeStart(pointerAt(500, 600));
-      onResizeMove(pointerAt(510, 610));
-      onResizeMove(pointerAt(520, 620));
-      onResizeEnd(pointerAt(530, 630));
+      expect(persisted()).toEqual([createPanelResize(size(530, 630), true)]);
+    });
 
-      const persisted = sentMessages().filter(m => (m as { persist: boolean }).persist);
-      expect(persisted).toEqual([
-        createPanelResize({ width: 530 + GRIP_OFFSET, height: 630 + GRIP_OFFSET }, true),
+    it('keeps tracking after the pointer has left the grip', () => {
+      // The whole point of tracking on `window`. A 16px target is one the pointer leaves on the
+      // first move, so a drag bound to the grip only survives while capture holds.
+      startDrag(500, 600);
+      move(900, 900);
+      move(1200, 1200);
+
+      expect(sentMessages()).toEqual([
+        createPanelResize(size(900, 900), false),
+        createPanelResize(size(1200, 1200), false),
       ]);
     });
 
+    it('drags on when the browser refuses to capture the pointer', () => {
+      // Capture is a widening, not the mechanism. `setPointerCapture` can throw, and a drag that
+      // stopped there would be the intermittent halfway-stop this rework exists to remove.
+      vi.spyOn(grip, 'setPointerCapture').mockImplementation(() => {
+        throw new Error('NotFoundError');
+      });
+
+      startDrag(500, 600);
+      move(900, 900);
+      release(950, 950);
+
+      expect(persisted()).toEqual([createPanelResize(size(950, 950), true)]);
+    });
+
+    it('releases the capture it took', () => {
+      vi.spyOn(grip, 'setPointerCapture').mockImplementation(() => {});
+      const releaseCapture = vi.spyOn(grip, 'releasePointerCapture').mockImplementation(() => {});
+
+      startDrag();
+      release(700, 700);
+
+      expect(releaseCapture).toHaveBeenCalledWith(1);
+    });
+
+    it('does not try to release a capture it never took', () => {
+      vi.spyOn(grip, 'setPointerCapture').mockImplementation(() => {
+        throw new Error('NotFoundError');
+      });
+      const releaseCapture = vi.spyOn(grip, 'releasePointerCapture').mockImplementation(() => {});
+
+      startDrag();
+      release(700, 700);
+
+      expect(releaseCapture).not.toHaveBeenCalled();
+    });
+
+    it('survives a release that throws because the browser already released', () => {
+      vi.spyOn(grip, 'setPointerCapture').mockImplementation(() => {});
+      vi.spyOn(grip, 'releasePointerCapture').mockImplementation(() => {
+        throw new Error('NotFoundError');
+      });
+
+      startDrag(500, 600);
+      move(700, 700);
+      expect(() => release(700, 700)).not.toThrow();
+      expect(persisted()).toEqual([createPanelResize(size(700, 700), true)]);
+    });
+
     it('stops tracking after release', () => {
-      const { onResizeStart, onResizeEnd, onResizeMove } = usePanelWindow();
-      onResizeStart(pointerAt(500, 600));
-      onResizeEnd(pointerAt(500, 600));
+      startDrag(500, 600);
+      release(500, 600);
       postMessage.mockClear();
 
-      onResizeMove(pointerAt(700, 800));
+      move(700, 800);
 
       expect(postMessage).not.toHaveBeenCalled();
     });
 
     it('does not emit a stray persist when release arrives without a drag', () => {
-      const { onResizeEnd } = usePanelWindow();
+      usePanelWindow();
 
-      onResizeEnd(pointerAt(500, 600));
+      release(500, 600);
 
       expect(postMessage).not.toHaveBeenCalled();
     });
 
     it('holds the floor while the pointer keeps moving past it', () => {
-      const { onResizeStart, onResizeMove } = usePanelWindow();
-
-      onResizeStart(pointerAt(500, 600));
-      onResizeMove(pointerAt(10, 10));
+      startDrag(500, 600);
+      move(10, 10);
 
       expect(sentMessages()).toEqual([
         createPanelResize({ width: PANEL_MIN_SIZE.width, height: PANEL_MIN_SIZE.height }, false),
       ]);
+    });
+
+    it('ends the drag on a move that arrives with no button held', () => {
+      // The release happened where this document could not see it — outside the iframe, or while
+      // capture was lost out there. Without this the drag stays armed, and the next hover over the
+      // corner resizes the window on its own.
+      startDrag(500, 600);
+      move(700, 700);
+      postMessage.mockClear();
+
+      move(900, 900, 0);
+      move(1100, 1100);
+
+      // Nothing was asked for by either move, and the size last actually dragged to is what stuck.
+      expect(sentMessages()).toEqual([createPanelResize(size(700, 700), true)]);
+    });
+
+    it('keeps the size the drag reached when the gesture is cancelled', () => {
+      // A cancel's coordinates are wherever the gesture was interrupted, not a size anyone chose.
+      startDrag(500, 600);
+      move(700, 700);
+      release(20, 20, 'pointercancel');
+
+      expect(persisted()).toEqual([createPanelResize(size(700, 700), true)]);
+    });
+
+    it('stores nothing for a press that never moved', () => {
+      // A click on the grip. Taking the release position would nudge the window by however far the
+      // press sat from the corner.
+      startDrag(500, 600);
+      release(500, 600);
+
+      expect(postMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores a second press while a drag is already running', () => {
+      const { onResizeStart } = usePanelWindow();
+      grip.addEventListener('pointerdown', e => onResizeStart(e as PointerEvent));
+
+      press(500, 600);
+      move(700, 700);
+      press(500, 600);
+      release(800, 800);
+
+      // One drag, one persist — a re-entrant start must not double the window listeners.
+      expect(persisted()).toEqual([createPanelResize(size(800, 800), true)]);
     });
   });
 });

--- a/packages/plugin/ui/components/PanelGrip.vue
+++ b/packages/plugin/ui/components/PanelGrip.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { usePanelWindow } from '../composables/usePanelWindow.js';
 
-const { onResizeStart, onResizeMove, onResizeEnd } = usePanelWindow();
+const { onResizeStart } = usePanelWindow();
 </script>
 
 <!--
@@ -27,14 +27,17 @@ const { onResizeStart, onResizeMove, onResizeEnd } = usePanelWindow();
   only a quarter of its width is lost. Screenshots at device scale 2 hide that entirely; check this
   in the real window, not in a render.
 -->
+<!--
+  Only the press is bound here. The rest of the drag lives on `window` (see usePanelWindow): a 16px
+  target is one the pointer leaves on the first move, so binding move and release to it would make
+  the drag depend on pointer capture holding — which is what makes a resize stop halfway when it
+  does not.
+-->
 <template>
   <div
     class="absolute right-0 bottom-0 size-4 cursor-nwse-resize touch-none text-faint transition-colors duration-150 hover:text-fg"
     title="Drag to resize"
     @pointerdown="onResizeStart"
-    @pointermove="onResizeMove"
-    @pointerup="onResizeEnd"
-    @pointercancel="onResizeEnd"
   >
     <svg
       aria-hidden="true"

--- a/packages/plugin/ui/composables/usePanelWindow.ts
+++ b/packages/plugin/ui/composables/usePanelWindow.ts
@@ -1,41 +1,115 @@
+import type { PanelSize } from '../../protocol/panel-control.js';
 import { hidePanel, resizePanel, sizeFromPointer } from '../sandbox/commands.js';
 
 export interface PanelWindow {
   /** Hide the panel; the iframe (and with it the relay socket) stays alive. */
   runInBackground: () => void;
+  /** Begin a resize drag. The rest of the drag is tracked on `window`, not on the grip. */
   onResizeStart: (e: PointerEvent) => void;
-  onResizeMove: (e: PointerEvent) => void;
-  onResizeEnd: (e: PointerEvent) => void;
 }
-
-const sendSize = (e: PointerEvent, persist: boolean): void =>
-  resizePanel(sizeFromPointer(e.clientX, e.clientY), persist);
 
 /**
  * Drag-to-resize and run-in-background, as the small state machine they are.
  *
- * Resize only tracks between pointerdown and pointerup — without that flag every stray pointermove
- * over the grip would resize the window. `persist` is sent once on release so the sandbox stores
- * the final size rather than every intermediate frame.
+ * The drag is tracked on `window` for its duration rather than on the grip, because the grip is
+ * 16px and the pointer leaves it immediately. Pointer capture is still taken, but as a widening
+ * rather than as the mechanism: the two cover different halves of the same problem, and only
+ * together do they cover all of it.
+ *
+ * - Capture is what keeps events coming to this document once the pointer leaves the _iframe_.
+ *   Nothing else can do that; a listener on `window` is still a listener inside a document the
+ *   pointer is no longer over.
+ * - The `window` listeners are what keep the drag working if capture is never established or is lost
+ *   mid-drag. Capture is not guaranteed: `setPointerCapture` can throw, and the browser drops
+ *   capture on its own (the captured element being re-rendered away is enough).
+ *
+ * Depending on capture alone is what makes a resize drag stop halfway: the moment the pointer is
+ * outside the grip with no capture, no further `pointermove` reaches the handler — and neither does
+ * the `pointerup`, so the drag stays armed and the _next_ hover over the corner resizes the window.
+ * That failure is intermittent by nature, which is exactly why the drag should not rest on it.
+ *
+ * The missed release is handled directly rather than inferred: a `pointermove` that arrives with no
+ * button held is a release this document never saw, and ends the drag. It subsumes every way the
+ * release can go missing — let go outside the iframe, capture lost while out there, the grip
+ * unmounted mid-drag — without needing to tell them apart.
+ *
+ * `persist` is sent once, on release, so the sandbox stores the final size rather than every
+ * intermediate frame — and what it stores is the last size the drag actually asked for. A cancel's
+ * coordinates are not that: they are wherever the gesture was interrupted, which is not a size the
+ * user chose. A press that never moved asked for no size at all, so it stores nothing.
  */
 export const usePanelWindow = (): PanelWindow => {
-  let resizing = false;
+  let dragging = false;
+  /** The last size this drag asked for; null until the pointer has actually moved. */
+  let lastSize: PanelSize | null = null;
+  /** Set only when capture was actually taken, so the release can be undone exactly once. */
+  let captured: { element: Element; pointerId: number } | null = null;
+
+  const finish = (): void => {
+    if (!dragging) return;
+    dragging = false;
+
+    window.removeEventListener('pointermove', onMove);
+    window.removeEventListener('pointerup', onUp);
+    window.removeEventListener('pointercancel', finish);
+
+    if (captured !== null) {
+      try {
+        captured.element.releasePointerCapture(captured.pointerId);
+      } catch {
+        // Already released — the browser does it itself on pointerup. Releasing is only load-bearing
+        // on the paths where no pointerup arrived.
+      }
+      captured = null;
+    }
+
+    if (lastSize !== null) resizePanel(lastSize, true);
+    lastSize = null;
+  };
+
+  const onMove = (e: PointerEvent): void => {
+    // No button held: the release happened somewhere this document could not see it.
+    if (e.buttons === 0) {
+      finish();
+      return;
+    }
+    lastSize = sizeFromPointer(e.clientX, e.clientY);
+    resizePanel(lastSize, false);
+  };
+
+  const onUp = (e: PointerEvent): void => {
+    // The release position is the size the user settled on — but only for a drag that moved. A
+    // press and release on the grip is a click, and taking its position would nudge the window by
+    // however far the press sat from the corner.
+    if (lastSize !== null) lastSize = sizeFromPointer(e.clientX, e.clientY);
+    finish();
+  };
 
   return {
     runInBackground: hidePanel,
 
-    onResizeStart: (e: PointerEvent) => {
-      resizing = true;
-      // Capture keeps the drag alive when the pointer leaves the 16px grip.
-      (e.target as Element).setPointerCapture(e.pointerId);
-    },
-    onResizeMove: (e: PointerEvent) => {
-      if (resizing) sendSize(e, false);
-    },
-    onResizeEnd: (e: PointerEvent) => {
-      if (!resizing) return;
-      resizing = false;
-      sendSize(e, true);
+    onResizeStart: (e: PointerEvent): void => {
+      if (dragging) return;
+      dragging = true;
+      lastSize = null;
+
+      // `currentTarget`, not `target`: the grip draws an svg, so the element under the pointer is a
+      // `<path>` or the `<svg>`, while the element that owns these listeners — and is guaranteed to
+      // outlive the drag — is the div they sit on.
+      const host = e.currentTarget;
+      if (host instanceof Element) {
+        try {
+          host.setPointerCapture(e.pointerId);
+          captured = { element: host, pointerId: e.pointerId };
+        } catch {
+          // A widening that did not apply, not a failure: the window listeners below are the drag.
+          captured = null;
+        }
+      }
+
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      window.addEventListener('pointercancel', finish);
     },
   };
 };


### PR DESCRIPTION
The panel's resize grip sometimes stops following the pointer partway through a drag. It is not reproducible on demand, so this does not claim to have found *the* trigger — it removes the mechanism that failure requires, and fixes four defects that are visible in the code without needing a repro.

## What the drag rested on

The grip is 16px, and the whole drag — `pointermove`, `pointerup`, `pointercancel` — was bound to that 16px element. The pointer leaves it on the first move, so every event after the press arrived only because `setPointerCapture` redirected it back.

Capture was therefore the mechanism, not a widening. And capture is not a guarantee: `setPointerCapture` can throw, and the browser drops capture on its own.

**When it does not hold, the failure is exactly the reported symptom.** No further `pointermove` reaches the handler, so the window stops following the pointer partway through the drag. And no `pointerup` reaches it either — so `resizing` stays `true`, and the *next* hover over the corner resizes the window with no button held.

## The fix

Track the drag on `window` for its duration; keep capture, but as a widening.

The two cover different halves of the same problem, and only together do they cover all of it:

- **Capture** is the only thing that can keep events coming to this document once the pointer leaves the **iframe**. A listener on `window` is still a listener inside a document the pointer is no longer over.
- **The `window` listeners** are the only thing that keeps the drag working if capture is never established or is lost mid-drag.

### Four smaller defects that went with it

| | before | after |
| --- | --- | --- |
| capture target | `event.target` — the `<path>` or `<svg>` the grip draws, not the div the listeners sit on | `event.currentTarget`, the element guaranteed to outlive the drag |
| `setPointerCapture` | unguarded; a throw left the drag armed with no capture | guarded — capture failing is not the drag failing |
| missed release | nothing; the drag stayed armed | a `pointermove` with no button held ends it |
| `pointercancel` | persisted the cancel event's own coordinates | persists the last size the drag actually asked for |

The missed-release check is deliberately one rule rather than several: a move that arrives with no button held is a release this document never saw, and it subsumes every way the release can go missing — let go outside the iframe, capture lost while out there, the grip unmounted mid-drag — without needing to tell them apart.

A `lostpointercapture` handler was considered and left out on purpose. With the drag tracked on `window`, ending it there would be wrong: if capture dies while the pointer is outside the iframe and the button is still down, the drag should resume when the pointer comes back — which it does, and the no-button check catches it if the release happened out there instead.

Storing "the last size actually asked for" also means a press that never moved stores nothing, which stops a plain click on the grip nudging the window by however far the press sat from the corner.

## The tests could not have seen any of this

They passed a bare `{ setPointerCapture }` object as the event target, so nothing exercised the thing the drag depends on: whether events keep arriving once the pointer has left the grip.

They now run on a real DOM against a real `div > svg > path`, and drive moves and releases through `window` the way a real drag does. 17 tests, up from 11.

Writing them surfaced a hygiene bug worth keeping the fix for: a test that leaves a drag running holds listeners on `window`, which the next test then sees too. `afterEach` now ends any live drag — and one release ending every live drag at once is itself the behaviour under test, since the listeners are per-drag and each removes its own.

## Mutation-checked

Reverting to element-only tracking fails 9. Capturing on `target`, unguarding the capture call, dropping the no-button check, persisting a cancel's coordinates, persisting a click that never moved, never releasing capture, and dropping the re-entrant-press guard each fail their own.

**Capturing on `target` survived the first pass.** The tests pressed the grip directly, so `target` and `currentTarget` were the same element and the guard was never exercised — the assertion was right and tested nothing. Pressing the `<path>` the way a real press lands is what made it visible.

## Gates

`typecheck · lint · format:check · knip · build · test` all green.

Note for whoever merges: this is plugin-side, so it only takes effect after re-importing the plugin in Figma.
