### PR TITLE
ci(repo): close the commit scope vocabulary and require one per title

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,9 @@
 Thank you for contributing to Figwright!
 
 Before opening the PR, please make sure:
-- The PR title follows Conventional Commits (`feat: …`, `fix: …`, `docs: …`).
+- The PR title follows Conventional Commits, `type(scope): subject`, with a
+  lowercase subject and a scope from the nine in CONTRIBUTING.md (`codegen`,
+  `design`, `grounding`, `tools`, `relay`, `plugin`, `skills`, `deps`, `repo`).
   It is validated by CI, and with squash merges it becomes the commit on
   `main` and drives the changelog — write it carefully.
 - For anything non-trivial, an issue was opened first to agree on the

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -25,7 +25,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # Match the commit-type vocabulary used across the repo.
+          # Match the commit-type vocabulary used across the repo. `revert` is
+          # deliberately absent: the Conventional Commits spec does not define
+          # revert behaviour ("we leave it to tooling authors"), and changelogen
+          # has no `revert` type, so such a commit would be dropped from the
+          # changelog in silence. Type a revert by its effect instead —
+          # `fix(relay): revert the msgpack bin wire format` lands in Fixes,
+          # which is where a reader looks for what changed for them, and carries
+          # the right semver. GitHub's own Revert button produces `Revert "…"`,
+          # which fails this gate on all three counts anyway, so the title has to
+          # be rewritten by hand either way.
           types: |
             feat
             fix
@@ -37,4 +46,31 @@ jobs:
             build
             perf
             style
-            revert
+          # A closed vocabulary, and every title has to pick from it. The axis is
+          # the capability a reader of the changelog experiences, NOT the package
+          # the diff lands in: Figwright ships one product, so `mcp` / `shared`
+          # would say nothing (they would be four fifths of every release), while
+          # `codegen` / `design` / `relay` say which part of it moved. See
+          # CONTRIBUTING.md for what each one covers and where the boundaries run.
+          scopes: |
+            codegen
+            design
+            grounding
+            tools
+            relay
+            plugin
+            skills
+            deps
+            repo
+          requireScope: true
+          # An unscoped title is not an unclassifiable change — it is one nobody
+          # had a list to pick from. Requiring the scope is what keeps the
+          # generated changelog uniform, since changelogen renders the scope as
+          # the bold lead-in of every line and an entry without one reads as an
+          # outlier next to the rest of its section.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character (changelogen capitalizes
+            it when rendering the changelog).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Figwright's moat is **grounding fidelity and generality** — how accurately and
 
 ## Conventions
 
