### PR TITLE
fix(relay): release the response bodies the follower never reads

### DIFF
--- a/packages/mcp/src/election/follower.ts
+++ b/packages/mcp/src/election/follower.ts
@@ -9,6 +9,20 @@ import { decode, encode } from '@msgpack/msgpack';
 
 import { ABDICATE_PATH, PING_PATH, RPC_PATH } from './leader-endpoints.js';
 
+/**
+ * Release the body of a response we are returning without reading. `fetch` delivers the body as a
+ * stream separate from the status and headers, so an early return on `res.status` alone leaves that
+ * stream open — undici keeps the socket held until the request times out or is collected.
+ * Cancelling is the explicit release.
+ *
+ * Deliberately fire-and-forget: every caller is inside a try/catch whose result depends on which
+ * branch it returned from, so awaiting a cancel that rejected would turn a diagnosed outcome
+ * ('unsupported', undefined) into a generic error.
+ */
+const releaseBody = (res: Response): void => {
+  void res.body?.cancel().catch(() => undefined);
+};
+
 export const DEFAULT_FOLLOWER_RPC_TIMEOUT_MS = 35_000;
 export const DEFAULT_PING_TIMEOUT_MS = 2_000;
 
@@ -73,7 +87,10 @@ export class Follower {
       const res = await this.opts.fetch(`${this.opts.leaderUrl}${PING_PATH}`, {
         signal: AbortSignal.timeout(this.opts.pingTimeoutMs),
       });
-      if (!res.ok) return undefined;
+      if (!res.ok) {
+        releaseBody(res);
+        return undefined;
+      }
       const body: unknown = await res.json();
       return typeof body === 'object' && body !== null
         ? (body as Record<string, unknown>)
@@ -122,8 +139,14 @@ export class Follower {
       });
       // A leader that predates the endpoint 404s ("not found" catch-all) — it can't be retired
       // programmatically, only by a human killing it (ping's buildSkew message covers that).
-      if (res.status === 404) return 'unsupported';
-      if (!res.ok) return 'error';
+      if (res.status === 404) {
+        releaseBody(res);
+        return 'unsupported';
+      }
+      if (!res.ok) {
+        releaseBody(res);
+        return 'error';
+      }
       const body: unknown = await res.json();
       if (typeof body !== 'object' || body === null) return 'error';
       if ((body as { ok?: unknown }).ok === true) return 'ok';

--- a/packages/mcp/test/election/follower.test.ts
+++ b/packages/mcp/test/election/follower.test.ts
@@ -316,6 +316,69 @@ describe('Follower HTTP client', () => {
     expect(await f.requestAbdication(200)).toBe('error');
   });
 
+  /**
+   * A response whose body reports whether anything released it. `fetch` streams the body separately
+   * from the status, so a branch that returns on `res.status` alone leaves the stream — and the
+   * socket behind it — held until the request times out.
+   */
+  const bodyWatcher = (
+    status: number,
+    onCancel: () => void = () => {},
+  ): { res: Response; cancelled: () => boolean } => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      cancel() {
+        cancelled = true;
+        onCancel();
+      },
+    });
+    return { res: new Response(body, { status }), cancelled: () => cancelled };
+  };
+
+  it('releases the response body when a ping is answered with a non-2xx', async () => {
+    const { res, cancelled } = bodyWatcher(503);
+    const f = new Follower({
+      leaderUrl: 'http://127.0.0.1:1',
+      pingTimeoutMs: 200,
+      fetch: async () => res,
+    });
+    expect(await f.ping()).toBe(false);
+    expect(cancelled()).toBe(true);
+  });
+
+  it('releases the response body on the abdication paths that never read it', async () => {
+    // 404 is the leader-predates-the-endpoint branch and 500 the generic failure; both return on
+    // the status alone, so both have to let the body go.
+    for (const [status, outcome] of [
+      [404, 'unsupported'],
+      [500, 'error'],
+    ] as const) {
+      const { res, cancelled } = bodyWatcher(status);
+      const f = new Follower({
+        leaderUrl: 'http://127.0.0.1:1',
+        pingTimeoutMs: 200,
+        fetch: async () => res,
+      });
+      expect(await f.requestAbdication(200)).toBe(outcome);
+      expect(cancelled()).toBe(true);
+    }
+  });
+
+  it('still reports the diagnosed outcome when releasing the body itself fails', async () => {
+    // Why the release is fire-and-forget rather than awaited: these callers sit inside a try/catch
+    // that maps any throw to 'error', so awaiting a rejected cancel would turn "this leader is too
+    // old to abdicate" into an indistinguishable transport failure.
+    const { res } = bodyWatcher(404, () => {
+      throw new Error('cancel failed');
+    });
+    const f = new Follower({
+      leaderUrl: 'http://127.0.0.1:1',
+      pingTimeoutMs: 200,
+      fetch: async () => res,
+    });
+    expect(await f.requestAbdication(200)).toBe('unsupported');
+  });
+
   it('sendRpc threads sessionId so the leader pins the call', async () => {
     const b = await startLeader();
     await attachFakePlugin(b, async () => ({ ok: true }));


### PR DESCRIPTION
`fetch` delivers a response body as a stream separate from the status and headers. Returning on `res.status` alone does not release it — undici keeps the socket held until the request times out or the response is collected.

Three of the follower's HTTP paths did exactly that:

| Path | Branch |
|---|---|
| `fetchPing` | `if (!res.ok) return undefined` |
| `requestAbdication` | `if (res.status === 404) return 'unsupported'` — the leader-predates-`/abdicate` case |
| `requestAbdication` | `if (!res.ok) return 'error'` |

The `sendRpc` path was already clean: it calls `await res.arrayBuffer()` unconditionally. These three are the only other `fetch` call sites in the repo.

## How bad

Not very, and worth saying so plainly. All three are **failure** paths, and both callers already pass an `AbortSignal.timeout` (`pingTimeoutMs`, default 2s), so the worst case is one socket held for that budget rather than an unbounded leak. But it is paid on exactly the unhealthy-leader ticks that already retry, which is when the election is least able to afford held connections.

## Why fire-and-forget

`releaseBody` intentionally does not await:

```ts
void res.body?.cancel().catch(() => undefined);
```

Both callers sit inside a `try/catch` that maps any throw to a generic failure. Awaiting a cancel that rejected would turn `'unsupported'` — a diagnosis the election acts on, meaning *only a human can retire this leader* — into an indistinguishable `'error'`. There is a test pinning exactly that: a body whose `cancel()` throws, asserting the outcome is still `'unsupported'`.

## Verification

Three tests, one per site, built on a `Response` whose `ReadableStream` reports its own cancellation — so the assertion is that the body was actually released, not that the function returned the right string.

Removing each `releaseBody` call in turn fails exactly one test and no others (20 → 19 passed, three times), so the three sites are independently guarded rather than covered by one broad test.

Six gates green, 1972 tests.

## Where it came from

Trying vitest 5's new `detectAsyncLeaks`. **That option is not being enabled here**: 25 of its 57 reports are `CustomGC` frames from `oxc-parser`'s native binding, appearing in nearly every mcp test file — noise that would train everyone to ignore the output. It did point at this, which is the useful thing a one-off diagnostic run can do.

The remaining reports are test-side (`await fetch(...)` then `expect(res.status)`), which is the same shape with no runtime consequence — the process exits at the end of the run. Left alone deliberately rather than churning the assertions.