-- **Commits / PRs**: [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `refactor:`, `ci:`, …). PR titles are validated by `semantic-pr.yml`; with squash merges the PR title becomes the commit on `main`.
+- **Commits / PRs**: [Conventional Commits](https://www.conventionalcommits.org/), `type(scope): subject`. The **scope is required and closed** — nine values (`codegen`, `design`, `grounding`, `tools`, `relay`, `plugin`, `skills`, `deps`, `repo`), chosen by the capability a changelog reader experiences rather than by which package the diff lands in, since one product ships from this repo and `mcp` would be most of every release. The subject starts lowercase (changelogen capitalizes it). [CONTRIBUTING.md](./CONTRIBUTING.md#scope-required) has the table and the two boundaries that are easy to get wrong. `semantic-pr.yml` is the gate: it validates the PR title, and with squash merges that title becomes the commit on `main`.
 - **Tests**: each package has a `test/` mirroring `src/` (no co-located tests). Tests that span packages live in the root `test/`.
 - **Formatting & lint** are enforced by CI (`format:check`, `lint`) — there are no git hooks. Run `pnpm format` before committing, or let your editor format on save.
 - **Scope**: internal packages are `@figwright/*`; only `@figwright/mcp` is published to npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,83 @@ A few things worth knowing (full details in [AGENTS.md](./AGENTS.md)):
 
 ## Commit & PR conventions
 
-- **[Conventional Commits](https://www.conventionalcommits.org/)**: prefix messages with `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `ci:`, etc. The version bump and changelog are derived from these.
-- **PR titles are validated** (`semantic-pr.yml`) and must follow the same format. PRs are **squash-merged**, so the PR title becomes the commit on `main`, so write it carefully.
+- **[Conventional Commits](https://www.conventionalcommits.org/)**: `type(scope): subject`. The version bump and the changelog are derived from these.
+- **PR titles are validated** (`semantic-pr.yml`) and must follow the same format. PRs are **squash-merged** and the PR title becomes the commit on `main`, so write it carefully.
 - **Branch off `main`**, keep PRs focused, and make sure CI is green before requesting review.
+
+### Type
+
+`feat` `fix` `perf` `refactor` `docs` `test` `ci` `build` `chore` `style`.
+
+There is deliberately no `revert` type. The Conventional Commits spec does not
+define revert behaviour ("we leave it to tooling authors"), and changelogen has no
+`revert` type — a commit typed that way would be dropped from the changelog in
+silence. **Type a revert by its effect**: `fix(relay): revert the msgpack bin wire
+format` lands in Fixes, which is where a reader looks for what changed for them,
+and carries the right semver. Note that GitHub's Revert button produces
+`Revert "<original title>"`, which has no type, no scope and an uppercase subject,
+so the title has to be rewritten by hand regardless.
+
+### Scope (required)
+
+The scope is **not optional and not free-form** — it must be one of nine. The axis is
+the capability a reader of the changelog experiences, not the package the diff
+lands in: Figwright ships one product, so `mcp` or `shared` would be four fifths
+of every release and tell nobody anything.
+
+| Scope       | Covers                                                                                                                                 |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `codegen`   | Figma → code output quality: `get_design_context`, the serializers, breakpoint hints, framework/style profiles                         |
+| `design`    | The Figma design surface itself — which node, style and variable properties we can read and write, and the sandbox handlers that do it |
+| `grounding` | Reading the local project: `token_map`, `component_map`, `icon_map`, the repo walk, config scanners                                    |
+| `tools`     | The MCP tool surface: the registry, input schemas, descriptions, annotations, argument validation, the protocol era                    |
+| `relay`     | Everything between the server and the plugin: transport, wire format, election, timeouts, shutdown                                     |
+| `plugin`    | The Figma plugin **panel UI** (`packages/plugin/ui`)                                                                                   |
+| `skills`    | The bundled `figma-codegen` / `figma-build` skills                                                                                     |
+| `deps`      | Dependency bumps (Renovate). Non-breaking `chore(deps)` is filtered out of the changelog by changelogen                                |
+| `repo`      | The repository itself: CI, build config, release tooling, editor config, README / CONTRIBUTING / governance docs                       |
+
+Two boundaries that are easy to get wrong:
+
+- **`plugin` is the panel UI only.** A sandbox handler in `packages/plugin/src` is
+  scoped by the capability it implements — a font that is not preloaded before a
+  text write is `fix(design)`, not `fix(plugin)`, because that is where the reader
+  feels it.
+- **`docs` is a type, not a scope.** The type already says it is documentation; the
+  scope says whose. README and governance docs are `docs(repo)`; a correction to
+  the codegen guidance is `docs(codegen)`.
+
+One scope outside the list appears in history and will keep appearing:
+`chore(release): vX.Y.Z` is changelogen's own commit template. It is committed
+straight to `main` by `pnpm release` and never passes through a PR, so the gate
+never sees it.
+
+### When one PR spans several scopes
+
+Scopes can be combined with a comma — `feat(codegen,relay): …` — and changelogen
+renders that verbatim as the line's lead-in. But reach for it last, in this order:
+
+1. **Check whether the PR should be two PRs.** A title that resists a single scope
+   is usually a PR doing two things. Splitting it is the better fix, and it is the
+   one the reader of the changelog benefits from.
+2. **Otherwise scope by purpose, not by footprint.** Most wide-reaching changes are
+   still one thing to a reader. Adding a text property touches the sandbox handler,
+   the Zod mirrors in `shared` and the tool registry — three trees — and is still
+   `feat(design)`, because "Figma text gained a property" is the whole of what
+   anyone outside the repo experiences. The other two trees are what it cost to
+   build, not what it delivered.
+3. **Combine only when the reader genuinely gets two things.** If a PR both teaches
+   codegen a new CSS property _and_ fixes a transport bug on the way, those are two
+   separate wins and `feat(codegen,relay)` is the honest answer.
+
+Three or more scopes is a strong signal for rule 1. As calibration: every one of
+the 28 entries in v0.5.0 lands in exactly one scope under this vocabulary.
+
+### Subject
+
+Lowercase first letter, imperative, no trailing period — `subjectPattern` enforces
+the casing. changelogen capitalizes it when rendering, so `feat(relay): carry
+export bytes as msgpack bin` becomes **relay:** Carry export bytes as msgpack bin.
 
 ## Releasing
 


### PR DESCRIPTION
## Description

The commit scope was free-form, and it showed. Across 333 commits it took **66 distinct values** on four unrelated axes — packages (`plugin`, `mcp`), tool names (`get_design_context`, `save_image_fills`), subsystems (`codegen`, `election`) and odds and ends (`vscode`, `m3`) — with the same thing spelled two ways more than once (`design-context` / `get_design_context`, `walk` / `repo-walk`, `skill` / `skills`). Another **69 commits (21%) carried no scope at all**, which is what makes a changelog line like

```
- Carry export bytes as msgpack bin instead of base64 (#156)
```

read as an outlier next to the `**tokens:**` and `**codegen:**` lines around it.

The unscoped ones were never unclassifiable changes — they were changes nobody had a list to pick from. This adds the list.

### The nine scopes

Chosen by the capability a changelog reader experiences, not by which package the diff lands in: Figwright ships one product, so `mcp` would be four fifths of every release and tell nobody anything, while `codegen` / `design` / `relay` say which part of it moved.

`codegen` · `design` · `grounding` · `tools` · `relay` · `plugin` · `skills` · `deps` · `repo`

As calibration, all 28 entries in v0.5.0 land in exactly one of them — including the two that historically needed a comma. Two boundaries are documented because both are easy to get wrong: `plugin` is the panel UI only (a sandbox handler is scoped by the capability it implements), and `docs` is a type rather than a scope.

### No `revert` type

The spec explicitly declines to define revert behaviour, and changelogen has no `revert` type — a commit typed that way is dropped from the changelog **in silence**. Typing a revert by its effect (`fix(relay): revert …`) lands it in Fixes, where a reader looks, and carries the right semver. GitHub's Revert button emits `Revert "…"` regardless, which has no type, no scope and an uppercase subject, so the title needs rewriting by hand either way.

### Related repo setting (already applied, not in this diff)

`squash_merge_commit_title` was `COMMIT_OR_PR_TITLE`, meaning **a single-commit PR takes its squash title from the commit message, not the PR title** — so the gate was validating a string that never reached `main` on half our PRs (20 of a 40-PR sample). It had already bitten once: #169 passed the gate as `test: measure the multi-mode font preload instead of arguing it` and landed on `main` as `test(text-style): pin the multi-mode font preload, now that it can be measured`. The setting is now `PR_TITLE`, which is step 1 of the action's own installation instructions.

## Checklist

- [x] The canonical checks pass locally: `pnpm typecheck && pnpm lint && pnpm format:check && pnpm knip && pnpm build && pnpm test`
- [x] Tests are added or updated for any behavior change (in `test/` mirroring `src/`; cross-package tests in the root `test/`) — n/a, no source change; the config was verified by running the action's real `validatePrTitle` against this exact `types`/`scopes`/`requireScope`/`subjectPattern` set
- [x] Read-path / serializer changes are verified with a live round-trip against a real Figma file — n/a
- [x] Documentation is updated if needed (README, AGENTS.md, tool descriptions) — AGENTS.md, CONTRIBUTING.md and the PR template all updated